### PR TITLE
Notarize via a keychain profile instead of a password in the environment

### DIFF
--- a/scripts/notarize.sh
+++ b/scripts/notarize.sh
@@ -1,33 +1,53 @@
 #!/bin/bash
 # notarize.sh — Sign with Developer ID and notarize for distribution
 #
-# SETUP:
+# SETUP (once):
 # 1. Enroll in Apple Developer Program ($99/year)
 # 2. Create a Developer ID Application certificate in Xcode
 # 3. Generate an app-specific password at https://appleid.apple.com
-# 4. Set environment variables:
+# 4. Store it in the keychain — the password is entered interactively and never
+#    has to appear in a command line or environment variable again:
 #
-#    export DEVELOPER_ID="Developer ID Application: Your Name (TEAMID)"
-#    export APPLE_ID="your@email.com"
-#    export TEAM_ID="YOURTEAMID"
-#    export NOTARIZE_PASSWORD="xxxx-xxxx-xxxx-xxxx"
+#    xcrun notarytool store-credentials "MikaScreenSnap" \
+#        --apple-id "your@email.com" --team-id "YOURTEAMID"
 #
-# 5. Run: bash scripts/notarize.sh
+# Then just run: bash scripts/notarize.sh
+#
+# Override NOTARY_PROFILE to use a different keychain profile, or DEVELOPER_ID to
+# pick a specific certificate when several are installed.
 #
 set -euo pipefail
 
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 APP_BUNDLE="$PROJECT_DIR/build/Mika+ScreenSnap.app"
 INSTALLER_DIR="$PROJECT_DIR/installer"
+NOTARY_PROFILE="${NOTARY_PROFILE:-MikaScreenSnap}"
 
-# Validate environment
-for var in DEVELOPER_ID APPLE_ID TEAM_ID NOTARIZE_PASSWORD; do
-    if [ -z "${!var:-}" ]; then
-        echo "ERROR: $var environment variable is not set."
-        echo "See the setup instructions at the top of this script."
+# Fall back to the single installed Developer ID certificate.
+if [ -z "${DEVELOPER_ID:-}" ]; then
+    DEVELOPER_ID=$(security find-identity -v -p codesigning \
+        | grep "Developer ID Application" \
+        | head -1 \
+        | sed -E 's/.*"(.*)".*/\1/')
+    if [ -z "$DEVELOPER_ID" ]; then
+        echo "ERROR: No 'Developer ID Application' certificate found in the keychain."
+        echo "Create one in Xcode > Settings > Accounts > Manage Certificates."
         exit 1
     fi
-done
+    echo "==> Using certificate: $DEVELOPER_ID"
+fi
+
+# notarytool stores each profile as a generic password under this service.
+if ! security find-generic-password -s "com.apple.gke.notary.tool" -a "$NOTARY_PROFILE" &>/dev/null; then
+    echo "ERROR: No notarytool keychain profile named '$NOTARY_PROFILE'."
+    echo ""
+    echo "Create it once — the app-specific password is prompted for, not passed in:"
+    echo "  xcrun notarytool store-credentials \"$NOTARY_PROFILE\" \\"
+    echo "      --apple-id \"your@email.com\" --team-id \"YOURTEAMID\""
+    echo ""
+    echo "Generate the app-specific password at https://appleid.apple.com"
+    exit 1
+fi
 
 if [ ! -d "$APP_BUNDLE" ]; then
     echo "ERROR: App bundle not found at $APP_BUNDLE"
@@ -100,9 +120,7 @@ codesign --force --sign "$DEVELOPER_ID" "$DMG_PATH"
 
 echo "==> Submitting for notarization (this may take a few minutes)..."
 xcrun notarytool submit "$DMG_PATH" \
-    --apple-id "$APPLE_ID" \
-    --team-id "$TEAM_ID" \
-    --password "$NOTARIZE_PASSWORD" \
+    --keychain-profile "$NOTARY_PROFILE" \
     --wait
 
 echo "==> Stapling notarization ticket..."
@@ -110,7 +128,10 @@ xcrun stapler staple "$DMG_PATH"
 
 echo ""
 echo "==> Done! Notarized DMG: $DMG_PATH"
-echo "    Size: $(du -h "$DMG_PATH" | cut -f1)"
+echo "    Size: $(du -h "$DMG_PATH" | cut -f1) ($(stat -f%z "$DMG_PATH") bytes — this is the appcast 'length')"
 echo ""
 echo "This DMG can be distributed outside the App Store."
+echo ""
+echo "For the appcast entry, sign it with Sparkle's tool:"
+echo "  sign_update \"$DMG_PATH\""
 echo ""


### PR DESCRIPTION
## Problem

`notarize.sh` required four exported variables, one of them an app-specific Apple password:

```bash
export NOTARIZE_PASSWORD="xxxx-xxxx-xxxx-xxxx"
```

That puts a credential into the shell environment, into `history`, and into the process list of every child process for the duration of the run.

## Change

`xcrun notarytool` can read credentials from a keychain profile. The password is entered interactively once during setup and never appears in a command line again:

```bash
xcrun notarytool store-credentials "MikaScreenSnap" \
    --apple-id "you@example.com" --team-id "TEAMID"
```

After that, `bash scripts/notarize.sh` needs no environment at all.

- `NOTARY_PROFILE` defaults to `MikaScreenSnap`, overridable
- `DEVELOPER_ID` is detected from the keychain when a single Developer ID Application certificate is installed, still overridable when several are
- Both prerequisites are checked *before* any signing happens, so a missing profile no longer leaves a half-resigned bundle behind. The error prints the exact `store-credentials` command to run.
- The final summary prints the DMG size in bytes and the `sign_update` invocation — the two values the appcast entry needs

## Verification

`bash -n` is clean. Running it on a machine with the certificate but no profile:

```
==> Using certificate: Developer ID Application: Michael Rodrigues (CWJM4J4HFN)
ERROR: No notarytool keychain profile named 'MikaScreenSnap'.

Create it once — the app-specific password is prompted for, not passed in:
  xcrun notarytool store-credentials "MikaScreenSnap" \
      --apple-id "your@email.com" --team-id "YOURTEAMID"
```

Certificate auto-detection resolves correctly and the guard exits 1 before touching the app bundle. The signing and notarization path itself is unchanged apart from the `--keychain-profile` flag, and is exercised the next time a release is notarized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
