### PR TITLE
Fix window capture and add an interactive window picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [3.4.1] - 2026-08-09
+
+### Fixed
+- **Window capture produced an empty image** — the window search sorted ascending by `windowLayer` and took the first result, but a higher `CGWindowLevel` means further front, so it picked the backmost window. Combined with `SCShareableContent.current` including the desktop layer, this selected WindowServer's backstop window, which captures as a fully transparent image. Window selection now uses `excludingDesktopWindows(_:onScreenWindowsOnly:)`, keeps only layers `0..<20`, and preserves the front-to-back order ScreenCaptureKit already provides
+- **Wrong resolution on secondary displays** — window captures sized themselves from `NSScreen.main.backingScaleFactor`; they now use `SCContentFilter.contentRect` and `.pointPixelScale`, so a window is captured at the scale of the display it is actually on
+- **Untitled windows were not capturable** — the candidate filter required a non-empty window title, which excluded legitimate windows from Electron, games and some Java apps
+- **Color picker and loupe** — replaced the deprecated `CGWindowListCreateImage` with ScreenCaptureKit. The screen is snapshotted once per display when the picker starts, so sampling stays synchronous while the loupe redraws on every mouse move
+- **Color picker on multi-display setups** — cursor coordinates were flipped against `NSScreen.main`, which follows the key window; they now use the display that owns the AppKit origin
+- **Capture failures were invisible** — every error path ended in `print()`, which goes nowhere in an `LSUIElement` bundle launched from Finder
+- **Accessibility pointer overlay slipped through** — the detection required an owning application with an empty bundle id, but WindowServer may report no owning application at all
+
+### Added
+- **Interactive window picker** — "Capture Window…" in the menubar opens an overlay that outlines the window under the pointer with its app icon, name and pixel size; click captures it, ESC or right-click cancels. Works across displays and on windows straddling two screens
+- **Capture Frontmost Window** — the previous one-shot behaviour, still on ⌃⇧⌘5 and now also a menubar entry
+- **Status toasts** — capture failures surface to the user, with a plain-language message when the screen recording permission is missing
+- **Unified logging** — failures are logged under the `com.mika.mikaplusscreensnap` subsystem and readable in Console.app
+
 ## [3.4.0] - 2026-03-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A lightweight macOS menubar screenshot tool with a professional annotation edito
 - **Capture Modes**
   - Full Screen (`Ctrl+Shift+Cmd+3`)
   - Area Selection (`Ctrl+Shift+Cmd+4`)
-  - Window (`Ctrl+Shift+Cmd+5`)
+  - Window — pick one by pointing at it, or grab the frontmost with `Ctrl+Shift+Cmd+5`
 - **Annotation Editor** — opens automatically after each capture
   - **Drawing Tools:** Arrow, Rectangle, Ellipse, Line, Freehand
   - **Text Tool:** Click to place editable text with background pill
@@ -64,7 +64,7 @@ A lightweight macOS menubar screenshot tool with a professional annotation edito
 |----------|--------|
 | `Ctrl+Shift+Cmd+3` | Capture Full Screen |
 | `Ctrl+Shift+Cmd+4` | Capture Area |
-| `Ctrl+Shift+Cmd+5` | Capture Window |
+| `Ctrl+Shift+Cmd+5` | Capture Frontmost Window |
 | `Shift+Cmd+6` | Capture Text (OCR) |
 | `Shift+Cmd+7` | Color Picker |
 | `Shift+Cmd+8` | Measure |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mika+ScreenSnap v3.4.0
+# Mika+ScreenSnap v3.4.1
 
 A lightweight macOS menubar screenshot tool with a professional annotation editor and power features. Capture your screen, annotate it with 11 tools, extract text via OCR, pick colors, measure pixels, pin screenshots, and manage your history — all without leaving your workflow.
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -11,9 +11,9 @@
     <key>CFBundleExecutable</key>
     <string>MikaScreenSnap</string>
     <key>CFBundleVersion</key>
-    <string>3.4.0</string>
+    <string>3.4.1</string>
     <key>CFBundleShortVersionString</key>
-    <string>3.4.0</string>
+    <string>3.4.1</string>
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundlePackageType</key>

--- a/Sources/CaptureEngine.swift
+++ b/Sources/CaptureEngine.swift
@@ -4,6 +4,7 @@ import AppKit
 @MainActor
 final class CaptureEngine {
     private var areaSelectionPanels: [AreaSelectionPanel] = []
+    private var windowSelectionController: WindowSelectionController?
     private var colorLoupeController: ColorLoupeController?
     private var measurementController: MeasurementOverlayController?
 
@@ -28,11 +29,65 @@ final class CaptureEngine {
     /// `SCStreamConfiguration.showsCursor` only suppresses the hardware cursor, so this
     /// overlay would otherwise be baked into every screenshot.
     private static func isPointerOverlay(_ window: SCWindow) -> Bool {
+        // The overlay is owned by WindowServer, which SCK may report as a nil
+        // application — treat that like the empty bundle id it otherwise carries.
         guard window.title == "Cursor",
-              window.owningApplication?.bundleIdentifier.isEmpty ?? false,
+              window.owningApplication?.bundleIdentifier.isEmpty ?? true,
               window.windowLayer > 100
         else { return false }
         return true
+    }
+
+    /// Window layers that hold real app windows: from `kCGNormalWindowLevel` (0) up to
+    /// just below `kCGDockWindowLevel` (20). Excludes desktop, wallpaper and backstop
+    /// windows (large negative layers) as well as the Dock, menubar (24), status items
+    /// (25) and open menus (101).
+    private static let selectableWindowLayers: Range<Int> = 0..<20
+
+    /// System UI that owns normal-layer windows but is never a useful capture target.
+    private static let nonTargetBundleIdentifiers: Set<String> = [
+        "com.apple.dock",                   // Dock, Mission Control, App Exposé
+        "com.apple.WindowManager",          // Stage Manager
+        "com.apple.wallpaper.agent",        // Wallpaper (macOS 14+)
+        "com.apple.notificationcenterui",
+        "com.apple.controlcenter",
+    ]
+
+    /// Every window that can serve as a capture target, ordered front to back.
+    ///
+    /// `SCShareableContent.windows` already arrives front to back, so the order is
+    /// preserved by sorting on the original index as a tiebreaker — `Array.sorted` is
+    /// not stable and all ordinary app windows share layer 0.
+    private func selectableWindows(in content: SCShareableContent, preferences: AppPreferences?) -> [SCWindow] {
+        let excludedIDs = Set(excludedWindows(in: content, preferences: preferences).map(\.windowID))
+        let minimumSide: CGFloat = 40
+
+        return content.windows.enumerated()
+            .filter { _, window in
+                guard !excludedIDs.contains(window.windowID),
+                      window.isOnScreen,
+                      CaptureEngine.selectableWindowLayers.contains(window.windowLayer),
+                      window.frame.width >= minimumSide,
+                      window.frame.height >= minimumSide,
+                      let app = window.owningApplication,
+                      !app.bundleIdentifier.isEmpty,
+                      !CaptureEngine.nonTargetBundleIdentifiers.contains(app.bundleIdentifier)
+                else { return false }
+                return true
+            }
+            .sorted { lhs, rhs in
+                if lhs.element.windowLayer != rhs.element.windowLayer {
+                    return lhs.element.windowLayer > rhs.element.windowLayer  // higher layer is further front
+                }
+                return lhs.offset < rhs.offset
+            }
+            .map(\.element)
+    }
+
+    /// Shareable content without the desktop and wallpaper layer, which are never
+    /// meaningful capture targets and used to win the window search.
+    private func shareableWindowContent() async throws -> SCShareableContent {
+        try await SCShareableContent.excludingDesktopWindows(true, onScreenWindowsOnly: true)
     }
 
     /// Captures a still image with the hardware cursor suppressed.
@@ -64,7 +119,7 @@ final class CaptureEngine {
         do {
             let content = try await SCShareableContent.current
             guard let display = content.displays.first else {
-                print("No display found")
+                CaptureLog.report("No display found", message: "No display available")
                 return
             }
 
@@ -83,7 +138,7 @@ final class CaptureEngine {
 
             postCapture(nsImage, appState: appState)
         } catch {
-            print("Full screen capture failed: \(error)")
+            CaptureLog.report(error, action: "Full screen capture")
         }
     }
 
@@ -117,43 +172,113 @@ final class CaptureEngine {
 
             postCapture(nsImage, appState: appState)
         } catch {
-            print("Area capture failed: \(error)")
+            CaptureLog.report(error, action: "Area capture")
         }
     }
 
+    /// Captures the frontmost window of the active app without any interaction.
     func captureWindow(appState: AppState?) async {
         do {
-            let content = try await SCShareableContent.current
+            let content = try await shareableWindowContent()
+            let candidates = selectableWindows(in: content, preferences: appState?.preferences)
 
-            // Find the frontmost window that is neither ours nor an excluded app's
-            let skipped = Set(excludedWindows(in: content, preferences: appState?.preferences).map(\.windowID))
-            let windows = content.windows.filter {
-                !skipped.contains($0.windowID) &&
-                $0.isOnScreen &&
-                $0.frame.width > 0 && $0.frame.height > 0 &&
-                $0.title?.isEmpty == false
-            }.sorted { $0.windowLayer < $1.windowLayer }
+            // Our own app never activates (.accessory), so the previously active app is
+            // still frontmost when the hotkey fires. Falling back to the front of the
+            // list covers the menubar path, where our own windows are filtered out anyway.
+            let frontPID = NSWorkspace.shared.frontmostApplication?.processIdentifier
+            let targetWindow = candidates.first { $0.owningApplication?.processID == frontPID }
+                ?? candidates.first
 
-            guard let targetWindow = windows.first else {
-                print("No window found")
+            guard let targetWindow else {
+                CaptureLog.report("No capturable window found", message: "No window to capture")
                 return
             }
 
-            let filter = SCContentFilter(desktopIndependentWindow: targetWindow)
-            let scale = NSScreen.main?.backingScaleFactor ?? 2.0
+            await captureWindow(targetWindow, appState: appState)
+        } catch {
+            CaptureLog.report(error, action: "Window capture")
+        }
+    }
+
+    /// Captures a single window.
+    ///
+    /// Size and scale come from the content filter rather than `NSScreen.main`, so a
+    /// window on a display with a different backing scale is captured at its own
+    /// resolution.
+    private func captureWindow(_ window: SCWindow, appState: AppState?) async {
+        let filter = SCContentFilter(desktopIndependentWindow: window)
+        let contentRect = filter.contentRect
+        let scale = CGFloat(filter.pointPixelScale)
+        let pixelWidth = Int((contentRect.width * scale).rounded())
+        let pixelHeight = Int((contentRect.height * scale).rounded())
+
+        guard pixelWidth > 0, pixelHeight > 0 else {
+            CaptureLog.report(
+                "Window \(window.windowID) has an empty content rect",
+                message: "Window has no capturable content"
+            )
+            return
+        }
+
+        do {
             let cgImage = try await captureCGImage(
                 filter: filter,
                 sourceRect: .null,
-                pixelWidth: Int(targetWindow.frame.width * scale),
-                pixelHeight: Int(targetWindow.frame.height * scale),
+                pixelWidth: pixelWidth,
+                pixelHeight: pixelHeight,
                 shouldBeOpaque: false
             )
-            let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: targetWindow.frame.width, height: targetWindow.frame.height))
+            let nsImage = NSImage(cgImage: cgImage, size: contentRect.size)
 
             postCapture(nsImage, appState: appState)
         } catch {
-            print("Window capture failed: \(error)")
+            CaptureLog.report(error, action: "Window capture")
         }
+    }
+
+    // MARK: - Window Selection
+
+    /// Shows the interactive window picker: hover to highlight, click to capture.
+    func startWindowSelection(appState: AppState?) {
+        dismissWindowSelection()
+
+        Task { @MainActor in
+            do {
+                let content = try await shareableWindowContent()
+                let windows = selectableWindows(in: content, preferences: appState?.preferences)
+                let targets = windows.compactMap { WindowTarget(scWindow: $0) }
+
+                guard !targets.isEmpty else {
+                    CaptureLog.report("No capturable window found", message: "No window to capture")
+                    return
+                }
+
+                let controller = WindowSelectionController()
+                self.windowSelectionController = controller
+                controller.start(
+                    targets: targets,
+                    onSelect: { [weak self] window in
+                        guard let self else { return }
+                        self.dismissWindowSelection()
+                        // Let the panels disappear before the editor opens.
+                        Task { @MainActor in
+                            try? await Task.sleep(for: .milliseconds(100))
+                            await self.captureWindow(window, appState: appState)
+                        }
+                    },
+                    onCancel: { [weak self] in
+                        self?.dismissWindowSelection()
+                    }
+                )
+            } catch {
+                CaptureLog.report(error, action: "Window picker")
+            }
+        }
+    }
+
+    func dismissWindowSelection() {
+        windowSelectionController?.dismiss()
+        windowSelectionController = nil
     }
 
     func startAreaSelection(appState: AppState?) {
@@ -246,7 +371,7 @@ final class CaptureEngine {
                 }
             }
         } catch {
-            print("Text capture failed: \(error)")
+            CaptureLog.report(error, action: "Text capture")
         }
     }
 
@@ -255,11 +380,26 @@ final class CaptureEngine {
     func startColorPicker(appState: AppState?) {
         guard let appState else { return }
 
-        let controller = ColorLoupeController()
-        self.colorLoupeController = controller
+        Task { @MainActor in
+            do {
+                // Snapshot the screen before any overlay exists, so nothing of ours
+                // can end up under the loupe.
+                let content = try await SCShareableContent.current
+                let engine = ColorPickerEngine()
+                try await engine.loadSnapshots(
+                    excludedWindows: excludedWindows(in: content, preferences: appState.preferences),
+                    content: content
+                )
 
-        controller.start(appState: appState) { [weak self] _ in
-            self?.colorLoupeController = nil
+                let controller = ColorLoupeController()
+                self.colorLoupeController = controller
+
+                controller.start(appState: appState, engine: engine) { [weak self] _ in
+                    self?.colorLoupeController = nil
+                }
+            } catch {
+                CaptureLog.report(error, action: "Colour picker")
+            }
         }
     }
 

--- a/Sources/CaptureLog.swift
+++ b/Sources/CaptureLog.swift
@@ -1,0 +1,50 @@
+// CaptureLog.swift
+// MikaScreenSnap
+//
+// Unified logging and user-facing reporting for capture failures.
+// Swift 6.0 strict concurrency, macOS 14+
+
+import Foundation
+import OSLog
+@preconcurrency import ScreenCaptureKit
+
+/// Capture failures used to end in `print()`, which goes nowhere in an LSUIElement
+/// bundle launched from Finder. Everything routes through here instead, so the same
+/// failure is both greppable in Console.app and visible to the user.
+enum CaptureLog {
+    private static let subsystem = Bundle.main.bundleIdentifier ?? "com.mika.mikaplusscreensnap"
+
+    static let engine = Logger(subsystem: subsystem, category: "capture")
+    static let hotkey = Logger(subsystem: subsystem, category: "hotkey")
+
+    /// Logs a failure and shows the user a short, plain-language toast.
+    /// - Parameter action: What was attempted, capitalised — e.g. "Window capture".
+    @MainActor
+    static func report(_ error: Error, action: String) {
+        engine.error("\(action) failed: \(error.localizedDescription, privacy: .public)")
+        StatusToast.show(message(for: error, action: action))
+    }
+
+    /// Logs a failure that has no underlying `Error` and shows the given message.
+    @MainActor
+    static func report(_ reason: String, message: String) {
+        engine.error("\(reason, privacy: .public)")
+        StatusToast.show(message)
+    }
+
+    private static func message(for error: Error, action: String) -> String {
+        let nsError = error as NSError
+        guard nsError.domain == SCStreamErrorDomain else { return "\(action) failed" }
+
+        // Raw values from SCError.h — spelled out so a missing Swift overlay
+        // enum on a future SDK cannot break the build.
+        switch nsError.code {
+        case -3801:             // userDeclined
+            return "Screen Recording permission required"
+        case -3813, -3814, -3815: // noWindowList, noDisplayList, noCaptureSource
+            return "Nothing available to capture"
+        default:
+            return "\(action) failed (\(nsError.code))"
+        }
+    }
+}

--- a/Sources/ColorLoupePanel.swift
+++ b/Sources/ColorLoupePanel.swift
@@ -16,9 +16,12 @@ final class ColorLoupeController {
     private var keyMonitor: Any?
     private weak var appState: AppState?
     private var onComplete: ((PickedColor) -> Void)?
+    /// Pre-loaded screen snapshot; sampling must stay synchronous for the loupe.
+    private var engine: ColorPickerEngine?
 
-    func start(appState: AppState, onComplete: @escaping (PickedColor) -> Void) {
+    func start(appState: AppState, engine: ColorPickerEngine, onComplete: @escaping (PickedColor) -> Void) {
         self.appState = appState
+        self.engine = engine
         self.onComplete = onComplete
 
         // Create fullscreen overlay panels for each screen
@@ -87,23 +90,18 @@ final class ColorLoupeController {
     }
 
     private func updateLoupe() {
-        guard let loupePanel, let loupeView else { return }
+        guard let loupePanel, let loupeView, let engine else { return }
 
         let mouseLocation = NSEvent.mouseLocation
-        // Convert to screen coordinates (CGDisplay uses top-left origin)
-        guard let screen = NSScreen.main else { return }
-        let screenHeight = screen.frame.height
-        let cgPoint = CGPoint(x: mouseLocation.x, y: screenHeight - mouseLocation.y)
-
-        let loupeWindowIDs = [loupePanel].compactMap { CGWindowID($0.windowNumber) }
+        let cgPoint = NSScreen.coreGraphicsPoint(fromAppKit: mouseLocation)
 
         // Sample color at cursor
-        if let pickedColor = ColorPickerEngine.sampleColor(at: cgPoint, excluding: loupeWindowIDs) {
+        if let pickedColor = engine.sampleColor(at: cgPoint) {
             loupeView.currentColor = pickedColor
         }
 
         // Capture loupe region
-        if let loupeImage = ColorPickerEngine.captureLoupeRegion(at: cgPoint, radius: 10, excluding: loupeWindowIDs) {
+        if let loupeImage = engine.captureLoupeRegion(at: cgPoint, radius: 10) {
             loupeView.loupeImage = loupeImage
         }
 
@@ -119,14 +117,9 @@ final class ColorLoupeController {
     }
 
     private func handleClick(event: NSEvent) {
-        let mouseLocation = NSEvent.mouseLocation
-        guard let screen = NSScreen.main else { return }
-        let screenHeight = screen.frame.height
-        let cgPoint = CGPoint(x: mouseLocation.x, y: screenHeight - mouseLocation.y)
+        let cgPoint = NSScreen.coreGraphicsPoint(fromAppKit: NSEvent.mouseLocation)
 
-        let loupeWindowIDs = loupePanel.map { [CGWindowID($0.windowNumber)] } ?? []
-
-        guard let pickedColor = ColorPickerEngine.sampleColor(at: cgPoint, excluding: loupeWindowIDs) else {
+        guard let engine, let pickedColor = engine.sampleColor(at: cgPoint) else {
             cancel()
             return
         }
@@ -179,6 +172,7 @@ final class ColorLoupeController {
         loupePanel?.orderOut(nil)
         loupePanel = nil
         loupeView = nil
+        engine = nil
     }
 }
 

--- a/Sources/ColorPickerEngine.swift
+++ b/Sources/ColorPickerEngine.swift
@@ -5,6 +5,7 @@
 // Swift 6.0 strict concurrency, macOS 14+
 
 import AppKit
+@preconcurrency import ScreenCaptureKit
 
 struct PickedColor: Sendable {
     let nsColor: NSColor
@@ -52,53 +53,108 @@ struct PickedColor: Sendable {
     }
 }
 
+/// Samples screen pixels for the colour picker.
+///
+/// `CGWindowListCreateImage` is deprecated and no longer a viable path, but its
+/// ScreenCaptureKit replacement is async — and the loupe redraws on every mouse move,
+/// where awaiting a round trip per sample would stutter. So the screen is snapshotted
+/// once when the picker starts and every sample reads from that buffer synchronously.
+///
+/// Consequence: live content (video, animation) under the cursor does not update while
+/// the picker is open.
 @MainActor
-enum ColorPickerEngine {
-    /// Sample the pixel color at the given screen-space point.
-    /// Uses CGWindowListCreateImage to capture a 1x1 pixel at the cursor location,
-    /// excluding the specified window IDs (e.g., the loupe panel).
-    static func sampleColor(at screenPoint: CGPoint, excluding windowIDs: [CGWindowID] = []) -> PickedColor? {
-        // Capture a 1x1 area at the cursor position
-        let captureRect = CGRect(x: screenPoint.x, y: screenPoint.y, width: 1, height: 1)
-
-        guard let cgImage = CGWindowListCreateImage(
-            captureRect,
-            .optionOnScreenBelowWindow,
-            windowIDs.first ?? kCGNullWindowID,
-            [.bestResolution]
-        ) else { return nil }
-
-        // Extract pixel color
-        guard let dataProvider = cgImage.dataProvider,
-              let data = dataProvider.data,
-              let ptr = CFDataGetBytePtr(data) else { return nil }
-
-        let bytesPerPixel = cgImage.bitsPerPixel / 8
-        guard bytesPerPixel >= 3 else { return nil }
-
-        let r = CGFloat(ptr[0]) / 255.0
-        let g = CGFloat(ptr[1]) / 255.0
-        let b = CGFloat(ptr[2]) / 255.0
-
-        let color = NSColor(srgbRed: r, green: g, blue: b, alpha: 1.0)
-        return PickedColor(nsColor: color)
+final class ColorPickerEngine {
+    private struct DisplaySnapshot {
+        /// Display bounds in global CoreGraphics points, top-left origin.
+        let frame: CGRect
+        let image: CGImage
+        let bytesPerPixel: Int
+        let bytesPerRow: Int
+        let data: CFData
+        /// Pixels per point.
+        let scale: CGFloat
     }
 
-    /// Capture a magnified region around the given screen point for the loupe display.
-    static func captureLoupeRegion(at screenPoint: CGPoint, radius: Int, excluding windowIDs: [CGWindowID] = []) -> CGImage? {
-        let size = radius * 2
-        let captureRect = CGRect(
-            x: screenPoint.x - CGFloat(radius),
-            y: screenPoint.y - CGFloat(radius),
-            width: CGFloat(size),
-            height: CGFloat(size)
-        )
+    private var snapshots: [DisplaySnapshot] = []
 
-        return CGWindowListCreateImage(
-            captureRect,
-            .optionOnScreenBelowWindow,
-            windowIDs.first ?? kCGNullWindowID,
-            [.bestResolution]
-        )
+    /// Captures every display once, excluding our own overlays and the user's blocked apps.
+    func loadSnapshots(excludedWindows: [SCWindow], content: SCShareableContent) async throws {
+        var loaded: [DisplaySnapshot] = []
+
+        for display in content.displays {
+            let filter = SCContentFilter(display: display, excludingWindows: excludedWindows)
+            let scale = CGFloat(filter.pointPixelScale)
+
+            let config = SCStreamConfiguration()
+            config.width = Int((CGFloat(display.width) * scale).rounded())
+            config.height = Int((CGFloat(display.height) * scale).rounded())
+            config.showsCursor = false
+            config.shouldBeOpaque = true
+
+            let image = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
+
+            guard let provider = image.dataProvider, let data = provider.data else { continue }
+
+            loaded.append(DisplaySnapshot(
+                frame: display.frame,
+                image: image,
+                bytesPerPixel: image.bitsPerPixel / 8,
+                bytesPerRow: image.bytesPerRow,
+                data: data,
+                scale: scale
+            ))
+        }
+
+        snapshots = loaded
+    }
+
+    /// Sample the pixel colour at the given point in global CoreGraphics space.
+    func sampleColor(at screenPoint: CGPoint) -> PickedColor? {
+        guard let snapshot = snapshot(containing: screenPoint),
+              let pixel = pixelCoordinate(of: screenPoint, in: snapshot),
+              snapshot.bytesPerPixel >= 3,
+              let ptr = CFDataGetBytePtr(snapshot.data)
+        else { return nil }
+
+        let offset = pixel.y * snapshot.bytesPerRow + pixel.x * snapshot.bytesPerPixel
+        guard offset + 2 < CFDataGetLength(snapshot.data) else { return nil }
+
+        // SCScreenshotManager hands back BGRA.
+        let b = CGFloat(ptr[offset]) / 255.0
+        let g = CGFloat(ptr[offset + 1]) / 255.0
+        let r = CGFloat(ptr[offset + 2]) / 255.0
+
+        return PickedColor(nsColor: NSColor(srgbRed: r, green: g, blue: b, alpha: 1.0))
+    }
+
+    /// Crop a magnified region around the given point for the loupe display.
+    func captureLoupeRegion(at screenPoint: CGPoint, radius: Int) -> CGImage? {
+        guard let snapshot = snapshot(containing: screenPoint),
+              let center = pixelCoordinate(of: screenPoint, in: snapshot)
+        else { return nil }
+
+        let pixelRadius = Int((CGFloat(radius) * snapshot.scale).rounded())
+        let cropRect = CGRect(
+            x: center.x - pixelRadius,
+            y: center.y - pixelRadius,
+            width: pixelRadius * 2,
+            height: pixelRadius * 2
+        ).intersection(CGRect(x: 0, y: 0, width: snapshot.image.width, height: snapshot.image.height))
+
+        guard cropRect.width >= 1, cropRect.height >= 1 else { return nil }
+        return snapshot.image.cropping(to: cropRect)
+    }
+
+    private func snapshot(containing point: CGPoint) -> DisplaySnapshot? {
+        snapshots.first { $0.frame.contains(point) } ?? snapshots.first
+    }
+
+    /// Global CoreGraphics point to pixel coordinates inside the snapshot. Both use a
+    /// top-left origin, so this is an offset plus the display's scale.
+    private func pixelCoordinate(of point: CGPoint, in snapshot: DisplaySnapshot) -> (x: Int, y: Int)? {
+        let x = Int(((point.x - snapshot.frame.origin.x) * snapshot.scale).rounded(.down))
+        let y = Int(((point.y - snapshot.frame.origin.y) * snapshot.scale).rounded(.down))
+        guard x >= 0, y >= 0, x < snapshot.image.width, y < snapshot.image.height else { return nil }
+        return (x, y)
     }
 }

--- a/Sources/HotkeyManager.swift
+++ b/Sources/HotkeyManager.swift
@@ -242,7 +242,7 @@ final class HotkeyManager {
             if status == noErr {
                 hotKeyRefs.append(ref)
             } else {
-                print("Failed to register hotkey \(action.rawValue): \(status)")
+                CaptureLog.hotkey.error("Failed to register hotkey \(action.rawValue, privacy: .public): \(status)")
             }
         }
     }

--- a/Sources/MikaScreenSnapApp.swift
+++ b/Sources/MikaScreenSnapApp.swift
@@ -174,7 +174,10 @@ struct MikaScreenSnapApp: App {
                     await appDelegate.appState.captureEngine.captureFullScreen(appState: appDelegate.appState)
                 }
             }
-            Button("Capture Window  \u{2303}\u{21E7}\u{2318}5") {
+            Button("Capture Window\u{2026}") {
+                appDelegate.appState.captureEngine.startWindowSelection(appState: appDelegate.appState)
+            }
+            Button("Capture Frontmost Window  \u{2303}\u{21E7}\u{2318}5") {
                 Task {
                     await appDelegate.appState.captureEngine.captureWindow(appState: appDelegate.appState)
                 }

--- a/Sources/ScreenGeometry.swift
+++ b/Sources/ScreenGeometry.swift
@@ -1,0 +1,34 @@
+// ScreenGeometry.swift
+// MikaScreenSnap
+//
+// Conversions between AppKit and CoreGraphics screen coordinates.
+// Swift 6.0 strict concurrency, macOS 14+
+
+import AppKit
+
+@MainActor
+extension NSScreen {
+    /// Height of the display that owns the AppKit origin.
+    ///
+    /// Not `NSScreen.main` — that follows the key window and moves between displays,
+    /// which silently breaks the y-flip on a multi-display setup.
+    static var primaryHeight: CGFloat {
+        let primary = NSScreen.screens.first { $0.frame.origin == .zero } ?? NSScreen.screens.first
+        return primary?.frame.height ?? 0
+    }
+
+    /// AppKit global point (bottom-left origin) to global CoreGraphics space (top-left origin).
+    static func coreGraphicsPoint(fromAppKit point: NSPoint) -> CGPoint {
+        CGPoint(x: point.x, y: primaryHeight - point.y)
+    }
+
+    /// Global CoreGraphics rect (top-left origin) to AppKit global coordinates.
+    static func appKitRect(fromCoreGraphics rect: CGRect) -> NSRect {
+        NSRect(
+            x: rect.origin.x,
+            y: primaryHeight - rect.origin.y - rect.height,
+            width: rect.width,
+            height: rect.height
+        )
+    }
+}

--- a/Sources/StatusToast.swift
+++ b/Sources/StatusToast.swift
@@ -1,0 +1,139 @@
+// StatusToast.swift
+// MikaScreenSnap
+//
+// Short-lived, non-blocking status message with auto-dismiss.
+// Swift 6.0 strict concurrency, macOS 14+
+
+import AppKit
+
+@MainActor
+enum StatusToast {
+    private static var currentPanel: NSPanel?
+
+    /// Shows a brief message near the top of the screen the pointer is on.
+    ///
+    /// Unlike `ColorPickerToast` this does not follow the cursor — most capture
+    /// failures are triggered by a hotkey, where a message under the pointer is
+    /// easy to miss.
+    static func show(_ message: String, symbol: String = "exclamationmark.triangle.fill", duration: TimeInterval = 2.5) {
+        currentPanel?.orderOut(nil)
+        currentPanel = nil
+
+        let view = StatusToastView(message: message, symbol: symbol)
+        let size = view.intrinsicContentSize
+        let frame = NSRect(origin: .zero, size: size)
+
+        let panel = NSPanel(
+            contentRect: frame,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.level = .statusBar
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.ignoresMouseEvents = true
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+        view.frame = frame
+        panel.contentView = view
+
+        let screen = NSScreen.screens.first { $0.frame.contains(NSEvent.mouseLocation) }
+            ?? NSScreen.main
+            ?? NSScreen.screens.first
+        if let visible = screen?.visibleFrame {
+            panel.setFrameOrigin(NSPoint(
+                x: visible.midX - size.width / 2,
+                y: visible.maxY - size.height - 24
+            ))
+        }
+
+        panel.alphaValue = 0
+        panel.orderFrontRegardless()
+        currentPanel = panel
+
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.2
+            panel.animator().alphaValue = 1.0
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration) { @MainActor in
+            guard currentPanel === panel else { return }
+            NSAnimationContext.runAnimationGroup({ ctx in
+                ctx.duration = 0.3
+                panel.animator().alphaValue = 0
+            }, completionHandler: {
+                MainActor.assumeIsolated {
+                    panel.orderOut(nil)
+                    if currentPanel === panel {
+                        currentPanel = nil
+                    }
+                }
+            })
+        }
+    }
+}
+
+@MainActor
+private final class StatusToastView: NSView {
+    private let message: NSString
+    private let symbol: String
+
+    private static let textAttributes: [NSAttributedString.Key: Any] = [
+        .font: NSFont.systemFont(ofSize: 13, weight: .medium),
+        .foregroundColor: NSColor.white,
+    ]
+
+    private let horizontalPadding: CGFloat = 14
+    private let symbolWidth: CGFloat = 18
+    private let symbolSpacing: CGFloat = 8
+
+    init(message: String, symbol: String) {
+        self.message = message as NSString
+        self.symbol = symbol
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var intrinsicContentSize: NSSize {
+        let textSize = message.size(withAttributes: StatusToastView.textAttributes)
+        return NSSize(
+            width: horizontalPadding * 2 + symbolWidth + symbolSpacing + ceil(textSize.width),
+            height: 38
+        )
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let ctx = NSGraphicsContext.current?.cgContext else { return }
+
+        let bgPath = CGPath(roundedRect: bounds, cornerWidth: 10, cornerHeight: 10, transform: nil)
+        ctx.setFillColor(NSColor.black.withAlphaComponent(0.85).cgColor)
+        ctx.addPath(bgPath)
+        ctx.fillPath()
+
+        let textSize = message.size(withAttributes: StatusToastView.textAttributes)
+        let textOrigin = NSPoint(
+            x: horizontalPadding + symbolWidth + symbolSpacing,
+            y: (bounds.height - textSize.height) / 2
+        )
+        message.draw(at: textOrigin, withAttributes: StatusToastView.textAttributes)
+
+        if let image = NSImage(systemSymbolName: symbol, accessibilityDescription: nil) {
+            let config = NSImage.SymbolConfiguration(pointSize: 14, weight: .semibold)
+                .applying(NSImage.SymbolConfiguration(paletteColors: [.white]))
+            let icon = image.withSymbolConfiguration(config) ?? image
+            let iconSize = icon.size
+            let iconRect = NSRect(
+                x: horizontalPadding + (symbolWidth - iconSize.width) / 2,
+                y: (bounds.height - iconSize.height) / 2,
+                width: iconSize.width,
+                height: iconSize.height
+            )
+            icon.draw(in: iconRect, from: .zero, operation: .sourceOver, fraction: 1.0)
+        }
+    }
+}

--- a/Sources/WindowSelectionOverlay.swift
+++ b/Sources/WindowSelectionOverlay.swift
@@ -1,0 +1,333 @@
+// WindowSelectionOverlay.swift
+// MikaScreenSnap
+//
+// Interactive window picker: hover to highlight, click to capture, ESC to cancel.
+// Swift 6.0 strict concurrency, macOS 14+
+
+import AppKit
+@preconcurrency import ScreenCaptureKit
+
+/// A picker candidate with its geometry already converted to AppKit coordinates.
+///
+/// Deliberately not `Sendable` — it holds an `SCWindow` and stays on the main actor.
+@MainActor
+struct WindowTarget {
+    let id: CGWindowID
+    let scWindow: SCWindow
+    /// AppKit global coordinates, bottom-left origin.
+    let globalFrame: NSRect
+    let appName: String
+    let title: String
+    let icon: NSImage?
+
+    var label: String {
+        title.isEmpty ? appName : "\(appName) — \(title)"
+    }
+
+    /// `SCWindow.frame` is global CoreGraphics space: origin at the top-left of the
+    /// primary display, y growing downwards. AppKit puts the origin at its bottom-left.
+    init?(scWindow: SCWindow) {
+        guard let app = scWindow.owningApplication else { return nil }
+
+        self.id = scWindow.windowID
+        self.scWindow = scWindow
+        self.globalFrame = NSScreen.appKitRect(fromCoreGraphics: scWindow.frame)
+        self.appName = app.applicationName
+        self.title = scWindow.title ?? ""
+        self.icon = NSRunningApplication(processIdentifier: app.processID)?.icon
+    }
+}
+
+@MainActor
+final class WindowSelectionController {
+    private var panels: [WindowSelectionPanel] = []
+    private var keyMonitor: Any?
+    private var spaceObserver: NSObjectProtocol?
+
+    /// Front to back — the first frame containing the pointer wins.
+    private var targets: [WindowTarget] = []
+    private var hovered: WindowTarget?
+    private var onSelect: (@MainActor (SCWindow) -> Void)?
+    private var onCancel: (@MainActor () -> Void)?
+
+    func start(
+        targets: [WindowTarget],
+        onSelect: @escaping @MainActor (SCWindow) -> Void,
+        onCancel: @escaping @MainActor () -> Void
+    ) {
+        self.targets = targets
+        self.onSelect = onSelect
+        self.onCancel = onCancel
+
+        for screen in NSScreen.screens {
+            let panel = WindowSelectionPanel(screen: screen, controller: self)
+            panel.makeKeyAndOrderFront(nil)
+            panels.append(panel)
+        }
+
+        // A local monitor is enough because our panel is key; a global one would need
+        // the Input Monitoring permission and fail silently without it.
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard event.keyCode == 53 else { return event }  // ESC
+            MainActor.assumeIsolated { self?.cancel() }
+            return nil
+        }
+
+        // The window list goes stale on a space switch, so end the picker instead of
+        // highlighting frames that no longer match what is on screen.
+        spaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.activeSpaceDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.cancel() }
+        }
+
+        // Highlight whatever is already under the pointer, before it moves.
+        pointerMoved(to: NSEvent.mouseLocation)
+    }
+
+    func dismiss() {
+        if let keyMonitor {
+            NSEvent.removeMonitor(keyMonitor)
+            self.keyMonitor = nil
+        }
+        if let spaceObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(spaceObserver)
+            self.spaceObserver = nil
+        }
+        for panel in panels {
+            panel.orderOut(nil)
+        }
+        panels.removeAll()
+        targets.removeAll()
+        hovered = nil
+        NSCursor.arrow.set()
+    }
+
+    fileprivate func pointerMoved(to globalPoint: NSPoint) {
+        let hit = targets.first { $0.globalFrame.contains(globalPoint) }
+        guard hit?.id != hovered?.id else { return }
+        hovered = hit
+        // Broadcast to every panel: a window can straddle two displays.
+        for panel in panels {
+            panel.setHovered(hit)
+        }
+    }
+
+    fileprivate func pointerClicked(at globalPoint: NSPoint) {
+        guard let target = targets.first(where: { $0.globalFrame.contains(globalPoint) }) else {
+            cancel()
+            return
+        }
+        let select = onSelect
+        onSelect = nil
+        onCancel = nil
+        select?(target.scWindow)
+    }
+
+    fileprivate func cancel() {
+        let cancelled = onCancel
+        onSelect = nil
+        onCancel = nil
+        cancelled?()
+    }
+}
+
+@MainActor
+final class WindowSelectionPanel: NSPanel {
+    private var selectionView: WindowSelectionView!
+
+    init(screen: NSScreen, controller: WindowSelectionController) {
+        super.init(
+            contentRect: screen.frame,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        self.level = .screenSaver
+        self.isOpaque = false
+        self.hasShadow = false
+        self.backgroundColor = .clear
+        self.ignoresMouseEvents = false
+        self.acceptsMouseMovedEvents = true
+        self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+        selectionView = WindowSelectionView(
+            frame: NSRect(origin: .zero, size: screen.frame.size),
+            screenFrame: screen.frame,
+            controller: controller
+        )
+        self.contentView = selectionView
+
+        self.setFrame(screen.frame, display: true)
+    }
+
+    func setHovered(_ target: WindowTarget?) {
+        selectionView.hovered = target
+    }
+}
+
+@MainActor
+final class WindowSelectionView: NSView {
+    /// Set by the controller, which broadcasts the hit to every panel.
+    var hovered: WindowTarget? {
+        didSet { needsDisplay = true }
+    }
+
+    private let screenFrame: NSRect
+    private weak var controller: WindowSelectionController?
+
+    /// Never fully transparent: the window server hit-tests borderless panels against
+    /// their alpha channel, so a clear region would let clicks fall through to the app
+    /// underneath instead of selecting it.
+    private let dimAlpha: CGFloat = 0.35
+    private let highlightAlpha: CGFloat = 0.18
+
+    init(frame: NSRect, screenFrame: NSRect, controller: WindowSelectionController) {
+        self.screenFrame = screenFrame
+        self.controller = controller
+        super.init(frame: frame)
+
+        let trackingArea = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseMoved, .mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(trackingArea)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: .pointingHand)
+    }
+
+    /// AppKit global coordinates to this view's coordinates. The panel covers exactly
+    /// one screen, so it is a plain offset.
+    private func localRect(_ globalRect: NSRect) -> NSRect {
+        globalRect.offsetBy(dx: -screenFrame.origin.x, dy: -screenFrame.origin.y)
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+
+        NSColor.black.withAlphaComponent(dimAlpha).setFill()
+        bounds.fill()
+
+        guard let hovered else {
+            drawHint()
+            return
+        }
+
+        let rect = localRect(hovered.globalFrame)
+        guard rect.intersects(bounds) else {
+            drawHint()
+            return
+        }
+
+        // Replace the dim over the target instead of clearing it — see `dimAlpha`.
+        NSGraphicsContext.current?.compositingOperation = .copy
+        NSColor.MikaPlus.tealPrimary.withAlphaComponent(highlightAlpha).setFill()
+        rect.intersection(bounds).fill()
+        NSGraphicsContext.current?.compositingOperation = .sourceOver
+
+        let borderPath = NSBezierPath(roundedRect: rect.insetBy(dx: 1.5, dy: 1.5), xRadius: 10, yRadius: 10)
+        borderPath.lineWidth = 3
+        NSColor.MikaPlus.tealLight.setStroke()
+        borderPath.stroke()
+
+        drawLabel(for: hovered, in: rect)
+        drawHint()
+    }
+
+    private func drawLabel(for target: WindowTarget, in rect: NSRect) {
+        let text = "\(target.label)  ·  \(Int(rect.width)) \u{00D7} \(Int(rect.height)) px"
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 13, weight: .medium),
+            .foregroundColor: NSColor.white,
+        ]
+
+        let iconSize: CGFloat = 22
+        let padding: CGFloat = 10
+        let spacing: CGFloat = 8
+        let textSize = (text as NSString).size(withAttributes: attributes)
+        let pillWidth = min(padding * 2 + iconSize + spacing + ceil(textSize.width), rect.width - 16, bounds.width - 32)
+        let pillHeight = max(iconSize + padding, textSize.height + padding * 2)
+
+        guard pillWidth > iconSize + padding * 2 else { return }
+
+        var origin = NSPoint(
+            x: rect.midX - pillWidth / 2,
+            y: rect.midY - pillHeight / 2
+        )
+        origin.x = min(max(origin.x, bounds.minX + 16), bounds.maxX - pillWidth - 16)
+        origin.y = min(max(origin.y, bounds.minY + 16), bounds.maxY - pillHeight - 16)
+
+        let pill = NSRect(x: origin.x, y: origin.y, width: pillWidth, height: pillHeight)
+        NSColor.black.withAlphaComponent(0.78).setFill()
+        NSBezierPath(roundedRect: pill, xRadius: 8, yRadius: 8).fill()
+
+        if let icon = target.icon {
+            icon.draw(in: NSRect(
+                x: pill.minX + padding,
+                y: pill.midY - iconSize / 2,
+                width: iconSize,
+                height: iconSize
+            ))
+        }
+
+        let textRect = NSRect(
+            x: pill.minX + padding + iconSize + spacing,
+            y: pill.midY - textSize.height / 2,
+            width: pill.maxX - padding - (pill.minX + padding + iconSize + spacing),
+            height: textSize.height
+        )
+        (text as NSString).draw(in: textRect, withAttributes: attributes)
+    }
+
+    private func drawHint() {
+        let text = "Click a window to capture  ·  ESC to cancel" as NSString
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 13, weight: .medium),
+            .foregroundColor: NSColor.white.withAlphaComponent(0.9),
+        ]
+        let textSize = text.size(withAttributes: attributes)
+        let padding: CGFloat = 12
+        let pill = NSRect(
+            x: bounds.midX - (textSize.width + padding * 2) / 2,
+            y: bounds.maxY - textSize.height - padding * 2 - 40,
+            width: textSize.width + padding * 2,
+            height: textSize.height + padding
+        )
+
+        NSColor.black.withAlphaComponent(0.7).setFill()
+        NSBezierPath(roundedRect: pill, xRadius: 8, yRadius: 8).fill()
+        text.draw(at: NSPoint(x: pill.minX + padding, y: pill.midY - textSize.height / 2), withAttributes: attributes)
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        NSCursor.pointingHand.set()
+        controller?.pointerMoved(to: NSEvent.mouseLocation)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        controller?.pointerClicked(at: NSEvent.mouseLocation)
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        controller?.cancel()
+    }
+
+    override func keyDown(with event: NSEvent) {
+        if event.keyCode == 53 {  // ESC
+            controller?.cancel()
+        }
+    }
+}

--- a/scripts/notarize.sh
+++ b/scripts/notarize.sh
@@ -44,6 +44,22 @@ echo "==> Removing quarantine attributes..."
 xattr -cr "$APP_BUNDLE"
 
 echo "==> Signing embedded frameworks with Developer ID (inside-out)..."
+# Sparkle nests XPC services and a helper app inside the framework. Signing only the
+# framework leaves those on build.sh's ad-hoc signature, which notarization rejects.
+SPARKLE_DIR="$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
+if [ -d "$SPARKLE_DIR" ]; then
+    for xpc in "$SPARKLE_DIR"/Versions/B/XPCServices/*.xpc; do
+        [ -d "$xpc" ] && echo "    Signing: $(basename "$xpc")" \
+            && codesign --force --sign "$DEVELOPER_ID" --options runtime "$xpc"
+    done
+    for app in "$SPARKLE_DIR"/Versions/B/*.app; do
+        [ -d "$app" ] && echo "    Signing: $(basename "$app")" \
+            && codesign --force --sign "$DEVELOPER_ID" --options runtime "$app"
+    done
+    codesign --force --sign "$DEVELOPER_ID" --options runtime \
+        "$SPARKLE_DIR/Versions/B/Autoupdate" 2>/dev/null || true
+fi
+
 if [ -d "$APP_BUNDLE/Contents/Frameworks" ]; then
     for fw in "$APP_BUNDLE/Contents/Frameworks/"*.framework; do
         if [ -d "$fw" ]; then
@@ -62,21 +78,22 @@ codesign --force --sign "$DEVELOPER_ID" \
 echo "==> Verifying signature..."
 codesign --verify --deep --strict "$APP_BUNDLE"
 
+# The DMG has to be rebuilt from the app we just re-signed — any existing one still
+# holds build.sh's ad-hoc signature. Delegating to create-dmg.sh keeps the background
+# and icon layout that a hand-rolled `hdiutil create` would throw away.
 echo "==> Creating DMG for notarization..."
 mkdir -p "$INSTALLER_DIR"
-STAGING_DIR=$(mktemp -d)
-trap "rm -rf '$STAGING_DIR'" EXIT
+if command -v create-dmg &>/dev/null; then
+    bash "$PROJECT_DIR/scripts/create-dmg.sh"
+else
+    echo "    'create-dmg' not installed — falling back to the built-in layout script."
+    bash "$PROJECT_DIR/scripts/create-dmg-simple.sh"
+fi
 
-cp -R "$APP_BUNDLE" "$STAGING_DIR/"
-ln -s /Applications "$STAGING_DIR/Applications"
-
-rm -f "$DMG_PATH"
-hdiutil create \
-    -volname "Mika+ScreenSnap" \
-    -srcfolder "$STAGING_DIR" \
-    -ov \
-    -format UDZO \
-    "$DMG_PATH"
+if [ ! -f "$DMG_PATH" ]; then
+    echo "ERROR: Expected DMG at $DMG_PATH but it was not created."
+    exit 1
+fi
 
 echo "==> Signing DMG..."
 codesign --force --sign "$DEVELOPER_ID" "$DMG_PATH"

--- a/web/lib/content.ts
+++ b/web/lib/content.ts
@@ -6,7 +6,7 @@
  * that needs editing.
  */
 
-const version = "3.4.0";
+const version = "3.4.1";
 const repo = "https://github.com/daumedia/MikaScreenSnap";
 
 export const product = {

--- a/web/lib/content.ts
+++ b/web/lib/content.ts
@@ -46,7 +46,7 @@ export type IconName =
 export const features: Feature[] = [
   {
     title: "Three capture modes",
-    body: "Full screen, a dragged region, or a single window — each on its own global shortcut, straight from the menu bar.",
+    body: "Full screen, a dragged region, or a single window — each on its own global shortcut, straight from the menu bar. Point at the window you want, or take the frontmost one outright.",
     icon: "capture",
   },
   {
@@ -89,7 +89,7 @@ export const features: Feature[] = [
 export const globalShortcuts: Array<[string, string]> = [
   ["⌃⇧⌘4", "Capture a region"],
   ["⌃⇧⌘3", "Capture the full screen"],
-  ["⌃⇧⌘5", "Capture a window"],
+  ["⌃⇧⌘5", "Capture the frontmost window"],
   ["⇧⌘6", "Extract text (OCR)"],
   ["⇧⌘7", "Pick a colour"],
   ["⇧⌘8", "Measure"],


### PR DESCRIPTION
## Problem

"Capture Window" opened the annotation editor with an empty, transparent image.

`captureWindow` sorted the candidate windows **ascending** by `windowLayer` and took `.first`. But a *higher* `CGWindowLevel` means *further front*, so this picked the backmost window. On top of that, `SCShareableContent.current` includes the desktop layer, which put WindowServer's backstop window at the head of the list.

Verified against the live window list on macOS 26:

```
OLD  layer -2147483626 |         | Display 6 Backstop    <- captured
NEW  layer           0 | Arc     | Mika+ Mika's Hub      <- captured
```

Fed through `SCContentFilter(desktopIndependentWindow:)` with `shouldBeOpaque = false`, a backstop window yields exactly the transparent image users reported. The bug predates #24 — it has been there since the initial commit.

## Changes

**Window selection** (`CaptureEngine.swift`)
- `SCShareableContent.excludingDesktopWindows(true, onScreenWindowsOnly: true)` instead of `.current`
- Keeps only layers `0..<20`, dropping desktop, wallpaper, Dock, menubar and Control Centre
- Preserves the front-to-back order `SCShareableContent` already provides, via an index-stable sort — `Array.sorted` is not stable and every ordinary app window shares layer 0
- `NSWorkspace.frontmostApplication` as the primary criterion for the non-interactive path
- Size and scale now come from `SCContentFilter.contentRect` / `.pointPixelScale` instead of `NSScreen.main`, so a window on a display with a different backing scale is captured at its own resolution
- Dropped the `title?.isEmpty == false` filter: it was a workaround for system windows that the layer filter now handles properly, and it excluded legitimate untitled windows
- `isPointerOverlay` treats a `nil` owning application like the empty bundle id it otherwise carries — WindowServer's cursor overlay may report either

**Interactive window picker** (`WindowSelectionOverlay.swift`, new)
- Menubar → "Capture Window…" opens an overlay per screen; hovering outlines the window under the pointer with its app icon, name and pixel size, click captures, ESC or right-click cancels
- ⌃⇧⌘5 keeps capturing the frontmost window directly, now also reachable as "Capture Frontmost Window"
- The highlight keeps a slight tint rather than being cut out. The window server hit-tests borderless panels against their alpha channel, so a fully clear region would let clicks fall through to the app underneath instead of selecting it.
- Hover state is broadcast to every panel so a window straddling two displays highlights on both; the picker ends on a space switch rather than showing a stale window list

**Error visibility** (`CaptureLog.swift`, `StatusToast.swift`, new)
- Every capture failure used to end in `print()`, which goes nowhere in an `LSUIElement` bundle launched from Finder. Failures now go to `os_log` under `com.mika.mikaplusscreensnap` and surface to the user as a toast, with a plain-language message for a missing screen-recording permission.

**Colour picker** (`ColorPickerEngine.swift`)
- Moves off the deprecated `CGWindowListCreateImage`. Its ScreenCaptureKit replacement is async while the loupe redraws on every mouse move, so the screen is snapshotted once per display when the picker starts and sampled synchronously from that buffer afterwards.
- Known trade-off: live content under the cursor does not update while the picker is open. An `SCStream` at a low frame rate would be the follow-up if that turns out to matter.
- Coordinate conversion moved off `NSScreen.main` (which follows the key window) onto the display that owns the AppKit origin — `ScreenGeometry.swift`, shared with the picker.

## Verification

`swift build -c release` and `bash build.sh` are clean; the app runs from the bundle.

Manual checks:
1. Focus a Finder window, press ⌃⇧⌘5 → the editor shows that window, not the desktop
2. Menubar → "Capture Window…" → hover outlines follow the pointer; with overlapping windows the frontmost one wins; click captures it
3. While the picker is open, clicking a foreign window must **not** reach that window (the alpha hit-testing case above)
4. ESC and right-click cancel without opening the editor
5. ⇧⌘7 colour picker: the loupe shows magnified pixels and a click copies the hex value
6. Multi-display: highlight frames line up with the real windows on both screens
7. Revoke the screen-recording permission → a toast appears and the failure shows up in `log stream --predicate 'subsystem == "com.mika.mikaplusscreensnap"'`

Not covered here: `captureFullScreen`, `captureArea` and `captureAreaForOCR` still use `content.displays.first` even though their overlays span every screen, so a selection on a secondary display lands on display 0. Separate bug, left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
