### PR TITLE
Keep accessibility overlays out of captures

### DIFF
--- a/Sources/AppPreferences.swift
+++ b/Sources/AppPreferences.swift
@@ -72,6 +72,19 @@ final class AppPreferences {
         didSet { defaults.set(showToolbarLabels, forKey: "showToolbarLabels") }
     }
 
+    /// Bundle identifiers whose windows are never included in a capture.
+    var excludedBundleIdentifiers: Set<String> {
+        didSet { defaults.set(Array(excludedBundleIdentifiers), forKey: "excludedBundleIdentifiers") }
+    }
+
+    /// Accessibility overlays that sit on top of everything and would otherwise be
+    /// baked into every screenshot.
+    static let defaultExcludedBundleIdentifiers = [
+        "com.apple.inputmethod.AssistiveControl",   // Accessibility Keyboard + Keyboard Viewer
+        "com.apple.DwellControl",                   // Dwell Control (pointer control panel)
+        "com.apple.AccessibilityVisualsAgent",      // Zoom / "shake to find pointer" visuals
+    ]
+
     var defaultStrokeNSColor: NSColor {
         get {
             guard let data = defaultStrokeColorData,
@@ -101,6 +114,11 @@ final class AppPreferences {
         self.defaultStrokeWidth = defaults.object(forKey: "defaultStrokeWidth") as? CGFloat ?? 3.0
         self.rememberLastTool = defaults.object(forKey: "rememberLastTool") as? Bool ?? true
         self.showToolbarLabels = defaults.object(forKey: "showToolbarLabels") as? Bool ?? false
+        // An explicitly emptied list stays empty — only a missing key falls back to the defaults.
+        self.excludedBundleIdentifiers = Set(
+            defaults.stringArray(forKey: "excludedBundleIdentifiers")
+                ?? AppPreferences.defaultExcludedBundleIdentifiers
+        )
 
         if let savedPath = defaults.string(forKey: "saveLocation") {
             self.saveLocation = URL(fileURLWithPath: savedPath)
@@ -118,7 +136,8 @@ final class AppPreferences {
             "hasCompletedOnboarding", "permissionSkipped",
             "captureSoundEnabled", "floatingPreviewEnabled", "previewDismissDuration",
             "defaultAnnotationTool", "defaultStrokeColorData", "defaultStrokeWidth",
-            "rememberLastTool", "showToolbarLabels", "hotkeyBindings"
+            "rememberLastTool", "showToolbarLabels", "hotkeyBindings",
+            "excludedBundleIdentifiers"
         ]
         for key in allKeys {
             defaults.removeObject(forKey: key)
@@ -143,6 +162,7 @@ final class AppPreferences {
         defaultStrokeWidth = 3.0
         rememberLastTool = true
         showToolbarLabels = false
+        excludedBundleIdentifiers = Set(AppPreferences.defaultExcludedBundleIdentifiers)
         saveLocation = defaultLocation
     }
 

--- a/Sources/CaptureEngine.swift
+++ b/Sources/CaptureEngine.swift
@@ -7,6 +7,59 @@ final class CaptureEngine {
     private var colorLoupeController: ColorLoupeController?
     private var measurementController: MeasurementOverlayController?
 
+    // MARK: - Content Filtering
+
+    /// Windows that must never end up in a capture: our own UI, every app the user
+    /// excluded, and the software-rendered pointer overlay.
+    private func excludedWindows(in content: SCShareableContent, preferences: AppPreferences?) -> [SCWindow] {
+        let ownPID = ProcessInfo.processInfo.processIdentifier
+        let blocked = preferences?.excludedBundleIdentifiers ?? []
+        return content.windows.filter { window in
+            if CaptureEngine.isPointerOverlay(window) { return true }
+            guard let app = window.owningApplication else { return false }
+            return app.processID == ownPID || blocked.contains(app.bundleIdentifier)
+        }
+    }
+
+    /// Detects the pointer that WindowServer draws as an ordinary window instead of a
+    /// hardware cursor — which is what happens once an accessibility pointer (coloured,
+    /// enlarged, or driven by Dwell Control) is enabled.
+    ///
+    /// `SCStreamConfiguration.showsCursor` only suppresses the hardware cursor, so this
+    /// overlay would otherwise be baked into every screenshot.
+    private static func isPointerOverlay(_ window: SCWindow) -> Bool {
+        guard window.title == "Cursor",
+              window.owningApplication?.bundleIdentifier.isEmpty ?? false,
+              window.windowLayer > 100
+        else { return false }
+        return true
+    }
+
+    /// Captures a still image with the hardware cursor suppressed.
+    /// - Parameters:
+    ///   - sourceRect: crop in points, top-left origin — pass `.null` to capture everything.
+    ///   - pixelWidth/pixelHeight: output size in pixels.
+    private func captureCGImage(
+        filter: SCContentFilter,
+        sourceRect: CGRect,
+        pixelWidth: Int,
+        pixelHeight: Int,
+        shouldBeOpaque: Bool = true
+    ) async throws -> CGImage {
+        let config = SCStreamConfiguration()
+        config.width = pixelWidth
+        config.height = pixelHeight
+        config.showsCursor = false
+        config.shouldBeOpaque = shouldBeOpaque
+        if !sourceRect.isNull {
+            config.sourceRect = sourceRect
+        }
+
+        return try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
+    }
+
+    // MARK: - Capture
+
     func captureFullScreen(appState: AppState?) async {
         do {
             let content = try await SCShareableContent.current
@@ -15,16 +68,17 @@ final class CaptureEngine {
                 return
             }
 
-            let ownPID = ProcessInfo.processInfo.processIdentifier
-            let excludedWindows = content.windows.filter { $0.owningApplication?.processID == ownPID }
+            let filter = SCContentFilter(
+                display: display,
+                excludingWindows: excludedWindows(in: content, preferences: appState?.preferences)
+            )
 
-            let filter = SCContentFilter(display: display, excludingWindows: excludedWindows)
-            let config = SCStreamConfiguration()
-            config.width = Int(display.width) * 2
-            config.height = Int(display.height) * 2
-            config.showsCursor = false
-
-            let cgImage = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
+            let cgImage = try await captureCGImage(
+                filter: filter,
+                sourceRect: .null,
+                pixelWidth: Int(display.width) * 2,
+                pixelHeight: Int(display.height) * 2
+            )
             let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: display.width, height: display.height))
 
             postCapture(nsImage, appState: appState)
@@ -38,10 +92,10 @@ final class CaptureEngine {
             let content = try await SCShareableContent.current
             guard let display = content.displays.first else { return }
 
-            let ownPID = ProcessInfo.processInfo.processIdentifier
-            let excludedWindows = content.windows.filter { $0.owningApplication?.processID == ownPID }
-
-            let filter = SCContentFilter(display: display, excludingWindows: excludedWindows)
+            let filter = SCContentFilter(
+                display: display,
+                excludingWindows: excludedWindows(in: content, preferences: appState?.preferences)
+            )
 
             // Convert from AppKit coordinates (origin bottom-left) to ScreenCaptureKit (origin top-left)
             let displayHeight = CGFloat(display.height)
@@ -53,13 +107,12 @@ final class CaptureEngine {
             )
 
             let scale = NSScreen.main?.backingScaleFactor ?? 2.0
-            let config = SCStreamConfiguration()
-            config.sourceRect = scRect
-            config.width = Int(rect.width * scale)
-            config.height = Int(rect.height * scale)
-            config.showsCursor = false
-
-            let cgImage = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
+            let cgImage = try await captureCGImage(
+                filter: filter,
+                sourceRect: scRect,
+                pixelWidth: Int(rect.width * scale),
+                pixelHeight: Int(rect.height * scale)
+            )
             let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: rect.width, height: rect.height))
 
             postCapture(nsImage, appState: appState)
@@ -72,10 +125,10 @@ final class CaptureEngine {
         do {
             let content = try await SCShareableContent.current
 
-            // Find the frontmost window that isn't ours
-            let ownPID = ProcessInfo.processInfo.processIdentifier
+            // Find the frontmost window that is neither ours nor an excluded app's
+            let skipped = Set(excludedWindows(in: content, preferences: appState?.preferences).map(\.windowID))
             let windows = content.windows.filter {
-                $0.owningApplication?.processID != ownPID &&
+                !skipped.contains($0.windowID) &&
                 $0.isOnScreen &&
                 $0.frame.width > 0 && $0.frame.height > 0 &&
                 $0.title?.isEmpty == false
@@ -87,15 +140,14 @@ final class CaptureEngine {
             }
 
             let filter = SCContentFilter(desktopIndependentWindow: targetWindow)
-            let config = SCStreamConfiguration()
             let scale = NSScreen.main?.backingScaleFactor ?? 2.0
-            config.width = Int(targetWindow.frame.width * scale)
-            config.height = Int(targetWindow.frame.height * scale)
-            config.showsCursor = false
-            config.capturesShadowsOnly = false
-            config.shouldBeOpaque = false
-
-            let cgImage = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
+            let cgImage = try await captureCGImage(
+                filter: filter,
+                sourceRect: .null,
+                pixelWidth: Int(targetWindow.frame.width * scale),
+                pixelHeight: Int(targetWindow.frame.height * scale),
+                shouldBeOpaque: false
+            )
             let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: targetWindow.frame.width, height: targetWindow.frame.height))
 
             postCapture(nsImage, appState: appState)
@@ -154,10 +206,10 @@ final class CaptureEngine {
             let content = try await SCShareableContent.current
             guard let display = content.displays.first else { return }
 
-            let ownPID = ProcessInfo.processInfo.processIdentifier
-            let excludedWindows = content.windows.filter { $0.owningApplication?.processID == ownPID }
-
-            let filter = SCContentFilter(display: display, excludingWindows: excludedWindows)
+            let filter = SCContentFilter(
+                display: display,
+                excludingWindows: excludedWindows(in: content, preferences: appState?.preferences)
+            )
 
             let displayHeight = CGFloat(display.height)
             let scRect = CGRect(
@@ -168,13 +220,12 @@ final class CaptureEngine {
             )
 
             let scale = NSScreen.main?.backingScaleFactor ?? 2.0
-            let config = SCStreamConfiguration()
-            config.sourceRect = scRect
-            config.width = Int(rect.width * scale)
-            config.height = Int(rect.height * scale)
-            config.showsCursor = false
-
-            let cgImage = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
+            let cgImage = try await captureCGImage(
+                filter: filter,
+                sourceRect: scRect,
+                pixelWidth: Int(rect.width * scale),
+                pixelHeight: Int(rect.height * scale)
+            )
 
             // Run OCR
             let recognizedText = try await OCREngine.recognizeText(in: cgImage)

--- a/Sources/ExcludedAppsManager.swift
+++ b/Sources/ExcludedAppsManager.swift
@@ -1,0 +1,61 @@
+// ExcludedAppsManager.swift
+// MikaScreenSnap
+//
+// Lists the capturable running applications so the user can exclude them from screenshots.
+// Swift 6.0 strict concurrency, macOS 14+
+
+import AppKit
+@preconcurrency import ScreenCaptureKit
+
+@Observable
+@MainActor
+final class ExcludedAppsManager {
+    struct CapturableApp: Identifiable, Hashable {
+        let bundleIdentifier: String
+        let name: String
+
+        var id: String { bundleIdentifier }
+    }
+
+    private(set) var apps: [CapturableApp] = []
+    private(set) var isLoading = false
+
+    /// Reloads the list of shareable applications.
+    ///
+    /// Already excluded bundle identifiers are merged in even when the app is not running,
+    /// so an existing selection never silently disappears from the UI.
+    func refresh(selected: Set<String>) async {
+        isLoading = true
+        defer { isLoading = false }
+
+        var byBundleID: [String: CapturableApp] = [:]
+
+        if let content = try? await SCShareableContent.current {
+            let ownPID = ProcessInfo.processInfo.processIdentifier
+            for app in content.applications where app.processID != ownPID {
+                let bundleID = app.bundleIdentifier
+                let name = app.applicationName
+                guard !bundleID.isEmpty, !name.isEmpty else { continue }
+                byBundleID[bundleID] = CapturableApp(bundleIdentifier: bundleID, name: name)
+            }
+        }
+
+        for bundleID in selected where byBundleID[bundleID] == nil {
+            byBundleID[bundleID] = CapturableApp(
+                bundleIdentifier: bundleID,
+                name: ExcludedAppsManager.displayName(for: bundleID)
+            )
+        }
+
+        apps = byBundleID.values.sorted {
+            $0.name.localizedStandardCompare($1.name) == .orderedAscending
+        }
+    }
+
+    /// Best-effort name for an app that is currently not running.
+    private static func displayName(for bundleIdentifier: String) -> String {
+        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)
+        else { return bundleIdentifier }
+        return FileManager.default.displayName(atPath: url.path)
+    }
+}

--- a/Sources/Preferences/GeneralTabView.swift
+++ b/Sources/Preferences/GeneralTabView.swift
@@ -135,6 +135,9 @@ struct GeneralTabView: View {
                     }
                 }
             }
+
+            // Privacy
+            ExcludedAppsSection(preferences: preferences)
         }
     }
 
@@ -156,5 +159,121 @@ struct GeneralTabView: View {
         if panel.runModal() == .OK, let url = panel.url {
             preferences.saveLocation = url
         }
+    }
+}
+
+// MARK: - Excluded Apps
+
+/// Lets the user pick applications whose windows are never captured — the on-screen
+/// keyboard and similar overlays that would otherwise be baked into every screenshot.
+struct ExcludedAppsSection: View {
+    let preferences: AppPreferences
+
+    @State private var manager = ExcludedAppsManager()
+    @State private var showPicker = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Privacy")
+                .font(.headline)
+                .padding(.bottom, 6)
+
+            GroupBox {
+                VStack(spacing: 0) {
+                    HStack {
+                        Label("Exclude apps from capture", systemImage: "eye.slash")
+                        Spacer()
+                        Text(excludedSummary)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                        Button("Choose...") {
+                            showPicker = true
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                }
+            }
+        }
+        .sheet(isPresented: $showPicker) {
+            ExcludedAppsPicker(preferences: preferences, manager: manager)
+        }
+    }
+
+    private var excludedSummary: String {
+        let count = preferences.excludedBundleIdentifiers.count
+        switch count {
+        case 0:  return "None"
+        case 1:  return "1 app"
+        default: return "\(count) apps"
+        }
+    }
+}
+
+private struct ExcludedAppsPicker: View {
+    let preferences: AppPreferences
+    let manager: ExcludedAppsManager
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Exclude Apps from Capture")
+                .font(.headline)
+
+            Text("Windows of the selected apps are left out of every screenshot.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            if manager.isLoading && manager.apps.isEmpty {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if manager.apps.isEmpty {
+                Text("No capturable apps found. Grant Screen Recording permission and try again.")
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List(manager.apps) { app in
+                    Toggle(isOn: binding(for: app.bundleIdentifier)) {
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(app.name)
+                            Text(app.bundleIdentifier)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .listStyle(.inset)
+                .alternatingRowBackgrounds()
+            }
+
+            HStack {
+                Button("Refresh") {
+                    Task { await manager.refresh(selected: preferences.excludedBundleIdentifiers) }
+                }
+                Spacer()
+                Button("Done") { dismiss() }
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(width: 420, height: 400)
+        .task {
+            await manager.refresh(selected: preferences.excludedBundleIdentifiers)
+        }
+    }
+
+    private func binding(for bundleIdentifier: String) -> Binding<Bool> {
+        Binding(
+            get: { preferences.excludedBundleIdentifiers.contains(bundleIdentifier) },
+            set: { isExcluded in
+                if isExcluded {
+                    preferences.excludedBundleIdentifiers.insert(bundleIdentifier)
+                } else {
+                    preferences.excludedBundleIdentifiers.remove(bundleIdentifier)
+                }
+            }
+        )
     }
 }


### PR DESCRIPTION
## Problem

The on-screen keyboard and the mouse pointer ended up in every screenshot. These turned out to be two unrelated causes:

**1. Foreign overlay windows were never filtered.** `CaptureEngine` excluded only our own windows (`processID == ownPID`), so the Accessibility Keyboard (`com.apple.inputmethod.AssistiveControl`) was captured like any other window.

**2. The pointer was not a cursor at all.** Once an accessibility pointer is enabled (coloured, enlarged, or driven by Dwell Control), WindowServer draws it as an ordinary window — title `"Cursor"`, empty bundle identifier, window layer `2147483630` — rather than as a hardware cursor. `SCStreamConfiguration.showsCursor` only suppresses the hardware cursor, so the overlay stayed in the image.

Cause 2 was measured, not assumed: capturing the same crop with `showsCursor` toggled on both the existing API and the macOS 26 `SCScreenshotConfiguration` showed **both honour the flag correctly**. The visible pointer came from the separate overlay window, which no cursor flag can reach.

## Changes

- **`AppPreferences`** — `excludedBundleIdentifiers`, pre-seeded with the accessibility overlays (Assistive Control, Dwell Control, AccessibilityVisualsAgent). An explicitly emptied list stays empty; only a missing key falls back to the defaults.
- **`ExcludedAppsManager`** (new) — lists capturable running apps via `SCShareableContent`; already-selected identifiers stay listed even when the app is not running, so a selection never silently disappears.
- **`GeneralTabView`** — new *Privacy* section with an app picker sheet.
- **`CaptureEngine`** — `excludedWindows(in:preferences:)` and `captureCGImage(...)` replace the filter and `SCStreamConfiguration` setup that were duplicated across all four capture paths. `isPointerOverlay(_:)` drops the WindowServer pointer window unconditionally. `captureWindow` also skips excluded apps when picking its target window.

No change to `Package.swift`; the deployment target stays macOS 14.

## Verification

Captured the same 120 pt crop before and after the filter, with the accessibility pointer parked inside it:

| | Result |
|---|---|
| Before | On-screen keyboard visible, green ring pointer visible |
| After | Both gone |

Also confirmed via the shipped filter logic that all seven overlay windows are matched, including the bundle-less `"Cursor"` window.

**Not yet covered:** the four capture paths have not been exercised through the app's own hotkeys (the test terminal lacks Accessibility permission). Worth a manual pass on the **area screenshot** in particular, to confirm the crop still lands exactly on the selection after the `captureCGImage` refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)