### PR TITLE
Add Launch at Login feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.2.0] - 2026-03-18
+
+### Added
+- **Launch at Login** — optional auto-start at macOS login via SMAppService; toggle in Preferences > General
+
+### Changed
+- Preferences window: new "General" section with Launch at Login toggle; window height increased for new section
+
 ## [3.1.0] - 2026-03-15
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ open "build/Mika+ScreenSnap.app"
 - **Pure Swift Package** — no Xcode project, uses `Package.swift`
 - **Menubar app** — `NSApp.setActivationPolicy(.accessory)` by default, switches to `.regular` when editor/history windows open
 - **Strict concurrency** — `@MainActor` isolation on all UI, `@Observable` for state, `nonisolated(unsafe)` for Carbon callback bridges
-- **Frameworks:** ScreenCaptureKit, Carbon (hotkeys), Vision (OCR), UniformTypeIdentifiers, CoreImage (blur/pixelate), Sparkle (auto-update)
+- **Frameworks:** ScreenCaptureKit, Carbon (hotkeys), Vision (OCR), UniformTypeIdentifiers, CoreImage (blur/pixelate), Sparkle (auto-update), ServiceManagement (launch at login)
 - **Build pipeline:** `scripts/build.sh` compiles, assembles .app, embeds Sparkle.framework, signs. DMG creation via `scripts/create-dmg.sh` or `scripts/create-dmg-simple.sh`. Notarization via `scripts/notarize.sh`
 
 ## Key Patterns

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# Mika+ScreenSnap v3.1.0
+# Mika+ScreenSnap v3.2.0
 
 A lightweight macOS menubar screenshot tool with a professional annotation editor and power features. Capture your screen, annotate it with 11 tools, extract text via OCR, pick colors, measure pixels, pin screenshots, and manage your history — all without leaving your workflow.
 
 ## Features
 
+- **Launch at Login** — optional auto-start at macOS login (Preferences > General)
 - **Menubar App** — lives in your menubar, no Dock icon
 - **Capture Modes**
   - Full Screen (`Ctrl+Shift+Cmd+3`)

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -11,9 +11,9 @@
     <key>CFBundleExecutable</key>
     <string>MikaScreenSnap</string>
     <key>CFBundleVersion</key>
-    <string>3.1.0</string>
+    <string>3.2.0</string>
     <key>CFBundleShortVersionString</key>
-    <string>3.1.0</string>
+    <string>3.2.0</string>
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundlePackageType</key>

--- a/Sources/LaunchAtLoginManager.swift
+++ b/Sources/LaunchAtLoginManager.swift
@@ -1,0 +1,27 @@
+// LaunchAtLoginManager.swift
+// MikaScreenSnap
+//
+// Manages Launch at Login via SMAppService (macOS 13+).
+// System is source of truth — no UserDefaults needed.
+
+import ServiceManagement
+
+@MainActor
+final class LaunchAtLoginManager {
+
+    var isEnabled: Bool {
+        SMAppService.mainApp.status == .enabled
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        do {
+            if enabled {
+                try SMAppService.mainApp.register()
+            } else {
+                try SMAppService.mainApp.unregister()
+            }
+        } catch {
+            print("Launch at Login failed: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Sources/MikaScreenSnapApp.swift
+++ b/Sources/MikaScreenSnapApp.swift
@@ -17,6 +17,7 @@ final class AppState {
     var preferencesController: PreferencesWindowController?
     var aboutController: AboutWindowController?
     var sparkleUpdater: SparkleUpdater
+    var launchAtLoginManager: LaunchAtLoginManager
 
     init() {
         let prefs = AppPreferences()
@@ -25,6 +26,7 @@ final class AppState {
         self.historyManager = ScreenshotHistoryManager(preferences: prefs)
         self.colorHistory = ColorHistoryManager()
         self.sparkleUpdater = SparkleUpdater()
+        self.launchAtLoginManager = LaunchAtLoginManager()
     }
 }
 
@@ -223,7 +225,8 @@ struct MikaScreenSnapApp: App {
             Button("Preferences...") {
                 if appDelegate.appState.preferencesController == nil {
                     appDelegate.appState.preferencesController = PreferencesWindowController(
-                        preferences: appDelegate.appState.preferences
+                        preferences: appDelegate.appState.preferences,
+                        launchAtLoginManager: appDelegate.appState.launchAtLoginManager
                     )
                 }
                 appDelegate.appState.preferencesController?.showWindow()

--- a/Sources/PreferencesView.swift
+++ b/Sources/PreferencesView.swift
@@ -10,9 +10,11 @@ import SwiftUI
 final class PreferencesWindowController {
     private var window: NSWindow?
     private let preferences: AppPreferences
+    private let launchAtLoginManager: LaunchAtLoginManager
 
-    init(preferences: AppPreferences) {
+    init(preferences: AppPreferences, launchAtLoginManager: LaunchAtLoginManager) {
         self.preferences = preferences
+        self.launchAtLoginManager = launchAtLoginManager
     }
 
     func showWindow() {
@@ -24,10 +26,13 @@ final class PreferencesWindowController {
 
         NSApp.setActivationPolicy(.regular)
 
-        let contentView = PreferencesView(preferences: preferences)
+        let contentView = PreferencesView(
+            preferences: preferences,
+            launchAtLoginManager: launchAtLoginManager
+        )
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 450, height: 280),
+            contentRect: NSRect(x: 0, y: 0, width: 450, height: 350),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
@@ -46,9 +51,17 @@ final class PreferencesWindowController {
 
 struct PreferencesView: View {
     let preferences: AppPreferences
+    let launchAtLoginManager: LaunchAtLoginManager
 
     var body: some View {
         Form {
+            Section("General") {
+                Toggle("Launch at Login", isOn: Binding(
+                    get: { launchAtLoginManager.isEnabled },
+                    set: { launchAtLoginManager.setEnabled($0) }
+                ))
+            }
+
             Section("Auto-Save") {
                 Toggle("Automatically save screenshots", isOn: Binding(
                     get: { preferences.autoSaveEnabled },
@@ -93,7 +106,7 @@ struct PreferencesView: View {
             }
         }
         .formStyle(.grouped)
-        .frame(width: 450, height: 280)
+        .frame(width: 450, height: 350)
     }
 
     private func chooseFolder() {


### PR DESCRIPTION
## Summary
- Adds optional auto-start at macOS login using `SMAppService` API (no helper bundle needed)
- New "General" section in Preferences with "Launch at Login" toggle
- Bumps version to 3.2.0

Closes #6

## Test plan
- [ ] Build with `swift build -c release` — no errors
- [ ] Open Preferences (⌘,) → "General" section with toggle visible
- [ ] Toggle on → app appears in System Settings > General > Login Items
- [ ] Toggle off → app removed from Login Items
- [ ] Close and reopen Preferences → toggle state persists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)