### PR TITLE
Add annotation editor for screenshots

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -20,6 +20,8 @@
     <true/>
     <key>NSScreenCaptureUsageDescription</key>
     <string>Mika+ScreenSnap needs screen capture permission to take screenshots of your screen, selected areas, and individual windows.</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
     <key>NSHighResolutionCapable</key>
     <true/>
     <key>LSMinimumSystemVersion</key>

--- a/Sources/AnnotationCanvasView.swift
+++ b/Sources/AnnotationCanvasView.swift
@@ -1,0 +1,387 @@
+import AppKit
+import CoreImage
+
+@MainActor
+final class AnnotationCanvasView: NSView {
+    let baseImage: NSImage
+    let document: AnnotationDocument
+
+    private var dragStartPoint: CGPoint?  // in image coordinates
+    private var dragCurrentPoint: CGPoint?  // in image coordinates
+    private var activeTextField: NSTextField?
+    private var activeTextPosition: CGPoint?  // in image coordinates
+
+    init(baseImage: NSImage, document: AnnotationDocument) {
+        self.baseImage = baseImage
+        self.document = document
+        super.init(frame: .zero)
+
+        document.onChange = { [weak self] in
+            self?.needsDisplay = true
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var acceptsFirstResponder: Bool { true }
+    override var isFlipped: Bool { false }
+
+    // MARK: - Coordinate Transforms
+
+    /// The rect within this view where the image is drawn (aspect-fit).
+    private var imageDrawRect: CGRect {
+        let viewSize = bounds.size
+        guard viewSize.width > 0, viewSize.height > 0 else { return .zero }
+
+        let imageSize = baseImage.size
+        let scale = min(viewSize.width / imageSize.width, viewSize.height / imageSize.height)
+        let scaledW = imageSize.width * scale
+        let scaledH = imageSize.height * scale
+        let x = (viewSize.width - scaledW) / 2
+        let y = (viewSize.height - scaledH) / 2
+        return CGRect(x: x, y: y, width: scaledW, height: scaledH)
+    }
+
+    /// The scale factor from image points to CGImage pixels.
+    private var imagePixelScale: CGFloat {
+        guard let cg = baseImage.cgImage(forProposedRect: nil, context: nil, hints: nil) else { return 1 }
+        return CGFloat(cg.width) / baseImage.size.width
+    }
+
+    /// Convert view coordinate to image pixel coordinate.
+    private func viewToImage(_ point: CGPoint) -> CGPoint {
+        let drawRect = imageDrawRect
+        guard drawRect.width > 0, drawRect.height > 0 else { return point }
+
+        let viewScale = baseImage.size.width / drawRect.width
+        let pixelScale = imagePixelScale
+
+        let imgX = (point.x - drawRect.origin.x) * viewScale * pixelScale
+        let imgY = (point.y - drawRect.origin.y) * viewScale * pixelScale
+        return CGPoint(x: imgX, y: imgY)
+    }
+
+    /// Convert image pixel coordinate to view coordinate.
+    private func imageToView(_ point: CGPoint) -> CGPoint {
+        let drawRect = imageDrawRect
+        guard baseImage.size.width > 0, baseImage.size.height > 0 else { return point }
+
+        let pixelScale = imagePixelScale
+        let viewScale = drawRect.width / (baseImage.size.width * pixelScale)
+
+        let vx = point.x * viewScale + drawRect.origin.x
+        let vy = point.y * viewScale + drawRect.origin.y
+        return CGPoint(x: vx, y: vy)
+    }
+
+    /// Convert image pixel rect to view rect.
+    private func imageRectToView(_ rect: CGRect) -> CGRect {
+        let origin = imageToView(rect.origin)
+        let corner = imageToView(CGPoint(x: rect.maxX, y: rect.maxY))
+        return CGRect(
+            x: min(origin.x, corner.x),
+            y: min(origin.y, corner.y),
+            width: abs(corner.x - origin.x),
+            height: abs(corner.y - origin.y)
+        )
+    }
+
+    /// Scale factor from image pixels to view points (for line widths, font sizes, etc).
+    private var imageToViewScale: CGFloat {
+        let drawRect = imageDrawRect
+        let pixelScale = imagePixelScale
+        guard baseImage.size.width > 0 else { return 1 }
+        return drawRect.width / (baseImage.size.width * pixelScale)
+    }
+
+    // MARK: - Drawing
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+
+        guard let ctx = NSGraphicsContext.current?.cgContext else { return }
+
+        // Background
+        ctx.setFillColor(NSColor.windowBackgroundColor.cgColor)
+        ctx.fill(bounds)
+
+        // Draw base image
+        let drawRect = imageDrawRect
+        baseImage.draw(in: drawRect, from: .zero, operation: .sourceOver, fraction: 1.0)
+
+        // Draw annotations in view space
+        let scale = imageToViewScale
+        guard let cgBase = baseImage.cgImage(forProposedRect: nil, context: nil, hints: nil) else { return }
+
+        for item in document.annotations {
+            drawAnnotationInView(ctx: ctx, item: item, scale: scale, baseImage: cgBase)
+        }
+
+        // Draw in-progress annotation
+        drawInProgressAnnotation(ctx: ctx, scale: scale, baseImage: cgBase)
+    }
+
+    private func drawAnnotationInView(ctx: CGContext, item: AnnotationItem, scale: CGFloat, baseImage: CGImage) {
+        switch item.kind {
+        case .arrow(let a):
+            let viewStart = imageToView(a.startPoint)
+            let viewEnd = imageToView(a.endPoint)
+            let viewAnnotation = ArrowAnnotation(startPoint: viewStart, endPoint: viewEnd, color: a.color, lineWidth: a.lineWidth * scale)
+            AnnotationRenderer.drawArrow(in: ctx, annotation: viewAnnotation)
+
+        case .rectangle(let r):
+            let viewRect = imageRectToView(r.rect)
+            let viewAnnotation = RectAnnotation(rect: viewRect, color: r.color, lineWidth: r.lineWidth * scale)
+            AnnotationRenderer.drawRectangle(in: ctx, annotation: viewAnnotation)
+
+        case .text(let t):
+            let viewPos = imageToView(t.position)
+            let scaledFontSize = t.font.pointSize * scale
+            let scaledFont = NSFont.systemFont(ofSize: max(scaledFontSize, 8), weight: .bold)
+            let viewAnnotation = TextAnnotation(position: viewPos, text: t.text, font: scaledFont, color: t.color)
+            AnnotationRenderer.drawText(in: ctx, annotation: viewAnnotation, imageHeight: bounds.height)
+
+        case .blur(let b):
+            let viewRect = imageRectToView(b.rect)
+            // For view display: pixelate by drawing a small scaled version
+            drawBlurInView(ctx: ctx, rect: viewRect, baseImage: baseImage, imageRect: b.rect, radius: b.radius * scale)
+        }
+    }
+
+    private func drawBlurInView(ctx: CGContext, rect: CGRect, baseImage: CGImage, imageRect: CGRect, radius: CGFloat) {
+        guard rect.width > 1 && rect.height > 1 else { return }
+
+        // Clamp to base image bounds
+        let imageBounds = CGRect(x: 0, y: 0, width: baseImage.width, height: baseImage.height)
+        let clampedImageRect = imageRect.intersection(imageBounds)
+        guard !clampedImageRect.isNull else { return }
+
+        guard let cropped = baseImage.cropping(to: clampedImageRect) else { return }
+
+        let ciImage = CIImage(cgImage: cropped)
+        guard let filter = CIFilter(name: "CIGaussianBlur") else { return }
+        filter.setValue(ciImage, forKey: kCIInputImageKey)
+        filter.setValue(radius, forKey: kCIInputRadiusKey)
+
+        let ciContext = CIContext()
+        guard let output = filter.outputImage,
+              let blurred = ciContext.createCGImage(output, from: ciImage.extent) else { return }
+
+        ctx.saveGState()
+        ctx.clip(to: rect)
+        ctx.draw(blurred, in: rect)
+        ctx.restoreGState()
+    }
+
+    private func drawInProgressAnnotation(ctx: CGContext, scale: CGFloat, baseImage: CGImage) {
+        guard let start = dragStartPoint, let current = dragCurrentPoint else { return }
+
+        let viewStart = imageToView(start)
+        let viewCurrent = imageToView(current)
+
+        switch document.selectedTool {
+        case .arrow:
+            let a = ArrowAnnotation(startPoint: viewStart, endPoint: viewCurrent, color: document.currentColor, lineWidth: document.currentLineWidth * scale)
+            AnnotationRenderer.drawArrow(in: ctx, annotation: a)
+
+        case .rectangle:
+            let rect = makeRect(from: viewStart, to: viewCurrent)
+            let r = RectAnnotation(rect: rect, color: document.currentColor, lineWidth: document.currentLineWidth * scale)
+            AnnotationRenderer.drawRectangle(in: ctx, annotation: r)
+
+        case .blur:
+            let viewRect = makeRect(from: viewStart, to: viewCurrent)
+            // Dashed preview
+            ctx.saveGState()
+            ctx.setStrokeColor(NSColor.white.cgColor)
+            ctx.setLineWidth(1.5)
+            ctx.setLineDash(phase: 0, lengths: [6, 4])
+            ctx.stroke(viewRect)
+            ctx.restoreGState()
+
+        case .text:
+            break
+        }
+    }
+
+    private func makeRect(from p1: CGPoint, to p2: CGPoint) -> CGRect {
+        CGRect(
+            x: min(p1.x, p2.x),
+            y: min(p1.y, p2.y),
+            width: abs(p1.x - p2.x),
+            height: abs(p1.y - p2.y)
+        )
+    }
+
+    // MARK: - Mouse Events
+
+    override func mouseDown(with event: NSEvent) {
+        let viewPoint = convert(event.locationInWindow, from: nil)
+        let imagePoint = viewToImage(viewPoint)
+
+        // Finalize any active text field first
+        finalizeTextField()
+
+        if document.selectedTool == .text {
+            placeTextField(at: viewPoint, imagePoint: imagePoint)
+            return
+        }
+
+        dragStartPoint = imagePoint
+        dragCurrentPoint = imagePoint
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        let viewPoint = convert(event.locationInWindow, from: nil)
+        dragCurrentPoint = viewToImage(viewPoint)
+        needsDisplay = true
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard let start = dragStartPoint, dragCurrentPoint != nil else { return }
+
+        let end = viewToImage(convert(event.locationInWindow, from: nil))
+
+        switch document.selectedTool {
+        case .arrow:
+            let dx = abs(end.x - start.x)
+            let dy = abs(end.y - start.y)
+            if dx > 2 || dy > 2 {
+                let annotation = AnnotationItem(kind: .arrow(ArrowAnnotation(
+                    startPoint: start, endPoint: end,
+                    color: document.currentColor, lineWidth: document.currentLineWidth
+                )))
+                document.addAnnotation(annotation)
+            }
+
+        case .rectangle:
+            let rect = makeRect(from: start, to: end)
+            if rect.width > 2 && rect.height > 2 {
+                let annotation = AnnotationItem(kind: .rectangle(RectAnnotation(
+                    rect: rect, color: document.currentColor, lineWidth: document.currentLineWidth
+                )))
+                document.addAnnotation(annotation)
+            }
+
+        case .blur:
+            let rect = makeRect(from: start, to: end)
+            if rect.width > 2 && rect.height > 2 {
+                let annotation = AnnotationItem(kind: .blur(BlurAnnotation(rect: rect)))
+                document.addAnnotation(annotation)
+            }
+
+        case .text:
+            break
+        }
+
+        dragStartPoint = nil
+        dragCurrentPoint = nil
+        needsDisplay = true
+    }
+
+    // MARK: - Text Tool
+
+    private func placeTextField(at viewPoint: CGPoint, imagePoint: CGPoint) {
+        let field = NSTextField(frame: NSRect(x: viewPoint.x, y: viewPoint.y - 12, width: 200, height: 24))
+        field.font = NSFont.systemFont(ofSize: 14, weight: .bold)
+        field.textColor = document.currentColor
+        field.backgroundColor = NSColor.black.withAlphaComponent(0.3)
+        field.isBordered = false
+        field.isBezeled = false
+        field.isEditable = true
+        field.isSelectable = true
+        field.focusRingType = .none
+        field.placeholderString = "Type here..."
+        field.delegate = self
+        field.target = self
+        field.action = #selector(textFieldAction(_:))
+
+        addSubview(field)
+        window?.makeFirstResponder(field)
+
+        activeTextField = field
+        activeTextPosition = imagePoint
+    }
+
+    @objc private func textFieldAction(_ sender: NSTextField) {
+        finalizeTextField()
+    }
+
+    private func finalizeTextField() {
+        guard let field = activeTextField, let imagePos = activeTextPosition else { return }
+
+        let text = field.stringValue
+        field.removeFromSuperview()
+        activeTextField = nil
+        activeTextPosition = nil
+
+        guard !text.isEmpty else { return }
+
+        let pixelScale = imagePixelScale
+        let fontSize = 16.0 * pixelScale
+        let annotation = AnnotationItem(kind: .text(TextAnnotation(
+            position: imagePos,
+            text: text,
+            font: NSFont.systemFont(ofSize: fontSize, weight: .bold),
+            color: document.currentColor
+        )))
+        document.addAnnotation(annotation)
+
+        // Re-gain first responder for key events
+        window?.makeFirstResponder(self)
+    }
+
+    // MARK: - Keyboard Events
+
+    override func keyDown(with event: NSEvent) {
+        if event.modifierFlags.contains(.command) {
+            if event.charactersIgnoringModifiers == "z" {
+                if event.modifierFlags.contains(.shift) {
+                    document.redo()
+                } else {
+                    document.undo()
+                }
+                return
+            }
+        }
+
+        if event.keyCode == 53 { // ESC
+            dragStartPoint = nil
+            dragCurrentPoint = nil
+            finalizeTextField()
+            needsDisplay = true
+            return
+        }
+
+        super.keyDown(with: event)
+    }
+
+    // MARK: - Cursor
+
+    override func resetCursorRects() {
+        let drawRect = imageDrawRect
+        switch document.selectedTool {
+        case .arrow, .rectangle, .blur:
+            addCursorRect(drawRect, cursor: .crosshair)
+        case .text:
+            addCursorRect(drawRect, cursor: .iBeam)
+        }
+    }
+
+    func toolChanged() {
+        window?.invalidateCursorRects(for: self)
+        needsDisplay = true
+    }
+}
+
+// MARK: - NSTextFieldDelegate
+
+extension AnnotationCanvasView: NSTextFieldDelegate {
+    nonisolated func controlTextDidEndEditing(_ obj: Notification) {
+        MainActor.assumeIsolated {
+            finalizeTextField()
+        }
+    }
+}

--- a/Sources/AnnotationEditorWindow.swift
+++ b/Sources/AnnotationEditorWindow.swift
@@ -1,0 +1,128 @@
+import AppKit
+import SwiftUI
+
+/// Custom NSWindow subclass that explicitly accepts key and main status.
+@MainActor
+private class AnnotationWindow: NSWindow {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
+}
+
+@MainActor
+final class AnnotationEditorWindowController {
+    private var window: NSWindow?
+    private let baseImage: NSImage
+    private let document = AnnotationDocument()
+    private var canvasView: AnnotationCanvasView?
+
+    init(image: NSImage) {
+        self.baseImage = image
+    }
+
+    func showWindow(_ sender: Any?) {
+        let screenFrame = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1200, height: 800)
+
+        // Size to fit image, capped at 80% of screen
+        let maxW = screenFrame.width * 0.8
+        let maxH = screenFrame.height * 0.8
+        let imageSize = baseImage.size
+        let scale = min(maxW / imageSize.width, maxH / imageSize.height, 1.0)
+        let contentW = max(imageSize.width * scale, 600)
+        let contentH = max(imageSize.height * scale, 400) + 50  // +50 for toolbar
+
+        // Switch to regular app BEFORE creating the window
+        NSApp.setActivationPolicy(.regular)
+
+        let window = AnnotationWindow(
+            contentRect: NSRect(x: 0, y: 0, width: contentW, height: contentH),
+            styleMask: [.titled, .closable, .resizable, .miniaturizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Annotate Screenshot"
+        window.isReleasedWhenClosed = false
+        window.acceptsMouseMovedEvents = true
+        window.center()
+
+        // Build content
+        let contentView = NSView(frame: window.contentView!.bounds)
+        contentView.autoresizingMask = [.width, .height]
+
+        // Toolbar (SwiftUI via NSHostingView)
+        let toolbarView = AnnotationToolbarView(
+            document: document,
+            onDone: { [weak self] in self?.done() },
+            onSave: { [weak self] in self?.save() },
+            onToolChanged: { [weak self] in self?.canvasView?.toolChanged() }
+        )
+        let toolbarHosting = NSHostingView(rootView: toolbarView)
+        toolbarHosting.translatesAutoresizingMaskIntoConstraints = false
+
+        // Canvas
+        let canvas = AnnotationCanvasView(baseImage: baseImage, document: document)
+        canvas.translatesAutoresizingMaskIntoConstraints = false
+        self.canvasView = canvas
+
+        contentView.addSubview(toolbarHosting)
+        contentView.addSubview(canvas)
+
+        NSLayoutConstraint.activate([
+            toolbarHosting.topAnchor.constraint(equalTo: contentView.topAnchor),
+            toolbarHosting.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            toolbarHosting.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            toolbarHosting.heightAnchor.constraint(equalToConstant: 50),
+
+            canvas.topAnchor.constraint(equalTo: toolbarHosting.bottomAnchor),
+            canvas.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            canvas.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            canvas.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+        ])
+
+        window.contentView = contentView
+        self.window = window
+
+        // Activate app and show window
+        NSApp.activate()
+        window.makeKeyAndOrderFront(nil)
+        window.makeFirstResponder(canvas)
+    }
+
+    private func done() {
+        guard let finalImage = AnnotationRenderer.renderFinalImage(
+            baseImage: baseImage, annotations: document.annotations
+        ) else { return }
+
+        ClipboardManager.copyToClipboard(finalImage)
+        close()
+    }
+
+    private func save() {
+        guard let finalImage = AnnotationRenderer.renderFinalImage(
+            baseImage: baseImage, annotations: document.annotations
+        ) else { return }
+
+        let savePanel = NSSavePanel()
+        savePanel.allowedContentTypes = [.png]
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
+        let timestamp = formatter.string(from: Date())
+        savePanel.nameFieldStringValue = "MikaSnap_annotated_\(timestamp).png"
+
+        savePanel.beginSheetModal(for: window!) { response in
+            MainActor.assumeIsolated {
+                if response == .OK, let url = savePanel.url {
+                    ClipboardManager.saveToFile(finalImage, url: url)
+                }
+            }
+        }
+    }
+
+    private func close() {
+        window?.orderOut(nil)
+        window = nil
+
+        // Switch back to accessory policy (menubar-only)
+        NSApp.setActivationPolicy(.accessory)
+    }
+}

--- a/Sources/AnnotationModel.swift
+++ b/Sources/AnnotationModel.swift
@@ -1,0 +1,137 @@
+import AppKit
+
+enum AnnotationTool: String, CaseIterable, Identifiable {
+    case arrow
+    case rectangle
+    case text
+    case blur
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .arrow: "Arrow"
+        case .rectangle: "Rectangle"
+        case .text: "Text"
+        case .blur: "Blur"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .arrow: "arrow.up.right"
+        case .rectangle: "rectangle"
+        case .text: "textformat"
+        case .blur: "eye.slash"
+        }
+    }
+}
+
+struct AnnotationItem: Identifiable {
+    let id: UUID
+    var kind: AnnotationKind
+
+    init(kind: AnnotationKind) {
+        self.id = UUID()
+        self.kind = kind
+    }
+}
+
+enum AnnotationKind {
+    case arrow(ArrowAnnotation)
+    case rectangle(RectAnnotation)
+    case text(TextAnnotation)
+    case blur(BlurAnnotation)
+}
+
+struct ArrowAnnotation {
+    var startPoint: CGPoint
+    var endPoint: CGPoint
+    var color: NSColor
+    var lineWidth: CGFloat
+
+    init(startPoint: CGPoint, endPoint: CGPoint, color: NSColor = .red, lineWidth: CGFloat = 3.0) {
+        self.startPoint = startPoint
+        self.endPoint = endPoint
+        self.color = color
+        self.lineWidth = lineWidth
+    }
+}
+
+struct RectAnnotation {
+    var rect: CGRect
+    var color: NSColor
+    var lineWidth: CGFloat
+
+    init(rect: CGRect, color: NSColor = .red, lineWidth: CGFloat = 2.0) {
+        self.rect = rect
+        self.color = color
+        self.lineWidth = lineWidth
+    }
+}
+
+struct TextAnnotation {
+    var position: CGPoint
+    var text: String
+    var font: NSFont
+    var color: NSColor
+
+    init(position: CGPoint, text: String, font: NSFont = .systemFont(ofSize: 16, weight: .bold), color: NSColor = .red) {
+        self.position = position
+        self.text = text
+        self.font = font
+        self.color = color
+    }
+}
+
+struct BlurAnnotation {
+    var rect: CGRect
+    var radius: CGFloat
+
+    init(rect: CGRect, radius: CGFloat = 15.0) {
+        self.rect = rect
+        self.radius = radius
+    }
+}
+
+@Observable
+@MainActor
+final class AnnotationDocument {
+    var annotations: [AnnotationItem] = []
+    private var undoStack: [[AnnotationItem]] = []
+    private var redoStack: [[AnnotationItem]] = []
+
+    var selectedTool: AnnotationTool = .arrow
+    var currentColor: NSColor = .red
+    var currentLineWidth: CGFloat = 3.0
+
+    var canUndo: Bool { !undoStack.isEmpty }
+    var canRedo: Bool { !redoStack.isEmpty }
+
+    var onChange: (() -> Void)?
+
+    private func pushUndo() {
+        undoStack.append(annotations)
+        redoStack.removeAll()
+    }
+
+    func addAnnotation(_ item: AnnotationItem) {
+        pushUndo()
+        annotations.append(item)
+        onChange?()
+    }
+
+    func undo() {
+        guard let previous = undoStack.popLast() else { return }
+        redoStack.append(annotations)
+        annotations = previous
+        onChange?()
+    }
+
+    func redo() {
+        guard let next = redoStack.popLast() else { return }
+        undoStack.append(annotations)
+        annotations = next
+        onChange?()
+    }
+}

--- a/Sources/AnnotationRenderer.swift
+++ b/Sources/AnnotationRenderer.swift
@@ -1,0 +1,174 @@
+import AppKit
+import CoreImage
+
+@MainActor
+enum AnnotationRenderer {
+
+    /// Render all annotations onto a CGContext. Coordinates are in image space.
+    static func render(
+        annotations: [AnnotationItem],
+        in ctx: CGContext,
+        imageSize: CGSize,
+        baseImage: CGImage
+    ) {
+        for item in annotations {
+            switch item.kind {
+            case .arrow(let a):
+                drawArrow(in: ctx, annotation: a)
+            case .rectangle(let r):
+                drawRectangle(in: ctx, annotation: r)
+            case .text(let t):
+                drawText(in: ctx, annotation: t, imageHeight: imageSize.height)
+            case .blur(let b):
+                drawBlur(in: ctx, annotation: b, baseImage: baseImage)
+            }
+        }
+    }
+
+    // MARK: - Arrow
+
+    static func drawArrow(in ctx: CGContext, annotation: ArrowAnnotation) {
+        let start = annotation.startPoint
+        let end = annotation.endPoint
+        let color = annotation.color.cgColor
+
+        ctx.saveGState()
+        ctx.setStrokeColor(color)
+        ctx.setLineWidth(annotation.lineWidth)
+        ctx.setLineCap(.round)
+        ctx.move(to: start)
+        ctx.addLine(to: end)
+        ctx.strokePath()
+
+        // Arrowhead
+        let angle = atan2(end.y - start.y, end.x - start.x)
+        let arrowLength: CGFloat = max(annotation.lineWidth * 4, 14)
+        let arrowAngle: CGFloat = .pi / 7
+
+        let p1 = CGPoint(
+            x: end.x - arrowLength * cos(angle - arrowAngle),
+            y: end.y - arrowLength * sin(angle - arrowAngle)
+        )
+        let p2 = CGPoint(
+            x: end.x - arrowLength * cos(angle + arrowAngle),
+            y: end.y - arrowLength * sin(angle + arrowAngle)
+        )
+
+        ctx.setFillColor(color)
+        ctx.move(to: end)
+        ctx.addLine(to: p1)
+        ctx.addLine(to: p2)
+        ctx.closePath()
+        ctx.fillPath()
+        ctx.restoreGState()
+    }
+
+    // MARK: - Rectangle
+
+    static func drawRectangle(in ctx: CGContext, annotation: RectAnnotation) {
+        ctx.saveGState()
+        ctx.setStrokeColor(annotation.color.cgColor)
+        ctx.setLineWidth(annotation.lineWidth)
+        ctx.stroke(annotation.rect)
+        ctx.restoreGState()
+    }
+
+    // MARK: - Text
+
+    static func drawText(in ctx: CGContext, annotation: TextAnnotation, imageHeight: CGFloat) {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: annotation.font,
+            .foregroundColor: annotation.color,
+        ]
+
+        let attrString = NSAttributedString(string: annotation.text, attributes: attributes)
+        let textSize = attrString.size()
+
+        // Background pill
+        let padding: CGFloat = 4
+        let bgRect = CGRect(
+            x: annotation.position.x - padding,
+            y: annotation.position.y - padding,
+            width: textSize.width + padding * 2,
+            height: textSize.height + padding * 2
+        )
+
+        ctx.saveGState()
+        let bgPath = CGPath(roundedRect: bgRect, cornerWidth: 4, cornerHeight: 4, transform: nil)
+        ctx.setFillColor(NSColor.black.withAlphaComponent(0.5).cgColor)
+        ctx.addPath(bgPath)
+        ctx.fillPath()
+        ctx.restoreGState()
+
+        // Draw text using NSGraphicsContext
+        NSGraphicsContext.saveGraphicsState()
+        let nsContext = NSGraphicsContext(cgContext: ctx, flipped: false)
+        NSGraphicsContext.current = nsContext
+        attrString.draw(at: annotation.position)
+        NSGraphicsContext.restoreGraphicsState()
+    }
+
+    // MARK: - Blur
+
+    static func drawBlur(in ctx: CGContext, annotation: BlurAnnotation, baseImage: CGImage) {
+        let rect = annotation.rect
+        guard rect.width > 0 && rect.height > 0 else { return }
+
+        // Scale rect to pixel coordinates of the CGImage
+        let imageW = CGFloat(baseImage.width)
+        let imageH = CGFloat(baseImage.height)
+
+        // Clamp rect to image bounds
+        let clampedRect = rect.intersection(CGRect(x: 0, y: 0, width: imageW, height: imageH))
+        guard !clampedRect.isNull && clampedRect.width > 0 && clampedRect.height > 0 else { return }
+
+        guard let cropped = baseImage.cropping(to: clampedRect) else { return }
+
+        let ciImage = CIImage(cgImage: cropped)
+        guard let filter = CIFilter(name: "CIGaussianBlur") else { return }
+        filter.setValue(ciImage, forKey: kCIInputImageKey)
+        filter.setValue(annotation.radius, forKey: kCIInputRadiusKey)
+
+        let ciContext = CIContext()
+        guard let output = filter.outputImage,
+              let blurred = ciContext.createCGImage(output, from: ciImage.extent) else { return }
+
+        ctx.saveGState()
+        ctx.clip(to: clampedRect)
+        ctx.draw(blurred, in: clampedRect)
+        ctx.restoreGState()
+    }
+
+    // MARK: - Final Export
+
+    /// Render the base image with all annotations to a new NSImage at full resolution.
+    static func renderFinalImage(baseImage: NSImage, annotations: [AnnotationItem]) -> NSImage? {
+        guard let cgBase = baseImage.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return nil
+        }
+
+        let width = cgBase.width
+        let height = cgBase.height
+
+        let colorSpace = cgBase.colorSpace ?? CGColorSpaceCreateDeviceRGB()
+        guard let ctx = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+
+        // Draw base image
+        ctx.draw(cgBase, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        // Draw annotations in image pixel space
+        let imageSize = CGSize(width: width, height: height)
+        render(annotations: annotations, in: ctx, imageSize: imageSize, baseImage: cgBase)
+
+        guard let resultCGImage = ctx.makeImage() else { return nil }
+        return NSImage(cgImage: resultCGImage, size: NSSize(width: width, height: height))
+    }
+}

--- a/Sources/AnnotationToolbar.swift
+++ b/Sources/AnnotationToolbar.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+
+struct AnnotationToolbarView: View {
+    let document: AnnotationDocument
+    let onDone: () -> Void
+    let onSave: () -> Void
+    let onToolChanged: () -> Void
+
+    private let presetColors: [Color] = [.red, .blue, .green, .yellow, .white, .black]
+
+    var body: some View {
+        HStack(spacing: 16) {
+            // Tool selection
+            toolButtons
+
+            Divider()
+                .frame(height: 24)
+
+            // Color swatches
+            colorPicker
+
+            Divider()
+                .frame(height: 24)
+
+            // Line width
+            lineWidthPicker
+
+            Divider()
+                .frame(height: 24)
+
+            // Undo/Redo
+            undoRedoButtons
+
+            Spacer()
+
+            // Done / Save
+            actionButtons
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(.ultraThinMaterial)
+    }
+
+    private var toolButtons: some View {
+        HStack(spacing: 4) {
+            ForEach(AnnotationTool.allCases) { tool in
+                Button {
+                    document.selectedTool = tool
+                    onToolChanged()
+                } label: {
+                    Image(systemName: tool.systemImage)
+                        .frame(width: 28, height: 28)
+                }
+                .buttonStyle(.plain)
+                .background(document.selectedTool == tool ? Color.accentColor.opacity(0.3) : Color.clear)
+                .cornerRadius(6)
+                .help(tool.label)
+            }
+        }
+    }
+
+    private var colorPicker: some View {
+        HStack(spacing: 4) {
+            ForEach(presetColors, id: \.self) { color in
+                Circle()
+                    .fill(color)
+                    .frame(width: 18, height: 18)
+                    .overlay(
+                        Circle()
+                            .stroke(isSelected(color) ? Color.primary : Color.clear, lineWidth: 2)
+                    )
+                    .onTapGesture {
+                        document.currentColor = NSColor(color)
+                    }
+            }
+        }
+    }
+
+    private func isSelected(_ color: Color) -> Bool {
+        NSColor(color).cgColor.components == document.currentColor.cgColor.components
+    }
+
+    private var lineWidthPicker: some View {
+        HStack(spacing: 4) {
+            ForEach([
+                (label: "Thin", width: CGFloat(1.5)),
+                (label: "Medium", width: CGFloat(3.0)),
+                (label: "Thick", width: CGFloat(5.0)),
+            ], id: \.label) { option in
+                Button {
+                    document.currentLineWidth = option.width
+                } label: {
+                    RoundedRectangle(cornerRadius: 1)
+                        .frame(width: 20, height: option.width + 1)
+                }
+                .buttonStyle(.plain)
+                .frame(width: 28, height: 28)
+                .background(document.currentLineWidth == option.width ? Color.accentColor.opacity(0.3) : Color.clear)
+                .cornerRadius(6)
+                .help(option.label)
+            }
+        }
+    }
+
+    private var undoRedoButtons: some View {
+        HStack(spacing: 4) {
+            Button {
+                document.undo()
+            } label: {
+                Image(systemName: "arrow.uturn.backward")
+                    .frame(width: 28, height: 28)
+            }
+            .buttonStyle(.plain)
+            .disabled(!document.canUndo)
+            .help("Undo (\u{2318}Z)")
+
+            Button {
+                document.redo()
+            } label: {
+                Image(systemName: "arrow.uturn.forward")
+                    .frame(width: 28, height: 28)
+            }
+            .buttonStyle(.plain)
+            .disabled(!document.canRedo)
+            .help("Redo (\u{21E7}\u{2318}Z)")
+        }
+    }
+
+    private var actionButtons: some View {
+        HStack(spacing: 8) {
+            Button("Save") {
+                onSave()
+            }
+            .buttonStyle(.bordered)
+
+            Button("Done") {
+                onDone()
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
+}

--- a/Sources/CaptureEngine.swift
+++ b/Sources/CaptureEngine.swift
@@ -128,7 +128,6 @@ final class CaptureEngine {
     }
 
     private func postCapture(_ image: NSImage, appState: AppState?) {
-        ClipboardManager.copyToClipboard(image)
         appState?.lastCapture = image
 
         // Play capture sound
@@ -136,9 +135,9 @@ final class CaptureEngine {
             sound.play()
         }
 
-        // Show preview window
-        let controller = PreviewWindowController(image: image)
+        // Open annotation editor
+        let controller = AnnotationEditorWindowController(image: image)
         controller.showWindow(nil)
-        appState?.previewWindowController = controller
+        appState?.annotationEditorController = controller
     }
 }

--- a/Sources/MikaScreenSnapApp.swift
+++ b/Sources/MikaScreenSnapApp.swift
@@ -6,7 +6,7 @@ import SwiftUI
 final class AppState {
     var captureEngine: CaptureEngine
     var lastCapture: NSImage?
-    var previewWindowController: PreviewWindowController?
+    var annotationEditorController: AnnotationEditorWindowController?
 
     init() {
         self.captureEngine = CaptureEngine()


### PR DESCRIPTION
## Summary
- Replace simple preview window with full annotation editor (arrow, rectangle, text, blur tools)
- Customizable colors, line widths, and undo/redo support
- Final image can be copied to clipboard or saved as PNG
- Proper window activation for LSUIElement menubar app

## Test plan
- [ ] Take a screenshot (full screen, area, or window)
- [ ] Verify annotation editor opens after capture
- [ ] Test each tool: arrow, rectangle, text, blur
- [ ] Test color and line width changes
- [ ] Test undo/redo (⌘Z / ⌘⇧Z)
- [ ] Test "Done" (copies to clipboard) and "Save" (PNG export)
- [ ] Verify menubar remains clickable after closing editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)