### PR TITLE
Ship 3.4.1 through the appcast

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -4,6 +4,34 @@
         <title>Mika+ScreenSnap Updates</title>
         <link>https://github.com/daumedia/MikaScreenSnap</link>
         <item>
+            <title>Version 3.4.1</title>
+            <sparkle:version>3.4.1</sparkle:version>
+            <sparkle:shortVersionString>3.4.1</sparkle:shortVersionString>
+            <description><![CDATA[
+                <h2>Fixed</h2>
+                <ul>
+                    <li><strong>Window capture produced an empty image</strong> — the window search picked the backmost window instead of the frontmost one, which meant capturing the desktop backstop</li>
+                    <li><strong>Wrong resolution on secondary displays</strong> — window captures now use the scale of the display the window is actually on</li>
+                    <li><strong>Untitled windows were not capturable</strong> — affected Electron apps, games and some Java apps</li>
+                    <li><strong>Colour picker and loupe</strong> — moved off a deprecated API and fixed cursor coordinates on multi-display setups</li>
+                    <li><strong>Capture failures were invisible</strong> — errors now surface as a message instead of failing silently</li>
+                </ul>
+                <h2>Added</h2>
+                <ul>
+                    <li><strong>Interactive window picker</strong> — "Capture Window…" outlines the window under the pointer; click to capture, ESC to cancel</li>
+                    <li><strong>Capture Frontmost Window</strong> — the previous one-shot behaviour, still on ⌃⇧⌘5</li>
+                </ul>
+            ]]></description>
+            <pubDate>Sun, 09 Aug 2026 01:00:00 +0100</pubDate>
+            <enclosure
+                url="https://github.com/daumedia/MikaScreenSnap/releases/download/v3.4.1/Mika%2BScreenSnap-v3.4.1.dmg"
+                sparkle:version="3.4.1"
+                sparkle:shortVersionString="3.4.1"
+                sparkle:edSignature="UJc7JmlGPmG4TWsABS1pKnT3ovIRFxYg8QqqdnEAX3LBEPt+pBiK7WiHq3NN1+jAQrXxbVI+MHf1VRKY2b3cDQ=="
+                length="2018145"
+                type="application/octet-stream" />
+        </item>
+        <item>
             <title>Version 3.4.0</title>
             <sparkle:version>3.4.0</sparkle:version>
             <sparkle:shortVersionString>3.4.0</sparkle:shortVersionString>

--- a/scripts/notarize.sh
+++ b/scripts/notarize.sh
@@ -37,9 +37,13 @@ if [ -z "${DEVELOPER_ID:-}" ]; then
     echo "==> Using certificate: $DEVELOPER_ID"
 fi
 
-# notarytool stores each profile as a generic password under this service.
-if ! security find-generic-password -s "com.apple.gke.notary.tool" -a "$NOTARY_PROFILE" &>/dev/null; then
-    echo "ERROR: No notarytool keychain profile named '$NOTARY_PROFILE'."
+# notarytool's keychain items are not reliably discoverable with
+# `security find-generic-password`, so verify the profile by using it. This also
+# catches a revoked or expired app-specific password, which a lookup would not —
+# worth one network round trip before we start re-signing anything.
+echo "==> Verifying notarization credentials..."
+if ! xcrun notarytool history --keychain-profile "$NOTARY_PROFILE" &>/dev/null; then
+    echo "ERROR: notarytool keychain profile '$NOTARY_PROFILE' is missing or invalid."
     echo ""
     echo "Create it once — the app-specific password is prompted for, not passed in:"
     echo "  xcrun notarytool store-credentials \"$NOTARY_PROFILE\" \\"


### PR DESCRIPTION
Completes the 3.4.1 release. **Merging this offers the update to every installed copy**, so the DMG had to be notarized first — it now is.

## Notarization

```
status: Accepted
The staple and validate action worked!
```

Gatekeeper on the app inside the DMG:

```
/Volumes/Mika+ScreenSnap/Mika+ScreenSnap.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Michael Rodrigues (CWJM4J4HFN)
```

The release asset was replaced with the notarized build (2,018,145 bytes, up from the 1,960,637 of the ad-hoc one — the stapled ticket accounts for the difference), and the release notes no longer tell people to right-click to open it.

## Appcast entry

Signature and length were verified against the asset **as downloaded from GitHub**, not the local file — `sign_update` over the fetched copy reproduces the entry exactly:

```
sparkle:edSignature="UJc7JmlGPmG4TWsABS1pKnT3ovIRFxYg8QqqdnEAX3LBEPt+pBiK7WiHq3NN1+jAQrXxbVI+MHf1VRKY2b3cDQ==" length="2018145"
```

`xmllint --noout appcast.xml` passes and the enclosure URL returns HTTP 200.

## notarize.sh fix

The preflight check added in #26 looked for a generic password under service `com.apple.gke.notary.tool` with the profile name as account. That found nothing even though the profile was valid and working — notarytool's keychain items are not reliably discoverable that way, so the script refused to run.

It now verifies the profile by using it (`notarytool history`). One network round trip before any signing starts, and it additionally catches a revoked or expired app-specific password, which a keychain lookup would have accepted. Confirmed by the run that produced this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
