### PR TITLE
Add first-launch onboarding flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.3.0] - 2026-03-18
+
+### Added
+- **First Launch Onboarding** — 3-screen guided flow (welcome, permissions, shortcuts) for new users
+- **Screen Recording permission warning** in menubar when not granted
+- **"Show Onboarding Again"** button in Preferences
+
 ## [3.2.0] - 2026-03-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,10 +32,11 @@ open "build/Mika+ScreenSnap.app"
 - **Annotation protocol** — self-drawing annotations with snapshot/restore for undo. Sorted by zIndex for render order
 - **Carbon hotkeys** — EventHotKeyID with static instance pointer for callback. Signature: `0x4D534E53`
 - **SwiftUI in AppKit** — Toolbar and BottomBar are `NSHostingView` with `@Observable` store binding
+- **Onboarding flow** — `OnboardingWindowController` follows AboutWindowController pattern; SwiftUI `TabView` with paged navigation, conditional permission screen, live permission polling
 
 ## File Organization
 
-All source files in `Sources/`, tools in `Sources/Tools/`. No subdirectories beyond that. Resources (Info.plist, entitlements) in `Resources/`. Build/distribution scripts in `scripts/`. Generated installer assets (DMGs, backgrounds) in `installer/` (gitignored except `.gitkeep`).
+All source files in `Sources/`, tools in `Sources/Tools/`, onboarding screens in `Sources/Onboarding/`. Resources (Info.plist, entitlements) in `Resources/`. Build/distribution scripts in `scripts/`. Generated installer assets (DMGs, backgrounds) in `installer/` (gitignored except `.gitkeep`).
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# Mika+ScreenSnap v3.2.0
+# Mika+ScreenSnap v3.3.0
 
 A lightweight macOS menubar screenshot tool with a professional annotation editor and power features. Capture your screen, annotate it with 11 tools, extract text via OCR, pick colors, measure pixels, pin screenshots, and manage your history — all without leaving your workflow.
 
 ## Features
 
+- **First Launch Onboarding** — guided setup for permissions, shortcuts, and launch-at-login
 - **Launch at Login** — optional auto-start at macOS login (Preferences > General)
 - **Menubar App** — lives in your menubar, no Dock icon
 - **Capture Modes**

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -11,9 +11,9 @@
     <key>CFBundleExecutable</key>
     <string>MikaScreenSnap</string>
     <key>CFBundleVersion</key>
-    <string>3.2.0</string>
+    <string>3.3.0</string>
     <key>CFBundleShortVersionString</key>
-    <string>3.2.0</string>
+    <string>3.3.0</string>
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundlePackageType</key>

--- a/Sources/AppPreferences.swift
+++ b/Sources/AppPreferences.swift
@@ -32,6 +32,14 @@ final class AppPreferences {
         didSet { defaults.set(jpegQuality, forKey: "jpegQuality") }
     }
 
+    var hasCompletedOnboarding: Bool {
+        didSet { defaults.set(hasCompletedOnboarding, forKey: "hasCompletedOnboarding") }
+    }
+
+    var permissionSkipped: Bool {
+        didSet { defaults.set(permissionSkipped, forKey: "permissionSkipped") }
+    }
+
     init() {
         let defaultLocation = FileManager.default.urls(for: .picturesDirectory, in: .userDomainMask).first!
             .appendingPathComponent("MikaScreenSnap", isDirectory: true)
@@ -39,6 +47,8 @@ final class AppPreferences {
         self.autoSaveEnabled = defaults.object(forKey: "autoSaveEnabled") as? Bool ?? true
         self.jpegQuality = defaults.object(forKey: "jpegQuality") as? CGFloat ?? 0.85
         self.imageFormat = ImageFormat(rawValue: defaults.string(forKey: "imageFormat") ?? "") ?? .png
+        self.hasCompletedOnboarding = defaults.object(forKey: "hasCompletedOnboarding") as? Bool ?? false
+        self.permissionSkipped = defaults.object(forKey: "permissionSkipped") as? Bool ?? false
 
         if let savedPath = defaults.string(forKey: "saveLocation") {
             self.saveLocation = URL(fileURLWithPath: savedPath)

--- a/Sources/MikaScreenSnapApp.swift
+++ b/Sources/MikaScreenSnapApp.swift
@@ -18,6 +18,7 @@ final class AppState {
     var aboutController: AboutWindowController?
     var sparkleUpdater: SparkleUpdater
     var launchAtLoginManager: LaunchAtLoginManager
+    var onboardingController: OnboardingWindowController?
 
     init() {
         let prefs = AppPreferences()
@@ -36,7 +37,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     var hotkeyManager: HotkeyManager?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        checkScreenCapturePermission()
+        if !appState.preferences.hasCompletedOnboarding {
+            showOnboarding()
+        } else if !CGPreflightScreenCaptureAccess() {
+            checkScreenCapturePermission()
+        }
 
         // Restore pinned screenshots
         PinnedScreenshotManager.restorePins(appState: appState)
@@ -75,6 +80,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self.showHistoryBrowser()
             }
         )
+    }
+
+    func showOnboarding() {
+        if appState.onboardingController == nil {
+            appState.onboardingController = OnboardingWindowController(
+                preferences: appState.preferences,
+                launchAtLoginManager: appState.launchAtLoginManager
+            )
+        }
+        appState.onboardingController?.showWindow()
     }
 
     private func showHistoryBrowser() {
@@ -136,6 +151,13 @@ struct MikaScreenSnapApp: App {
             }
             Button("Check for Updates...") {
                 appDelegate.appState.sparkleUpdater.checkForUpdates()
+            }
+            if !CGPreflightScreenCaptureAccess() {
+                Button("\u{26A0} Screen Recording not granted") {
+                    if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture") {
+                        NSWorkspace.shared.open(url)
+                    }
+                }
             }
             Divider()
 
@@ -226,7 +248,10 @@ struct MikaScreenSnapApp: App {
                 if appDelegate.appState.preferencesController == nil {
                     appDelegate.appState.preferencesController = PreferencesWindowController(
                         preferences: appDelegate.appState.preferences,
-                        launchAtLoginManager: appDelegate.appState.launchAtLoginManager
+                        launchAtLoginManager: appDelegate.appState.launchAtLoginManager,
+                        onShowOnboarding: { [weak appDelegate] in
+                            appDelegate?.showOnboarding()
+                        }
                     )
                 }
                 appDelegate.appState.preferencesController?.showWindow()

--- a/Sources/Onboarding/OnboardingView.swift
+++ b/Sources/Onboarding/OnboardingView.swift
@@ -1,0 +1,78 @@
+// OnboardingView.swift
+// MikaScreenSnap
+//
+// SwiftUI container for onboarding flow with paged navigation.
+// Swift 6.0 strict concurrency, macOS 14+
+
+import SwiftUI
+
+struct OnboardingView: View {
+    let preferences: AppPreferences
+    let launchAtLoginManager: LaunchAtLoginManager
+    let onDismiss: () -> Void
+
+    @State private var currentPage = 0
+
+    private var needsPermission: Bool {
+        !CGPreflightScreenCaptureAccess()
+    }
+
+    private var pageCount: Int {
+        needsPermission ? 3 : 2
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            TabView(selection: $currentPage) {
+                WelcomeScreen {
+                    withAnimation { currentPage = 1 }
+                }
+                .tag(0)
+
+                if needsPermission {
+                    PermissionScreen(preferences: preferences) {
+                        withAnimation { currentPage = 2 }
+                    }
+                    .tag(1)
+
+                    ShortcutsScreen(
+                        launchAtLoginManager: launchAtLoginManager,
+                        preferences: preferences,
+                        onDismiss: onDismiss
+                    )
+                    .tag(2)
+                } else {
+                    ShortcutsScreen(
+                        launchAtLoginManager: launchAtLoginManager,
+                        preferences: preferences,
+                        onDismiss: onDismiss
+                    )
+                    .tag(1)
+                }
+            }
+            .tabViewStyle(.automatic)
+
+            // Dot indicators
+            HStack(spacing: 8) {
+                ForEach(0..<pageCount, id: \.self) { index in
+                    Circle()
+                        .fill(index == currentPage ? Color.MikaPlus.tealPrimary : Color.gray.opacity(0.5))
+                        .frame(width: 8, height: 8)
+                }
+            }
+            .padding(.bottom, 16)
+        }
+        .frame(width: 480, height: 560)
+        .background(
+            LinearGradient(
+                colors: [Color.MikaPlus.darkBgDeep, Color.MikaPlus.darkBg],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+        .onKeyPress(.escape) {
+            onDismiss()
+            return .handled
+        }
+    }
+}

--- a/Sources/Onboarding/OnboardingWindow.swift
+++ b/Sources/Onboarding/OnboardingWindow.swift
@@ -1,0 +1,70 @@
+// OnboardingWindow.swift
+// MikaScreenSnap
+//
+// Window controller for the first-launch onboarding flow.
+// Swift 6.0 strict concurrency, macOS 14+
+
+import SwiftUI
+
+@MainActor
+final class OnboardingWindowController: NSObject, NSWindowDelegate {
+    private var window: NSWindow?
+    private let preferences: AppPreferences
+    private let launchAtLoginManager: LaunchAtLoginManager
+
+    init(preferences: AppPreferences, launchAtLoginManager: LaunchAtLoginManager) {
+        self.preferences = preferences
+        self.launchAtLoginManager = launchAtLoginManager
+    }
+
+    func showWindow() {
+        if let existing = window, existing.isVisible {
+            existing.makeKeyAndOrderFront(nil)
+            NSApp.activate()
+            return
+        }
+
+        NSApp.setActivationPolicy(.regular)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 560),
+            styleMask: [.titled, .closable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
+        window.isMovableByWindowBackground = true
+        window.isReleasedWhenClosed = false
+        window.delegate = self
+
+        let contentView = OnboardingView(
+            preferences: preferences,
+            launchAtLoginManager: launchAtLoginManager,
+            onDismiss: { [weak self] in self?.close() }
+        )
+        window.contentView = NSHostingView(rootView: contentView)
+        window.center()
+
+        self.window = window
+
+        NSApp.activate()
+        window.makeKeyAndOrderFront(nil)
+    }
+
+    func close() {
+        window?.close()
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        preferences.hasCompletedOnboarding = true
+
+        // Switch back to accessory if no other windows are visible
+        let hasVisibleWindows = NSApp.windows.contains { win in
+            win !== window && win.isVisible && !(win is NSPanel)
+        }
+        if !hasVisibleWindows {
+            NSApp.setActivationPolicy(.accessory)
+        }
+    }
+}

--- a/Sources/Onboarding/PermissionScreen.swift
+++ b/Sources/Onboarding/PermissionScreen.swift
@@ -1,0 +1,92 @@
+// PermissionScreen.swift
+// MikaScreenSnap
+//
+// Onboarding screen 2: Screen Recording permission request.
+// Swift 6.0 strict concurrency, macOS 14+
+
+import SwiftUI
+
+struct PermissionScreen: View {
+    let preferences: AppPreferences
+    let onNext: () -> Void
+
+    @State private var granted = CGPreflightScreenCaptureAccess()
+    @State private var autoAdvanceTask: Task<Void, Never>?
+
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            if granted {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 48))
+                    .foregroundStyle(Color.green)
+                    .transition(.scale.combined(with: .opacity))
+            } else {
+                Image(systemName: "lock.shield")
+                    .font(.system(size: 48))
+                    .foregroundStyle(Color.MikaPlus.tealPrimary)
+            }
+
+            Text("Screen Recording Permission")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(Color.MikaPlus.textPrimary)
+
+            Text("Mika+ScreenSnap needs Screen Recording access to capture screenshots. Your data stays on your Mac — nothing is uploaded or shared.")
+                .font(.system(size: 13))
+                .foregroundStyle(Color.MikaPlus.textSecondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 340)
+
+            if !granted {
+                Button {
+                    if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture") {
+                        NSWorkspace.shared.open(url)
+                    }
+                } label: {
+                    Text("Open System Settings")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(.white)
+                        .frame(width: 200, height: 40)
+                        .background(Color.MikaPlus.tealPrimary)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+                .buttonStyle(.plain)
+            }
+
+            Spacer()
+
+            if !granted {
+                Button("Skip for now") {
+                    preferences.permissionSkipped = true
+                    onNext()
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 12))
+                .foregroundStyle(Color.MikaPlus.tealLight.opacity(0.5))
+            }
+
+            Spacer()
+                .frame(height: 20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .animation(.easeInOut, value: granted)
+        .onReceive(timer) { _ in
+            let status = CGPreflightScreenCaptureAccess()
+            if status && !granted {
+                granted = true
+                autoAdvanceTask = Task { @MainActor in
+                    try? await Task.sleep(for: .seconds(1))
+                    if !Task.isCancelled {
+                        onNext()
+                    }
+                }
+            }
+        }
+        .onDisappear {
+            autoAdvanceTask?.cancel()
+        }
+    }
+}

--- a/Sources/Onboarding/ShortcutsScreen.swift
+++ b/Sources/Onboarding/ShortcutsScreen.swift
@@ -1,0 +1,81 @@
+// ShortcutsScreen.swift
+// MikaScreenSnap
+//
+// Onboarding screen 3: Keyboard shortcuts overview and launch-at-login toggle.
+// Swift 6.0 strict concurrency, macOS 14+
+
+import SwiftUI
+
+struct ShortcutsScreen: View {
+    let launchAtLoginManager: LaunchAtLoginManager
+    let preferences: AppPreferences
+    let onDismiss: () -> Void
+
+    @State private var launchAtLogin = true
+
+    private let shortcuts: [(keys: String, label: String)] = [
+        ("\u{2303}\u{21E7}\u{2318}3", "Fullscreen Capture"),
+        ("\u{2303}\u{21E7}\u{2318}4", "Area Capture"),
+        ("\u{2303}\u{21E7}\u{2318}5", "Window Capture"),
+        ("\u{21E7}\u{2318}6", "OCR Text Extraction"),
+        ("\u{21E7}\u{2318}7", "Color Picker"),
+        ("\u{21E7}\u{2318}8", "Measure"),
+    ]
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer()
+                .frame(height: 8)
+
+            Text("Keyboard Shortcuts")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(Color.MikaPlus.textPrimary)
+
+            VStack(spacing: 8) {
+                ForEach(shortcuts, id: \.keys) { shortcut in
+                    HStack {
+                        Text(shortcut.keys)
+                            .font(.system(size: 13, design: .monospaced))
+                            .foregroundStyle(Color.MikaPlus.tealLight)
+                            .frame(width: 100, alignment: .trailing)
+                        Text(shortcut.label)
+                            .font(.system(size: 13))
+                            .foregroundStyle(Color.MikaPlus.textPrimary)
+                        Spacer()
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                    .background(Color.white.opacity(0.05))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+            }
+            .padding(.horizontal, 40)
+
+            Spacer()
+
+            Toggle("Launch Mika+ScreenSnap at login", isOn: $launchAtLogin)
+                .toggleStyle(.checkbox)
+                .font(.system(size: 13))
+                .foregroundStyle(Color.MikaPlus.textPrimary)
+                .padding(.horizontal, 40)
+
+            Button {
+                launchAtLoginManager.setEnabled(launchAtLogin)
+                preferences.hasCompletedOnboarding = true
+                onDismiss()
+            } label: {
+                Text("Done")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.white)
+                    .frame(width: 200, height: 40)
+                    .background(Color.MikaPlus.tealPrimary)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
+                .frame(height: 30)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/Sources/Onboarding/WelcomeScreen.swift
+++ b/Sources/Onboarding/WelcomeScreen.swift
@@ -1,0 +1,52 @@
+// WelcomeScreen.swift
+// MikaScreenSnap
+//
+// Onboarding screen 1: Welcome with app icon and tagline.
+// Swift 6.0 strict concurrency, macOS 14+
+
+import SwiftUI
+
+struct WelcomeScreen: View {
+    let onNext: () -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            if let appIcon = NSImage(named: NSImage.applicationIconName) {
+                Image(nsImage: appIcon)
+                    .resizable()
+                    .frame(width: 192, height: 192)
+            } else {
+                Image(systemName: "camera.viewfinder")
+                    .resizable()
+                    .frame(width: 192, height: 192)
+                    .foregroundStyle(Color.MikaPlus.tealPrimary)
+            }
+
+            Text("Welcome to Mika+ScreenSnap")
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundStyle(Color.MikaPlus.textPrimary)
+
+            Text("Screenshot. Annotate. Ship.")
+                .font(.system(size: 14))
+                .foregroundStyle(Color.MikaPlus.tealLight)
+
+            Spacer()
+
+            Button(action: onNext) {
+                Text("Get Started")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.white)
+                    .frame(width: 200, height: 40)
+                    .background(Color.MikaPlus.tealPrimary)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
+                .frame(height: 40)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/Sources/PreferencesView.swift
+++ b/Sources/PreferencesView.swift
@@ -11,10 +11,12 @@ final class PreferencesWindowController {
     private var window: NSWindow?
     private let preferences: AppPreferences
     private let launchAtLoginManager: LaunchAtLoginManager
+    let onShowOnboarding: () -> Void
 
-    init(preferences: AppPreferences, launchAtLoginManager: LaunchAtLoginManager) {
+    init(preferences: AppPreferences, launchAtLoginManager: LaunchAtLoginManager, onShowOnboarding: @escaping () -> Void) {
         self.preferences = preferences
         self.launchAtLoginManager = launchAtLoginManager
+        self.onShowOnboarding = onShowOnboarding
     }
 
     func showWindow() {
@@ -28,7 +30,8 @@ final class PreferencesWindowController {
 
         let contentView = PreferencesView(
             preferences: preferences,
-            launchAtLoginManager: launchAtLoginManager
+            launchAtLoginManager: launchAtLoginManager,
+            onShowOnboarding: onShowOnboarding
         )
 
         let window = NSWindow(
@@ -52,6 +55,7 @@ final class PreferencesWindowController {
 struct PreferencesView: View {
     let preferences: AppPreferences
     let launchAtLoginManager: LaunchAtLoginManager
+    let onShowOnboarding: () -> Void
 
     var body: some View {
         Form {
@@ -102,6 +106,12 @@ struct PreferencesView: View {
                         Text("\(Int(preferences.jpegQuality * 100))%")
                             .frame(width: 40)
                     }
+                }
+            }
+
+            Section("Onboarding") {
+                Button("Show Onboarding Again") {
+                    onShowOnboarding()
                 }
             }
         }


### PR DESCRIPTION
## Summary
- 3-screen onboarding flow (welcome, permissions, shortcuts) for first-time users
- Live permission polling with auto-advance when Screen Recording is granted
- Launch-at-login toggle on final screen (defaults to enabled)
- Menubar warning item when Screen Recording permission is not granted
- "Show Onboarding Again" button in Preferences
- Version bump to 3.3.0

## New Files
- `Sources/Onboarding/OnboardingWindow.swift` — Window controller (AboutWindowController pattern)
- `Sources/Onboarding/OnboardingView.swift` — SwiftUI container with TabView navigation
- `Sources/Onboarding/WelcomeScreen.swift` — Screen 1: app icon + tagline
- `Sources/Onboarding/PermissionScreen.swift` — Screen 2: permission request with live polling
- `Sources/Onboarding/ShortcutsScreen.swift` — Screen 3: shortcut cards + launch-at-login

## Modified Files
- `AppPreferences.swift` — `hasCompletedOnboarding` + `permissionSkipped` properties
- `MikaScreenSnapApp.swift` — onboarding launch flow, menubar warning, preferences closure
- `PreferencesView.swift` — "Show Onboarding Again" section + `onShowOnboarding` closure

## Test plan
- [ ] First launch → onboarding appears (480×560, centered, dark gradient)
- [ ] Screen 1 → icon, texts, "Get Started" advances to next screen
- [ ] Screen 2 → permission polling, "Open System Settings", "Skip for now"
- [ ] Screen 3 → 6 shortcut cards, launch-at-login toggle, "Done" closes window
- [ ] Restart → no onboarding, menubar only
- [ ] Preferences → "Show Onboarding Again" reopens onboarding
- [ ] Escape → closes window, marks as completed
- [ ] Menubar → "⚠ Screen Recording not granted" when permission missing
- [ ] Permission already granted → Screen 2 is skipped

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)