### PR TITLE
Point all GitHub URLs at the daumedia account

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ swift scripts/GenerateDMGBackground.swift
 ### Auto-Update (Sparkle)
 
 The app uses Sparkle 2.x for auto-updates. Configuration:
-- **Feed URL:** `https://raw.githubusercontent.com/Mukaarts/MikaScreenSnap/main/appcast.xml`
+- **Feed URL:** `https://raw.githubusercontent.com/daumedia/MikaScreenSnap/master/appcast.xml` (as configured in `Resources/Info.plist`)
 - **Ed25519 public key:** configured in `Resources/Info.plist` (`SUPublicEDKey`)
 - **Private key:** stored in the macOS Keychain (generated via `.build/artifacts/sparkle/Sparkle/bin/generate_keys`)
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -29,7 +29,7 @@
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>SUFeedURL</key>
-    <string>https://raw.githubusercontent.com/Mukaarts/MikaScreenSnap/master/appcast.xml</string>
+    <string>https://raw.githubusercontent.com/daumedia/MikaScreenSnap/master/appcast.xml</string>
     <key>SUPublicEDKey</key>
     <string>eauiHgP4PM9ynLekAmo3URrX3ye3HW7D53xOZa5AeYI=</string>
 </dict>

--- a/appcast.xml
+++ b/appcast.xml
@@ -2,7 +2,7 @@
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
     <channel>
         <title>Mika+ScreenSnap Updates</title>
-        <link>https://github.com/Mukaarts/MikaScreenSnap</link>
+        <link>https://github.com/daumedia/MikaScreenSnap</link>
         <item>
             <title>Version 3.4.0</title>
             <sparkle:version>3.4.0</sparkle:version>
@@ -21,7 +21,7 @@
             ]]></description>
             <pubDate>Wed, 18 Mar 2026 18:00:00 +0100</pubDate>
             <enclosure
-                url="https://github.com/Mukaarts/MikaScreenSnap/releases/download/v3.4.0/Mika%2BScreenSnap-v3.4.0.dmg"
+                url="https://github.com/daumedia/MikaScreenSnap/releases/download/v3.4.0/Mika%2BScreenSnap-v3.4.0.dmg"
                 sparkle:version="3.4.0"
                 sparkle:shortVersionString="3.4.0"
                 sparkle:edSignature="UUmCjjLEg5BoCzzflTqvTbxOd1fxHZT+6kQY0/7WYWjANuwrgIrLOEecuukzup0ufCvm72iB8ofvogcHhLhlCA=="
@@ -45,7 +45,7 @@
             ]]></description>
             <pubDate>Wed, 18 Mar 2026 12:00:00 +0100</pubDate>
             <enclosure
-                url="https://github.com/Mukaarts/MikaScreenSnap/releases/download/v3.3.1/Mika%2BScreenSnap-v3.3.1.dmg"
+                url="https://github.com/daumedia/MikaScreenSnap/releases/download/v3.3.1/Mika%2BScreenSnap-v3.3.1.dmg"
                 sparkle:version="3.3.1"
                 sparkle:shortVersionString="3.3.1"
                 sparkle:edSignature="XvTwo4/t5juWRF7G744QyIW8KDR4jj9+rQdiB3jNlcSjPF4MpIiFmn5MaPGqoUCd4ugk57V0+Qbf0qSmI/oFAw=="

--- a/web/lib/content.ts
+++ b/web/lib/content.ts
@@ -6,21 +6,24 @@
  * that needs editing.
  */
 
+const version = "3.4.0";
+const repo = "https://github.com/daumedia/MikaScreenSnap";
+
 export const product = {
   name: "Mika+ScreenSnap",
   tagline: "Screenshots, annotated before you even switch windows.",
   description:
     "A lightweight macOS menu bar screenshot tool with a real annotation editor, OCR, a colour picker and pixel measurement — all one keystroke away.",
-  version: "3.4.0",
+  version,
   minimumOS: "macOS 14.0 (Sonoma)",
   // The shipped binary is arm64-only (verified with `lipo -info`), so the site
   // must not promise Intel support.
   architecture: "Apple silicon",
   license: "MIT",
-  repo: "https://github.com/Mukaarts/MikaScreenSnap",
-  releases: "https://github.com/Mukaarts/MikaScreenSnap/releases",
-  download:
-    "https://github.com/Mukaarts/MikaScreenSnap/releases/download/v3.4.0/Mika%2BScreenSnap-v3.4.0.dmg",
+  repo,
+  releases: `${repo}/releases`,
+  // Derived from version so a release only needs the constant above changed.
+  download: `${repo}/releases/download/v${version}/Mika%2BScreenSnap-v${version}.dmg`,
   saveFolder: "~/Pictures/MikaScreenSnap/",
 } as const;
 


### PR DESCRIPTION
The GitHub account was renamed from `Mukaarts` to `daumedia`. GitHub still redirects the old paths, but that redirect breaks the moment someone else claims the old name — so every reference is updated rather than left to the redirect.

## Changed

| File | What |
|---|---|
| `appcast.xml` | Feed link and both DMG enclosure URLs (3.4.0 and 3.3.1). The Ed25519 signatures are unaffected — they sign the archive, not its URL |
| `Resources/Info.plist` | `SUFeedURL` |
| `web/lib/content.ts` | Repo, releases and download URLs. `repo` and `version` are now constants the other URLs derive from, so a release only needs the version changed in one place |
| `README.md` | Sparkle feed URL |

The local git remote was repointed as well (not part of the diff).

## Verified

- Both DMG downloads and the Sparkle feed return **200** under the new account
- `appcast.xml` is well-formed (`xmllint`), `Info.plist` is valid (`plutil -lint`)
- `npm run build` is clean and the production output contains only the new URLs

## Worth knowing

**The `Info.plist` change only affects future builds.** Installed copies of 3.4.0 keep the old feed URL and depend on GitHub's redirect until users update.

**The feed points at `master`, not the default branch.** `README.md` documented it as `main` while `Info.plist` actually ships `master`; the README is corrected to match reality. Both branches currently carry the same appcast, so updates work — but if only `main` gets maintained from here on, existing installations stop seeing updates. Either keep `master` in sync or move the feed to `main` in a future release.

**`LICENSE` still reads `Copyright (c) 2026 Mukaarts`.** That is an authorship notice rather than a URL, so it is deliberately left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)