### PR TITLE
Fix appcast.xml Sparkle parsing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.3.2] - 2026-03-18
+
+### Fixed
+- **Appcast parsing error** — corrected XML namespace (`sparkle` → `http://www.andymatuschak.org/xml-namespaces/sparkle`) and XML declaration encoding in `appcast.xml`; fixes "An error occurred while parsing the update feed"
+
 ## [3.3.1] - 2026-03-18
 
 ### Fixed

--- a/appcast.xml
+++ b/appcast.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" standalone="yes"?>
-<rss xmlns:sparkle="http://www.sparkle-project.org/SUAppcastItem" version="2.0">
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
     <channel>
         <title>Mika+ScreenSnap Updates</title>
         <item>


### PR DESCRIPTION
## Summary
- Corrected Sparkle XML namespace from `http://www.sparkle-project.org/SUAppcastItem` to `http://www.andymatuschak.org/xml-namespaces/sparkle`
- Fixed XML declaration: replaced `standalone="yes"` with `encoding="utf-8"`
- Added v3.3.2 changelog entry

## Test plan
- [x] `xmllint --noout appcast.xml` passes
- [x] App → "Check for Updates..." → no parsing error, shows "You're up to date"

🤖 Generated with [Claude Code](https://claude.com/claude-code)