### PR TITLE
Add first-launch onboarding flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.2.0] - 2026-03-18
+
+### Added
+- **First Launch Onboarding** — 3-screen guided flow (welcome, permissions, shortcuts) shown only on first launch
+- **Launch at Login** — toggle in onboarding and Preferences, backed by SMAppService
+- **Screen Recording Permission Warning** — menubar shows warning when permission not granted
+- **Show Onboarding Again** — button in Preferences to re-trigger onboarding flow
+
 ## [3.1.0] - 2026-03-15
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ open "build/Mika+ScreenSnap.app"
 - **Pure Swift Package** — no Xcode project, uses `Package.swift`
 - **Menubar app** — `NSApp.setActivationPolicy(.accessory)` by default, switches to `.regular` when editor/history windows open
 - **Strict concurrency** — `@MainActor` isolation on all UI, `@Observable` for state, `nonisolated(unsafe)` for Carbon callback bridges
-- **Frameworks:** ScreenCaptureKit, Carbon (hotkeys), Vision (OCR), UniformTypeIdentifiers, CoreImage (blur/pixelate), Sparkle (auto-update)
+- **Frameworks:** ScreenCaptureKit, Carbon (hotkeys), Vision (OCR), UniformTypeIdentifiers, CoreImage (blur/pixelate), Sparkle (auto-update), ServiceManagement (launch at login)
 - **Build pipeline:** `scripts/build.sh` compiles, assembles .app, embeds Sparkle.framework, signs. DMG creation via `scripts/create-dmg.sh` or `scripts/create-dmg-simple.sh`. Notarization via `scripts/notarize.sh`
 
 ## Key Patterns
@@ -32,6 +32,7 @@ open "build/Mika+ScreenSnap.app"
 - **Annotation protocol** — self-drawing annotations with snapshot/restore for undo. Sorted by zIndex for render order
 - **Carbon hotkeys** — EventHotKeyID with static instance pointer for callback. Signature: `0x4D534E53`
 - **SwiftUI in AppKit** — Toolbar and BottomBar are `NSHostingView` with `@Observable` store binding
+- **Onboarding flow** — `OnboardingWindowController` + `OnboardingView` (3-screen TabView); shown once on first launch, re-triggerable from Preferences
 
 ## File Organization
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# Mika+ScreenSnap v3.1.0
+# Mika+ScreenSnap v3.2.0
 
 A lightweight macOS menubar screenshot tool with a professional annotation editor and power features. Capture your screen, annotate it with 11 tools, extract text via OCR, pick colors, measure pixels, pin screenshots, and manage your history — all without leaving your workflow.
 
 ## Features
 
+- **First Launch Onboarding** — guided setup with permissions and shortcut overview
 - **Menubar App** — lives in your menubar, no Dock icon
 - **Capture Modes**
   - Full Screen (`Ctrl+Shift+Cmd+3`)
@@ -187,6 +188,8 @@ Sources/
 ├── AppPreferences.swift          # UserDefaults-backed preferences
 ├── ScreenshotHistoryManager.swift # Auto-save, thumbnails, history
 ├── HistoryBrowserWindow.swift    # History browser window (LazyVGrid)
+├── OnboardingView.swift          # First-launch onboarding SwiftUI views
+├── OnboardingWindowController.swift # Onboarding window controller
 ├── PreferencesView.swift         # Preferences window
 ├── OCREngine.swift               # Vision framework text recognition
 ├── OCRResultPanel.swift          # HUD result panel for OCR

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -11,9 +11,9 @@
     <key>CFBundleExecutable</key>
     <string>MikaScreenSnap</string>
     <key>CFBundleVersion</key>
-    <string>3.1.0</string>
+    <string>3.2.0</string>
     <key>CFBundleShortVersionString</key>
-    <string>3.1.0</string>
+    <string>3.2.0</string>
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundlePackageType</key>

--- a/Sources/AppPreferences.swift
+++ b/Sources/AppPreferences.swift
@@ -5,6 +5,7 @@
 // Swift 6.0 strict concurrency, macOS 14+
 
 import AppKit
+import ServiceManagement
 
 enum ImageFormat: String, CaseIterable, Sendable {
     case png = "PNG"
@@ -32,6 +33,22 @@ final class AppPreferences {
         didSet { defaults.set(jpegQuality, forKey: "jpegQuality") }
     }
 
+    var hasCompletedOnboarding: Bool {
+        didSet { defaults.set(hasCompletedOnboarding, forKey: "hasCompletedOnboarding") }
+    }
+
+    var permissionSkipped: Bool {
+        didSet { defaults.set(permissionSkipped, forKey: "permissionSkipped") }
+    }
+
+    var launchAtLogin: Bool {
+        didSet {
+            defaults.set(launchAtLogin, forKey: "launchAtLogin")
+            if launchAtLogin { try? SMAppService.mainApp.register() }
+            else { try? SMAppService.mainApp.unregister() }
+        }
+    }
+
     init() {
         let defaultLocation = FileManager.default.urls(for: .picturesDirectory, in: .userDomainMask).first!
             .appendingPathComponent("MikaScreenSnap", isDirectory: true)
@@ -39,6 +56,9 @@ final class AppPreferences {
         self.autoSaveEnabled = defaults.object(forKey: "autoSaveEnabled") as? Bool ?? true
         self.jpegQuality = defaults.object(forKey: "jpegQuality") as? CGFloat ?? 0.85
         self.imageFormat = ImageFormat(rawValue: defaults.string(forKey: "imageFormat") ?? "") ?? .png
+        self.hasCompletedOnboarding = defaults.object(forKey: "hasCompletedOnboarding") as? Bool ?? false
+        self.permissionSkipped = defaults.object(forKey: "permissionSkipped") as? Bool ?? false
+        self.launchAtLogin = defaults.object(forKey: "launchAtLogin") as? Bool ?? false
 
         if let savedPath = defaults.string(forKey: "saveLocation") {
             self.saveLocation = URL(fileURLWithPath: savedPath)

--- a/Sources/MikaScreenSnapApp.swift
+++ b/Sources/MikaScreenSnapApp.swift
@@ -16,6 +16,7 @@ final class AppState {
     var measurementController: MeasurementOverlayController?
     var preferencesController: PreferencesWindowController?
     var aboutController: AboutWindowController?
+    var onboardingController: OnboardingWindowController?
     var sparkleUpdater: SparkleUpdater
 
     init() {
@@ -34,7 +35,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     var hotkeyManager: HotkeyManager?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        checkScreenCapturePermission()
+        if !appState.preferences.hasCompletedOnboarding {
+            showOnboarding()
+        } else if !CGPreflightScreenCaptureAccess() {
+            checkScreenCapturePermission()
+        }
 
         // Restore pinned screenshots
         PinnedScreenshotManager.restorePins(appState: appState)
@@ -83,6 +88,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             )
         }
         appState.historyBrowserController?.showWindow()
+    }
+
+    func showOnboarding() {
+        if appState.onboardingController == nil {
+            appState.onboardingController = OnboardingWindowController(preferences: appState.preferences)
+        }
+        appState.onboardingController?.showWindow()
     }
 
     private func checkScreenCapturePermission() {
@@ -134,6 +146,13 @@ struct MikaScreenSnapApp: App {
             }
             Button("Check for Updates...") {
                 appDelegate.appState.sparkleUpdater.checkForUpdates()
+            }
+            if !CGPreflightScreenCaptureAccess() {
+                Button("\u{26A0} Screen Recording not granted") {
+                    if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture") {
+                        NSWorkspace.shared.open(url)
+                    }
+                }
             }
             Divider()
 
@@ -223,7 +242,10 @@ struct MikaScreenSnapApp: App {
             Button("Preferences...") {
                 if appDelegate.appState.preferencesController == nil {
                     appDelegate.appState.preferencesController = PreferencesWindowController(
-                        preferences: appDelegate.appState.preferences
+                        preferences: appDelegate.appState.preferences,
+                        onShowOnboarding: { [weak appDelegate] in
+                            appDelegate?.showOnboarding()
+                        }
                     )
                 }
                 appDelegate.appState.preferencesController?.showWindow()

--- a/Sources/OnboardingView.swift
+++ b/Sources/OnboardingView.swift
@@ -1,0 +1,331 @@
+// OnboardingView.swift
+// MikaScreenSnap
+//
+// First-launch onboarding flow with welcome, permissions, and shortcuts screens.
+// Swift 6.0 strict concurrency, macOS 14+
+
+import SwiftUI
+import ServiceManagement
+
+@MainActor
+struct OnboardingView: View {
+    let preferences: AppPreferences
+    let onDismiss: () -> Void
+
+    @State private var currentPage = 0
+    @State private var permissionGranted = CGPreflightScreenCaptureAccess()
+    @State private var launchAtLogin = true
+
+    private var totalPages: Int {
+        permissionGranted ? 2 : 3
+    }
+
+    private var pageIndex: Int {
+        if permissionGranted && currentPage >= 1 {
+            // Skip permissions page: page 1 maps to shortcuts (index 2)
+            return currentPage == 1 ? 2 : currentPage
+        }
+        return currentPage
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            TabView(selection: $currentPage) {
+                WelcomePageView(onNext: advanceFromWelcome)
+                    .tag(0)
+
+                if !permissionGranted {
+                    PermissionsPageView(
+                        permissionGranted: $permissionGranted,
+                        onNext: { withAnimation { currentPage = permissionGranted ? 1 : 2 } },
+                        onSkip: {
+                            preferences.permissionSkipped = true
+                            withAnimation { currentPage = 2 }
+                        }
+                    )
+                    .tag(1)
+
+                    ShortcutsPageView(launchAtLogin: $launchAtLogin, onDone: finishOnboarding)
+                        .tag(2)
+                } else {
+                    ShortcutsPageView(launchAtLogin: $launchAtLogin, onDone: finishOnboarding)
+                        .tag(1)
+                }
+            }
+            .tabViewStyle(.automatic)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            // Dot indicators
+            HStack(spacing: 8) {
+                ForEach(0..<totalPages, id: \.self) { index in
+                    Circle()
+                        .fill(index == currentPage ? Color.MikaPlus.tealPrimary : Color.gray.opacity(0.5))
+                        .frame(width: 8, height: 8)
+                }
+            }
+            .padding(.bottom, 20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(
+            LinearGradient(
+                colors: [Color.MikaPlus.darkBgDeep, Color.MikaPlus.darkBg],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+        .onKeyPress(.escape) {
+            onDismiss()
+            return .handled
+        }
+    }
+
+    private func advanceFromWelcome() {
+        withAnimation {
+            if permissionGranted {
+                currentPage = 1
+            } else {
+                currentPage = 1
+            }
+        }
+    }
+
+    private func finishOnboarding() {
+        if launchAtLogin {
+            try? SMAppService.mainApp.register()
+        }
+        preferences.launchAtLogin = launchAtLogin
+        preferences.hasCompletedOnboarding = true
+        onDismiss()
+    }
+}
+
+// MARK: - Welcome Page
+
+@MainActor
+private struct WelcomePageView: View {
+    let onNext: () -> Void
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer()
+
+            if let appIcon = NSImage(named: NSImage.applicationIconName) {
+                Image(nsImage: appIcon)
+                    .resizable()
+                    .frame(width: 192, height: 192)
+            } else {
+                Image(systemName: "camera.viewfinder")
+                    .resizable()
+                    .frame(width: 192, height: 192)
+                    .foregroundStyle(Color.MikaPlus.tealPrimary)
+            }
+
+            Text("Welcome to Mika+ScreenSnap")
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundStyle(Color.MikaPlus.textPrimary)
+
+            Text("Screenshot. Annotate. Ship.")
+                .font(.system(size: 14))
+                .foregroundStyle(Color.MikaPlus.tealLight)
+
+            Spacer()
+
+            Button(action: onNext) {
+                Text("Get Started")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.white)
+                    .frame(width: 200, height: 40)
+                    .background(Color.MikaPlus.tealPrimary)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
+                .frame(height: 40)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Permissions Page
+
+@MainActor
+private struct PermissionsPageView: View {
+    @Binding var permissionGranted: Bool
+    let onNext: () -> Void
+    let onSkip: () -> Void
+
+    @State private var autoAdvanceTask: Task<Void, Never>?
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer()
+
+            if permissionGranted {
+                Image(systemName: "checkmark.circle.fill")
+                    .resizable()
+                    .frame(width: 48, height: 48)
+                    .foregroundStyle(Color.green)
+                    .transition(.scale.combined(with: .opacity))
+            } else {
+                Image(systemName: "lock.shield")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 48, height: 48)
+                    .foregroundStyle(Color.MikaPlus.tealPrimary)
+            }
+
+            Text("Screen Recording Permission")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(Color.MikaPlus.textPrimary)
+
+            Text("Mika+ScreenSnap needs screen recording access to capture screenshots. Your privacy is respected — we never record audio or video.")
+                .font(.system(size: 13))
+                .foregroundStyle(Color.MikaPlus.textSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 40)
+
+            if permissionGranted {
+                Text("Permission granted!")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(Color.green)
+            } else {
+                Button(action: openSystemSettings) {
+                    Text("Open System Settings")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(.white)
+                        .frame(width: 200, height: 40)
+                        .background(Color.MikaPlus.tealPrimary)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+                .buttonStyle(.plain)
+            }
+
+            Spacer()
+
+            if !permissionGranted {
+                Button("Skip for now") {
+                    onSkip()
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 12))
+                .foregroundStyle(Color.MikaPlus.tealLight.opacity(0.5))
+            }
+
+            Spacer()
+                .frame(height: 40)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onReceive(Timer.publish(every: 1, on: .main, in: .common).autoconnect()) { _ in
+            if !permissionGranted && CGPreflightScreenCaptureAccess() {
+                withAnimation {
+                    permissionGranted = true
+                }
+                autoAdvanceTask = Task { @MainActor in
+                    try? await Task.sleep(for: .seconds(1))
+                    if !Task.isCancelled {
+                        onNext()
+                    }
+                }
+            }
+        }
+        .onDisappear {
+            autoAdvanceTask?.cancel()
+        }
+    }
+
+    private func openSystemSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+}
+
+// MARK: - Shortcuts Page
+
+@MainActor
+private struct ShortcutsPageView: View {
+    @Binding var launchAtLogin: Bool
+    let onDone: () -> Void
+
+    private let shortcuts: [(keys: String, label: String)] = [
+        ("\u{2303}\u{21E7}\u{2318}3", "Fullscreen"),
+        ("\u{2303}\u{21E7}\u{2318}4", "Area"),
+        ("\u{2303}\u{21E7}\u{2318}5", "Window"),
+        ("\u{21E7}\u{2318}6", "OCR"),
+        ("\u{21E7}\u{2318}7", "Color Picker"),
+        ("\u{21E7}\u{2318}8", "Measure"),
+    ]
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Spacer()
+                .frame(height: 20)
+
+            Text("Keyboard Shortcuts")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(Color.MikaPlus.textPrimary)
+
+            Text("Use these global hotkeys from anywhere.")
+                .font(.system(size: 13))
+                .foregroundStyle(Color.MikaPlus.textSecondary)
+
+            VStack(spacing: 8) {
+                ForEach(shortcuts, id: \.keys) { shortcut in
+                    ShortcutCardView(keys: shortcut.keys, label: shortcut.label)
+                }
+            }
+            .padding(.horizontal, 40)
+
+            Spacer()
+                .frame(height: 12)
+
+            Toggle("Launch Mika+ScreenSnap at login", isOn: $launchAtLogin)
+                .toggleStyle(.checkbox)
+                .font(.system(size: 13))
+                .foregroundStyle(Color.MikaPlus.textSecondary)
+                .padding(.horizontal, 40)
+
+            Spacer()
+
+            Button(action: onDone) {
+                Text("Done")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.white)
+                    .frame(width: 200, height: 40)
+                    .background(Color.MikaPlus.tealPrimary)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
+                .frame(height: 40)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+@MainActor
+private struct ShortcutCardView: View {
+    let keys: String
+    let label: String
+
+    var body: some View {
+        HStack {
+            Text(keys)
+                .font(.system(size: 14, design: .monospaced))
+                .foregroundStyle(Color.MikaPlus.tealLight)
+                .frame(width: 100, alignment: .trailing)
+
+            Text(label)
+                .font(.system(size: 14))
+                .foregroundStyle(Color.MikaPlus.textPrimary)
+
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(Color.white.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}

--- a/Sources/OnboardingWindowController.swift
+++ b/Sources/OnboardingWindowController.swift
@@ -1,0 +1,67 @@
+// OnboardingWindowController.swift
+// MikaScreenSnap
+//
+// Window controller for the first-launch onboarding flow.
+// Swift 6.0 strict concurrency, macOS 14+
+
+import SwiftUI
+
+@MainActor
+final class OnboardingWindowController: NSObject, NSWindowDelegate {
+    private var window: NSWindow?
+    private let preferences: AppPreferences
+
+    init(preferences: AppPreferences) {
+        self.preferences = preferences
+    }
+
+    func showWindow() {
+        if let existing = window, existing.isVisible {
+            existing.makeKeyAndOrderFront(nil)
+            NSApp.activate()
+            return
+        }
+
+        NSApp.setActivationPolicy(.regular)
+
+        let contentView = OnboardingView(
+            preferences: preferences,
+            onDismiss: { [weak self] in self?.close() }
+        )
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 560),
+            styleMask: [.titled, .closable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
+        window.isMovableByWindowBackground = true
+        window.isReleasedWhenClosed = false
+        window.contentView = NSHostingView(rootView: contentView)
+        window.center()
+        window.delegate = self
+
+        self.window = window
+
+        NSApp.activate()
+        window.makeKeyAndOrderFront(nil)
+    }
+
+    func close() {
+        window?.close()
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        preferences.hasCompletedOnboarding = true
+
+        // Switch back to accessory if no other windows are visible
+        let hasVisibleWindows = NSApp.windows.contains { win in
+            win !== window && win.isVisible && !(win is NSPanel)
+        }
+        if !hasVisibleWindows {
+            NSApp.setActivationPolicy(.accessory)
+        }
+    }
+}

--- a/Sources/PreferencesView.swift
+++ b/Sources/PreferencesView.swift
@@ -10,9 +10,11 @@ import SwiftUI
 final class PreferencesWindowController {
     private var window: NSWindow?
     private let preferences: AppPreferences
+    private let onShowOnboarding: () -> Void
 
-    init(preferences: AppPreferences) {
+    init(preferences: AppPreferences, onShowOnboarding: @escaping () -> Void) {
         self.preferences = preferences
+        self.onShowOnboarding = onShowOnboarding
     }
 
     func showWindow() {
@@ -24,10 +26,10 @@ final class PreferencesWindowController {
 
         NSApp.setActivationPolicy(.regular)
 
-        let contentView = PreferencesView(preferences: preferences)
+        let contentView = PreferencesView(preferences: preferences, onShowOnboarding: onShowOnboarding)
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 450, height: 280),
+            contentRect: NSRect(x: 0, y: 0, width: 450, height: 350),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
@@ -46,9 +48,17 @@ final class PreferencesWindowController {
 
 struct PreferencesView: View {
     let preferences: AppPreferences
+    let onShowOnboarding: () -> Void
 
     var body: some View {
         Form {
+            Section("General") {
+                Toggle("Launch at Login", isOn: Binding(
+                    get: { preferences.launchAtLogin },
+                    set: { preferences.launchAtLogin = $0 }
+                ))
+            }
+
             Section("Auto-Save") {
                 Toggle("Automatically save screenshots", isOn: Binding(
                     get: { preferences.autoSaveEnabled },
@@ -91,9 +101,15 @@ struct PreferencesView: View {
                     }
                 }
             }
+
+            Section("Onboarding") {
+                Button("Show Onboarding Again") {
+                    onShowOnboarding()
+                }
+            }
         }
         .formStyle(.grouped)
-        .frame(width: 450, height: 280)
+        .frame(width: 450, height: 350)
     }
 
     private func chooseFolder() {


### PR DESCRIPTION
## Summary
- 3-screen onboarding flow (welcome, screen recording permission, keyboard shortcuts) shown only on first launch
- Launch at Login toggle via SMAppService (in onboarding + Preferences)
- Menubar warning when screen recording permission is not granted
- "Show Onboarding Again" button in Preferences

Closes #8

## Test plan
- [x] Reset with `defaults delete com.mika.mikaplusscreensnap hasCompletedOnboarding` and launch — onboarding appears
- [x] Screen 1: icon, text, "Get Started" advances to next screen
- [x] Screen 2: permission polling, "Open System Settings", "Skip for now"
- [x] Screen 3: 6 shortcut cards, launch-at-login toggle, "Done" closes window
- [x] Relaunch — no onboarding, only menubar
- [x] Preferences → "Show Onboarding Again" re-opens onboarding
- [x] Escape closes onboarding and marks as completed
- [x] Menubar shows "⚠ Screen Recording not granted" when permission missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)