### PR TITLE
Point the Sparkle feed at main instead of master

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -29,7 +29,7 @@
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>SUFeedURL</key>
-    <string>https://raw.githubusercontent.com/daumedia/MikaScreenSnap/master/appcast.xml</string>
+    <string>https://raw.githubusercontent.com/daumedia/MikaScreenSnap/main/appcast.xml</string>
     <key>SUPublicEDKey</key>
     <string>eauiHgP4PM9ynLekAmo3URrX3ye3HW7D53xOZa5AeYI=</string>
 </dict>


### PR DESCRIPTION
## Problem

`SUFeedURL` in `Resources/Info.plist` pointed at the **master** branch:

```
https://raw.githubusercontent.com/daumedia/MikaScreenSnap/master/appcast.xml
```

`master`'s last commit is `f02c80b` from 18 March 2026 — the day 3.4.0 shipped. Development continued on `main`, which is the repository's default branch and 17 commits ahead. So the update feed has been serving a stale appcast ever since, and the 3.4.1 entry merged in #27 would have reached nobody.

This predates the 3.4.1 work; it simply never surfaced because no release happened in between.

## Change

The feed now reads from `main`.

This only affects builds made **after** 3.4.1 — the shipped 3.4.1 DMG already carries the old URL. So `master` is separately being force-pushed to `main`'s state, which is what actually delivers 3.4.1 to installed 3.4.0 copies. The old master tip is preserved as the tag `master-archive-2026-08-09`; its three master-only commits are old merges whose content is already in `main`.

## Verification

After merging and the master sync, both URLs must serve the 3.4.1 entry:

```bash
curl -sL https://raw.githubusercontent.com/daumedia/MikaScreenSnap/main/appcast.xml   | grep shortVersionString | head -1
curl -sL https://raw.githubusercontent.com/daumedia/MikaScreenSnap/master/appcast.xml | grep shortVersionString | head -1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)