### PR TITLE
Record the shipped app as SDD artefacts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,21 @@ open "build/Mika+ScreenSnap.app"
 - **SwiftUI in AppKit** — Toolbar and BottomBar are `NSHostingView` with `@Observable` store binding
 - **Onboarding flow** — `OnboardingWindowController` follows AboutWindowController pattern; SwiftUI `TabView` with paged navigation, conditional permission screen, live permission polling
 
+## SDD-Artefakte
+
+**Artefaktpfad: `docs/`** — alle `sdd-`-Skills lesen ihn hier.
+
+- `docs/prd.md` · `docs/datenmodell.md` · `docs/design-system.md` · `docs/app-shell.md`
+- `features/index.md` — Statustabelle aller Features, `features/NN-slug/` je Feature
+
+Das Projekt wurde am 2026-08-25 über `sdd-erfassen` rückwirkend erfasst. Alle 15 Features
+tragen das `B`-Präfix (`B01`…`B15`): Sie existierten vor der Kette und wurden nie gegen
+eine Anforderung gebaut. Ihre Specs sind Rekonstruktionen und können selbst falsch sein.
+
+Ein Bestandsfeature läuft **nie** durch `sdd-tasks` oder den regulären `sdd-build` — es
+ist gebaut. Wer ein `B`-Feature erweitern will, legt ein neues Feature mit eigener Nummer
+an, das unter *Abhängigkeiten* darauf verweist.
+
 ## File Organization
 
 All source files in `Sources/`, tools in `Sources/Tools/`, onboarding screens in `Sources/Onboarding/`, preferences tabs in `Sources/Preferences/`. Resources (Info.plist, entitlements) in `Resources/`. Build/distribution scripts in `scripts/`. Generated installer assets (DMGs, backgrounds) in `installer/` (gitignored except `.gitkeep`).

--- a/docs/app-shell.md
+++ b/docs/app-shell.md
@@ -1,0 +1,175 @@
+# App-Shell — Mika+ScreenSnap
+
+Stand: 2026-08-25 · rückwirkend aus dem Code gelesen, Version 3.4.1
+
+Bei einer Menüleisten-App ist die Shell nicht Navigation, sondern **Erreichbarkeit**: Es
+gibt kein Hauptfenster, keinen Zurück-Weg und keinen Ort, an dem die App „offen" ist. Was
+auf jeder Ebene gleich bleibt, ist das Statusleistensymbol und die Art, wie Fenster
+davor treten.
+
+---
+
+## Der Rahmen
+
+**`LSUIElement = true`** in `Resources/Info.plist`. Die App hat kein Dock-Symbol, keine
+Menüleiste am oberen Bildschirmrand und erscheint nicht im App-Umschalter. Sie bleibt
+**dauerhaft** in `.accessory` — die Aktivierungsrichtlinie wird nie umgeschaltet.
+
+Das war nicht immer so: Bis 3.4.0 wechselte die App die Policy und wurde nach dem
+Schließen aus dem Dock unerreichbar (`a1b57e8`, Issue #18). Seither gilt die Regel aus
+`CLAUDE.md` ausnahmslos — Fenster kommen über `NSApp.activate()` nach vorn, nicht über
+einen Policy-Wechsel.
+
+`applicationShouldTerminateAfterLastWindowClosed` liefert `false`. Die App läuft weiter,
+wenn alle Fenster zu sind; beendet wird nur über *Quit* im Menü.
+
+## Der einzige Einstiegspunkt
+
+`MenuBarExtra` in `Sources/MikaScreenSnapApp.swift`, Symbol
+`Resources/MenubarIconTemplate.png` (Template-Bild, folgt hell/dunkel automatisch).
+
+Das Menü in seiner tatsächlichen Reihenfolge:
+
+```
+About Mika+ScreenSnap
+Check for Updates…
+⚠ Screen Recording not granted        ← nur wenn Berechtigung fehlt
+─────────────────────────────
+Capture Area                 ⌃⇧⌘4
+Capture Full Screen          ⌃⇧⌘3
+Capture Window…
+Capture Frontmost Window     ⌃⇧⌘5
+─────────────────────────────
+Capture Text                  ⇧⌘6
+Pick Color                    ⇧⌘7
+Measure                       ⇧⌘8
+─────────────────────────────
+Pinned Screenshots      ▸     ← Untermenü, leer: „No pinned screenshots"
+Color History           ▸     ← Untermenü, leer: „No colors picked yet"
+Screenshot History            ⇧⌘H
+─────────────────────────────
+Preferences…                    ⌘,
+Quit                            ⌘Q
+```
+
+Drei Muster, die durchgehalten sind:
+
+1. **Die Tastenkombination steht im Titel**, nicht als `keyEquivalent` — sie ist ja
+   global registriert (Carbon) und nicht an das geöffnete Menü gebunden. Ausnahmen sind
+   `Preferences…` und `Quit`, die echte `.keyboardShortcut` tragen.
+2. **Untermenüs zeigen ihren Leerzustand als Text**, statt zu verschwinden.
+3. **Der Berechtigungshinweis erscheint nur bei Bedarf**, geprüft über
+   `CGPreflightScreenCaptureAccess()` bei jedem Öffnen des Menüs, und führt per
+   `x-apple.systempreferences:`-Deeplink direkt in die Systemeinstellung.
+
+Der Menüpunkt `Capture Window…` hat bewusst **keine** Tastenkombination: Er öffnet die
+interaktive Fensterauswahl, während `⌃⇧⌘5` das vorderste Fenster ohne Rückfrage nimmt.
+
+## Fensterarten
+
+Zwei Familien, sauber getrennt. Reguläre Fenster für alles, womit man arbeitet; Panels
+für alles, was sich über den Bildschirm legt.
+
+### Reguläre Fenster — `NSWindow`, über einen Controller
+
+| Fenster | Stilmaske | Besonderheit |
+|---|---|---|
+| Annotations-Editor | `.titled .closable .resizable .miniaturizable` | einziges Fenster, das sich **selbst öffnet** — nach jeder Aufnahme |
+| Verlauf-Browser | `.titled .closable .resizable .miniaturizable` | `LazyVGrid` mit Vorschaubildern |
+| Einstellungen | `.titled .closable` | vier Tabs |
+| Onboarding | `.titled .closable` | `TabView`, seitenweise |
+| „Über" | `.titled .closable` | Version aus `Bundle.main` |
+
+Alle folgen demselben Muster: ein Controller wird beim ersten Aufruf erzeugt, in
+`AppState` gehalten und danach wiederverwendet. `showWindow()` ruft `NSApp.activate()`,
+damit das Fenster trotz `.accessory` den Fokus bekommt.
+
+### Panels — `NSPanel`, borderless und nonactivating
+
+Das Muster aus `CLAUDE.md`, hier in seiner tatsächlichen Ausprägung:
+
+| Panel | Ebene | Hintergrund |
+|---|---|---|
+| Bereichsauswahl | `.screenSaver` | `.clear` |
+| Fensterauswahl | `.screenSaver` | `.clear` |
+| Mess-Overlay | `.screenSaver` | `.clear` |
+| Farbpipette — Klickfläche je Display | `.screenSaver` | `NSColor.clear.withAlphaComponent(0.001)` |
+| Farbpipette — Lupe | **`.screenSaver + 1`** | `.clear` |
+| Angehefteter Screenshot | `.floating` | `.clear` |
+| Farb-Toast | `.floating` | `.clear` |
+| Status-Toast | `.floating` | `.clear` |
+| OCR-Ergebnis | `.hudWindow .utilityWindow .titled .closable` | systemgesteuert |
+
+Zwei Feinheiten, die keine Willkür sind:
+
+- **Die Lupe liegt eine Ebene über allem anderen** (`.screenSaver + 1`), damit sie nicht
+  von der eigenen Klickfläche verdeckt wird.
+- **Die Klickfläche der Pipette ist nicht ganz durchsichtig** (`alpha 0.001`): Ein
+  vollständig transparentes Panel nimmt keine Mausereignisse entgegen.
+- **Das OCR-Ergebnis ist das einzige Panel mit Titelleiste** — es wird gelesen, nicht
+  darübergezogen.
+
+## Was auf jeder Ebene gleich ist
+
+**Rückmeldung.** `StatusToast` (Fehler, seit 3.4.1) und `ColorPickerToast` (Erfolg) sind
+die einzige Art, wie die App ohne Fenster spricht. In einem `LSUIElement`-Bundle geht
+`print()` ins Leere — Fehler, die keinen Toast auslösen, erreichen niemanden.
+
+**Protokoll.** `CaptureLog` schreibt über `OSLog` unter dem Subsystem
+`com.mika.mikaplusscreensnap`, Kategorien `capture` und `hotkey`. Lesbar in Console.app.
+
+**Zustand.** `AppState` ist der gemeinsame Halter: Manager, Controller, offene Pin-Panels
+und Einstellungen. Alle UI-Klassen sind `@MainActor`, Zustand ist `@Observable`.
+
+**Erreichbarkeit.** Jede Funktion ist über zwei Wege erreichbar — Menü und
+Tastenkombination — mit einer Ausnahme: `Capture Window…` gibt es nur im Menü.
+
+## Ablauf nach einer Aufnahme
+
+Der einzige Ablauf, der mehrere Ebenen berührt, und deshalb hier statt in einer
+Feature-Spec:
+
+```
+Hotkey oder Menü
+   └→ Aufnahme (ScreenCaptureKit, ausgeschlossene Apps herausgefiltert)
+        └→ postCapture
+             ├→ Auslöseton                     (wenn captureSoundEnabled)
+             ├→ automatisches Sichern + Vorschaubild   (wenn autoSaveEnabled)
+             └→ Annotations-Editor öffnet sich
+                  └→ Kopieren · Sichern · Sichern unter · Anheften · Verwerfen
+```
+
+Der Editor öffnet sich **immer**, auch wenn nichts annotiert werden soll. Der schnelle
+Weg hinaus ist `Escape`: ohne Annotationen kopiert das die unveränderte Aufnahme und
+schließt; mit Annotationen erscheint eine Rückfrage.
+
+---
+
+## Fehlbestand
+
+**FB-AS-01 · Kein Weg zurück ins Onboarding außer über die Einstellungen.** Der
+Erststart-Flow wird über `hasCompletedOnboarding` gesteuert; wer ihn abbricht, erreicht
+ihn nur über *Preferences → Show Onboarding Again* wieder. Das ist auffindbar, aber nicht
+naheliegend, wenn die Berechtigung fehlt — dort führt der Menüeintrag stattdessen direkt
+in die Systemeinstellungen.
+
+**FB-AS-02 · Der Berechtigungshinweis prüft, aber blockiert nicht.** Fehlt die
+Bildschirmaufnahme-Berechtigung, erscheint der Warneintrag im Menü — die Aufnahme-Punkte
+bleiben trotzdem aktiv und anklickbar. Der Fehlschlag wird seit 3.4.1 als Toast
+gemeldet („Screen Recording permission required"), aber der Weg dorthin führt durch einen
+misslungenen Versuch. Gehört in die Spec von **B01** und **B12**.
+
+**FB-AS-03 · Sechs `print()`-Aufrufe in Fehlerpfaden.** 3.4.1 hat das Protokollieren auf
+`OSLog` umgestellt, aber nur im Aufnahmepfad. Verblieben sind:
+`AnnotationEditor.swift:267` (OCR fehlgeschlagen), `LaunchAtLoginManager.swift:24`,
+`ClipboardManager.swift:32` und `:40` (Speichern fehlgeschlagen),
+`AppPreferences.swift:196` (automatisches Sichern fehlgeschlagen),
+`PinnedScreenshotManager.swift:21` (Höchstzahl erreicht). In einem
+`LSUIElement`-Bundle, das aus dem Finder gestartet wird, erreichen diese Meldungen
+niemanden — **der Nutzer erfährt nicht, dass sein Screenshot nicht gespeichert wurde.**
+Betrifft die Specs von **B03**, **B05**, **B08**, **B09** und **B13**.
+
+**FB-AS-04 · Kein Fenster-Wiederherstellungsverhalten.** Editor, Verlauf und
+Einstellungen merken sich Größe und Position nicht über einen Neustart hinweg. Bei einer
+App, die mehrmals stündlich benutzt wird, ist das spürbar — es ist aber nirgends als
+Entscheidung festgehalten.

--- a/docs/datenmodell.md
+++ b/docs/datenmodell.md
@@ -1,0 +1,236 @@
+# Datenmodell — Mika+ScreenSnap
+
+Stand: 2026-08-25 · rückwirkend erfasst aus Version 3.4.1
+
+**Es gibt keine Datenbank.** Die App hält vier Arten von Zustand: Einstellungen in
+`UserDefaults`, Bilddateien im Dateisystem, flüchtigen Zustand im Speicher und ein paar
+Listen in `UserDefaults`, die eigentlich Daten sind. Dieses Dokument nimmt alle vier auf
+— so, wie sie sind.
+
+---
+
+## 1 · `UserDefaults` — Einstellungen
+
+Alle Schlüssel liegen in der Standard-Suite unter `com.mika.mikaplusscreensnap`.
+Geschrieben ausschließlich über `AppPreferences` (`Sources/AppPreferences.swift`),
+jeweils per `didSet`.
+
+| Schlüssel | Typ | Standard | Bedeutung |
+|---|---|---|---|
+| `autoSaveEnabled` | Bool | `true` | jede Aufnahme automatisch sichern |
+| `saveLocation` | String (Pfad) | `~/Pictures/MikaScreenSnap` | Zielordner der Aufnahmen |
+| `imageFormat` | String | `PNG` | `PNG` oder `JPEG` |
+| `jpegQuality` | CGFloat | `0.85` | nur bei JPEG wirksam |
+| `hasCompletedOnboarding` | Bool | `false` | steuert den Erststart-Flow |
+| `permissionSkipped` | Bool | `false` | Berechtigung im Onboarding übersprungen |
+| `captureSoundEnabled` | Bool | `true` | Auslöseton **— wird konsumiert** |
+| `floatingPreviewEnabled` | Bool | `false` | **wirkungslos**, siehe Fehlbestand |
+| `previewDismissDuration` | Int | `5` | **wirkungslos**, siehe Fehlbestand |
+| `defaultAnnotationTool` | String | `arrow` | Startwerkzeug im Editor **— wird konsumiert** |
+| `defaultStrokeColorData` | Data | `nil` | archivierte `NSColor` |
+| `defaultStrokeWidth` | CGFloat | `3.0` | Strichstärke |
+| `rememberLastTool` | Bool | `true` | überschreibt beim Schließen `defaultAnnotationTool` **— wird konsumiert** |
+| `showToolbarLabels` | Bool | `false` | **wirkungslos**, siehe Fehlbestand |
+| `excludedBundleIdentifiers` | [String] | `[]` | Bundle-IDs, die in keiner Aufnahme erscheinen |
+| `hotkeyBindings` | Data (JSON) | `nil` | `[String: HotkeyBinding]`, siehe unten |
+| `colorHistory` | [String] | `[]` | HEX-Werte, **max. 10** |
+| `colorPalette` | [String] | `[]` | HEX-Werte, **max. 20** |
+
+`resetAll()` (`AppPreferences.swift:135`) entfernt eine **fest verdrahtete Liste** von
+Schlüsseln. `colorHistory` und `colorPalette` stehen nicht darin — siehe Fehlbestand.
+
+### `HotkeyBinding`
+
+```
+struct HotkeyBinding: Codable, Equatable, Sendable {
+    let keyCode:   UInt32     // Carbon-Keycode, z. B. 0x14 = "3"
+    let modifiers: UInt32     // Carbon-Maske: cmdKey | shiftKey | controlKey | optionKey
+}
+```
+
+Persistiert als JSON-Wörterbuch unter `hotkeyBindings`, Schlüssel ist der `rawValue` von
+`HotkeyAction`. Sieben Aktionen: `fullScreen`, `area`, `window`, `captureText`,
+`colorPicker`, `measure`, `history`.
+
+---
+
+## 2 · Dateisystem
+
+### Aufnahmen — `~/Pictures/MikaScreenSnap/` (konfigurierbar)
+
+| Was | Wo | Benennung | Gelöscht durch |
+|---|---|---|---|
+| Aufnahme | `<saveLocation>/` | Zeitstempel + `.png`/`.jpg` | Verlauf-Browser (einzeln), *Clear History* (alle) |
+| Vorschaubild | `<saveLocation>/.thumbnails/` | gleicher Dateiname wie das Original | dieselben Pfade |
+
+`HistoryItem` wird beim Start **aus dem Verzeichnis rekonstruiert**, nicht aus einem
+Index gelesen:
+
+```
+struct HistoryItem: Identifiable, Sendable {
+    let id: UUID          // bei jedem Start neu vergeben — nicht stabil
+    let url: URL
+    let thumbnailURL: URL
+    let date: Date        // Änderungsdatum der Datei, nicht Aufnahmezeit
+    let pixelWidth: Int
+    let pixelHeight: Int
+}
+```
+
+Das Verzeichnis **ist** das Datenmodell. Eine Datei, die dort von Hand hineingelegt wird,
+erscheint im Verlauf; eine gelöschte verschwindet. Das ist robust und hat den Preis, dass
+`id` und `date` nicht das sind, wonach sie aussehen.
+
+### Angeheftete Bilder — `~/Library/Application Support/MikaScreenSnap/PinnedScreenshots/`
+
+| Was | Benennung | Gelöscht durch |
+|---|---|---|
+| PNG des angehefteten Bildes | `pin_JJJJ-MM-TT_HH-mm-ss-SSS.png` | **nichts** — siehe Fehlbestand |
+
+Gespeichert wird **ausschließlich das Bild**. Position, Größe und Deckkraft des Panels
+werden nicht abgelegt; beim Neustart erscheinen wiederhergestellte Pins in Standardgröße
+an Standardposition.
+
+---
+
+## 3 · Flüchtiger Zustand — nur im Speicher
+
+`AnnotationStore` (`Sources/AnnotationModels.swift:1025`) hält den gesamten Editorzustand
+und wird **nie persistiert**:
+
+```
+final class AnnotationStore {
+    var annotations:          [any Annotation]
+    var selectedAnnotationID: UUID?
+    var currentColor:         NSColor
+    var currentStrokeWidth:   CGFloat
+    var selectedTool:         DrawingToolType
+    var zoomLevel:            CGFloat
+    var panOffset:            CGPoint
+    var hasUnsavedChanges:    Bool
+    let undoManager:          UndoManager
+}
+```
+
+**Es gibt kein Projektformat.** Ein geschlossener Editor verliert alle Annotationen; ein
+exportiertes PNG ist flach und nicht mehr bearbeitbar. Das ist eine bewusst wirkende
+Entscheidung — sie steht nirgends geschrieben, weshalb sie als offener Punkt in der Spec
+von B03 landet und nicht hier als Tatsache.
+
+### `Annotation` — das Protokoll
+
+Neun Typen (`arrow`, `rectangle`, `ellipse`, `line`, `freehand`, `text`, `highlight`,
+`blur`, `pixelate`) implementieren dasselbe Protokoll. Sie zeichnen sich selbst, sind
+nach `zIndex` sortiert und liefern für Undo einen `AnnotationSnapshot`:
+
+```
+protocol Annotation: AnyObject, Identifiable {
+    var id: UUID { get }
+    var annotationType: AnnotationType { get }
+    var bounds: CGRect { get }
+    var color: NSColor { get set }
+    var strokeWidth: CGFloat { get set }
+    var isSelected: Bool { get set }
+    var zIndex: Int { get set }
+
+    func contains(_ point: CGPoint) -> Bool
+    func draw(in ctx: CGContext, baseImage: CGImage?)
+    func moved(by delta: CGSize)
+    func resized(from oldBounds: CGRect, to newBounds: CGRect)
+    func snapshot() -> AnnotationSnapshot
+    func restore(from snapshot: AnnotationSnapshot)
+}
+```
+
+`AnnotationSnapshot.data` ist ein `[String: any Sendable]` — untypisiert. Jede
+Annotation kennt ihre eigenen Schlüssel; ein Tippfehler fällt erst zur Laufzeit auf.
+
+`baseImage` in `draw(in:baseImage:)` existiert für `BlurAnnotation` und
+`PixelateAnnotation`: Beide lesen den Bereich aus dem **Originalbild** und rendern ihn
+verfremdet darüber. Das heißt auch, dass ihre Wirkung erst beim Rendern entsteht — im
+Modell steht nur ein Rechteck.
+
+`DrawingToolType` kennt zusätzlich `select` und `measure`; beide erzeugen keine
+Annotation. Messungen werden **nicht exportiert**.
+
+### `ExcludedAppsManager.CapturableApp`
+
+```
+struct CapturableApp: Identifiable, Hashable {
+    let bundleIdentifier: String   // zugleich die id
+    let name: String
+}
+```
+
+Wird bei jedem Öffnen der Einstellungen aus `SCShareableContent.current` neu aufgebaut.
+Bereits ausgewählte, aber nicht laufende Apps werden eingemischt, damit eine bestehende
+Auswahl nicht unbemerkt aus der Liste fällt — der Name kommt dann über
+`NSWorkspace.urlForApplication(withBundleIdentifier:)`.
+
+---
+
+## 4 · Löschregeln — Bestandsaufnahme
+
+| Daten | Nutzer kann löschen? | Wie |
+|---|---|---|
+| Aufnahmen + Vorschaubilder | ja | Verlauf-Browser einzeln, *Advanced → Clear History* für alle |
+| Einstellungen | ja | *Advanced → Reset All Preferences* |
+| Farbverlauf und Palette | **nein** | von `resetAll()` nicht erfasst |
+| Angeheftete Bilder | **nein** | kein Löschpfad im Code |
+| Hotkey-Belegungen | ja | *Restore Defaults* im Shortcuts-Tab |
+
+---
+
+## Fehlbestand
+
+Was hier steht, sind **Befunde, keine Kriterien.** Sie werden in der Spec des jeweiligen
+Features aufgenommen und von `sdd-qa` bewertet — nicht hier repariert.
+
+**FB-DM-01 · Angeheftete Bilder werden nie gelöscht.** `PinnedScreenshotManager`
+schreibt bei jedem Anheften ein PNG nach
+`~/Library/Application Support/MikaScreenSnap/PinnedScreenshots/`. Es existiert kein
+einziger `removeItem`-Aufruf: `unpinPanel` und `unpinAll` rufen nur `orderOut(nil)`, und
+`closePanel` im Panel selbst ebenso. Folgen:
+
+1. Bildschirminhalte sammeln sich dort **unbegrenzt** an, auch von längst geschlossenen Pins.
+2. `maxPins = 20` begrenzt nur gleichzeitig offene Panels und die Wiederherstellung
+   (`prefix(maxPins)`), nicht die Dateimenge.
+3. `restorePins` sortiert alphabetisch — bei Zeitstempel-Dateinamen also **aufsteigend nach
+   Alter** — und stellt die ersten 20 wieder her. Ein bewusst geschlossener Pin kann beim
+   nächsten Start zurückkehren, während ein neuerer nicht erscheint.
+4. Weder `storageUsage()` noch `clearAll()` kennen diesen Ordner: Die Speicheranzeige im
+   Advanced-Tab arbeitet ausschließlich über `historyManager`, also über `saveLocation`.
+   Der Nutzer sieht diese Daten nicht und kann sie in der App nicht entfernen.
+
+Gemessen an der Datenschutzregel des PRD („was der Nutzer unkenntlich macht, bleibt
+unkenntlich" und „lokale Ablagen sind eine bewusste Entscheidung") ist das der schwerste
+Einzelbefund der Kartierung. Gehört in die Spec von **B08**.
+
+**FB-DM-02 · Drei Einstellungen ohne Wirkung.** `floatingPreviewEnabled`,
+`previewDismissDuration` und `showToolbarLabels` werden gespeichert, geladen,
+zurückgesetzt und in der Oberfläche angeboten — aber von keinem Feature gelesen. Die
+Gegenprobe mit `captureSoundEnabled`, `rememberLastTool` und `defaultAnnotationTool`
+zeigt, dass die übrigen Schalter sehr wohl greifen. Der Nutzer stellt etwas ein, das
+nichts tut. Gehört in die Spec von **B11**.
+
+**FB-DM-03 · `resetAll()` erfasst Farbverlauf und Palette nicht.** Die Schlüsselliste in
+`AppPreferences.swift:135` ist von Hand gepflegt; `colorHistory` und `colorPalette`
+werden von `ColorHistoryManager` unter eigenen Schlüsseln geschrieben und überleben ein
+*Reset All Preferences*. Gehört in die Spec von **B06**.
+
+**FB-DM-04 · `HistoryItem.id` ist bei jedem Start neu.** Die UUID wird beim Einlesen des
+Verzeichnisses vergeben. Solange sie nur zur Darstellung in einer Liste dient, ist das
+folgenlos — sie darf aber nie zur Referenzierung über einen Start hinweg benutzt werden.
+`date` ist das Änderungsdatum der Datei, nicht der Aufnahmezeitpunkt: Ein Kopiervorgang
+verschiebt es. Gehört in die Spec von **B09**.
+
+**FB-DM-05 · `AnnotationSnapshot.data` ist untypisiert.** `[String: any Sendable]` mit
+Schlüsseln, die jede Annotation für sich definiert. Ein falscher Schlüssel oder ein
+Typwechsel scheitert stumm zur Laufzeit statt beim Übersetzen — bei einem Undo-Pfad, der
+selten läuft, fällt das lange nicht auf. Gehört in die Spec von **B03**.
+
+**FB-DM-06 · Kein Migrationspfad für die Einstellungen.** Es gibt keine Schemaversion in
+`UserDefaults`. Das Stack-Profil `swiftui-macos` benennt das ausdrücklich als Risiko:
+Ändert sich das Format eines Schlüssels — etwa `hotkeyBindings` —, verliert der Nutzer
+beim Update seine Konfiguration, ohne dass es auffällt. Gehört ins **Design des
+nächsten Features**, das ein Format ändert; bis dahin projektweiter Befund.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,163 @@
+# Design-System — Mika+ScreenSnap
+
+Stand: 2026-08-25 · rückwirkend aus dem Code gelesen, Version 3.4.1
+
+**Was hier steht, ist eine Bestandsaufnahme, keine Vorgabe.** Wo der Bestand
+uneinheitlich ist, steht das als Befund da und wird nicht begradigt — eine Aufräumaktion
+ist ein eigenes Feature mit eigener Spec, keine Nebenwirkung der Erfassung.
+
+---
+
+## Farben
+
+Die Markenpalette liegt vollständig in `Sources/MikaPlusColors.swift`, doppelt
+ausgeführt als `NSColor.MikaPlus` und `Color.MikaPlus`. Definiert über einen
+`init(hex:)`-Convenience-Initializer in sRGB.
+
+| Token | Hex | Verwendung im Bestand |
+|---|---|---|
+| `tealPrimary` | `#1D9E75` | Akzent: aktives Werkzeug, Auswahlring, Fokus |
+| `tealLight` | `#5DCAA5` | sekundärer Akzent |
+| `tealLightest` | `#9FE1CB` | zugleich `textSecondary` |
+| `tealSurface` | `#E1F5EE` | helle Fläche, zugleich `textPrimary` |
+| `darkBg` | `#1A1A2E` | Flächen der dunklen Oberflächen |
+| `darkBgDeep` | `#0F0F1A` | tiefere Ebene, Fensterhintergrund |
+| `textPrimary` | `#E1F5EE` | **identisch mit** `tealSurface` |
+| `textSecondary` | `#9FE1CB` | **identisch mit** `tealLightest` |
+| `destructive` | `#E24B4A` | Löschen, Zurücksetzen (seit 3.4.0) |
+
+Neun Namen für sieben Werte: `textPrimary`/`tealSurface` und
+`textSecondary`/`tealLightest` sind je zwei Namen für denselben Hex-Wert. Das ist
+gewollt lesbar (Rolle vs. Farbe), sollte aber bewusst bleiben — wer `tealSurface`
+ändert, ändert stillschweigend die Textfarbe mit.
+
+### Wo die Palette gilt — und wo nicht
+
+| Bereich | Palette |
+|---|---|
+| Annotations-Toolbar und Bottom-Bar | `MikaPlus` |
+| Onboarding (alle vier Bildschirme) | `MikaPlus` |
+| „Über"-Fenster | `MikaPlus` |
+| Angeheftetes Screenshot-Panel | `MikaPlus` |
+| Fensterauswahl-Overlay | `MikaPlus` |
+| **Einstellungen (alle vier Tabs)** | **keine** — durchgehend Systemfarben |
+| **Verlauf-Browser** | **keine** — durchgehend Systemfarben |
+| **Farbpresets im Editor** | **keine** — `.systemRed`, `.systemBlue`, `.systemGreen`, `.yellow`, `.white`, `.black` |
+
+Die sechs Farbpresets sind bewusst Systemfarben: Sie sind das Zeichenmaterial des
+Nutzers, nicht Oberfläche der App. Bei Einstellungen und Verlauf ist die Lage anders —
+siehe Befund DS-01.
+
+## Typografie
+
+Keine Schriftskala, keine Tokens. Größen stehen als Zahlen an der Stelle, an der sie
+gebraucht werden. Erhoben über Einstellungen, Onboarding und die beiden Editor-Leisten:
+
+| Verwendung | Aufruf | Häufigkeit |
+|---|---|---|
+| Abschnittsüberschrift | `.font(.headline)` | 10× |
+| Betonter Text | `.font(.system(size: 14, weight: .medium))` | 3× |
+| Fließtext | `.font(.system(size: 13))` | 3× |
+| Hilfstext | `.font(.caption)` | 3× |
+| Symbolgröße groß | `.font(.system(size: 48))` | 2× |
+| Titel | `.font(.system(size: 20, weight: .semibold))` | 2× |
+| Titel, abweichend | `.font(.system(size: 22, weight: .semibold))` | 1× |
+| Zahlen und HEX-Werte | `.font(.system(size: 12/13, design: .monospaced))` | 2× |
+| Weitere | `.subheadline`, `size: 12`, `size: 14` | je 1× |
+
+Semantische Stile (`.headline`, `.caption`) und feste Punktgrößen stehen nebeneinander.
+Zwei Titelgrößen (20 und 22) erfüllen erkennbar dieselbe Rolle. Monospace wird konsequent
+für Zahlen und Farbwerte eingesetzt — das ist die einzige durchgehaltene Regel.
+
+## Abstände
+
+| Wert | Häufigkeit | Rolle im Bestand |
+|---|---|---|
+| `spacing: 0` | 19× | Listen ohne Zwischenraum, Trennlinien tragen die Struktur |
+| `spacing: 4` | 5× | eng: Farbkreise, Symbolreihen |
+| `spacing: 20` | 5× | Abschnittsabstand |
+| `spacing: 12` | 3× | mittel |
+| `spacing: 8` | 2× | eng-mittel |
+| `spacing: 24` | 2× | Abschnittsabstand, abweichend |
+| `spacing: 1` | 1× | Trennlinie |
+| `padding(20)` | 1× | Fensterrand |
+
+Kein 4er- oder 8er-Raster: 20 und 24 erfüllen dieselbe Rolle, 8 und 12 ebenso.
+
+## Radien
+
+`cornerRadius: 8` (3×) · `cornerRadius: 6` (1×, Toolbar-Schaltflächen) ·
+`cornerRadius: 5` (2×) · `cornerRadius: 1` (1×, Strichstärken-Vorschau).
+Vier Werte, drei davon im selben Größenbereich.
+
+## Wiederkehrende Komponenten
+
+**Werkzeug-Schaltfläche** (`AnnotationToolbar.swift:102`) — die einzige Komponente mit
+konsistenter Ausprägung im ganzen Projekt:
+`28 × 28`, `cornerRadius: 6`, Symbol `18 × 18`, aktiv hinterlegt mit
+`tealPrimary.opacity(0.2)`.
+
+**Farbkreis** — `Circle()`, `18 × 18`, bei Auswahl `stroke(tealPrimary, lineWidth: 2)`.
+
+**Strichstärken-Vorschau** — `RoundedRectangle(cornerRadius: 1)`, `20 × <Stärke>`, in
+einer `28 × 28`-Schaltfläche. Drei Stärken: 2, 4, 6 px.
+
+**Toolbar-Leiste** — `height: 50`, `padding(.horizontal, 16)`,
+`padding(.vertical, 8)`, Gruppen durch `Divider().frame(height: 24)` getrennt.
+
+**Einstellungs-Abschnitt** — Überschrift in `.headline`, darunter ein Block; die
+Struktur trägt `Divider`, nicht Abstand.
+
+## Symbole
+
+Durchgehend SF Symbols über `Image(systemName:)`. Die Tab-Symbole der Einstellungen sind
+in `PreferencesTab` zentral definiert (`gearshape`, `keyboard`, `pencil.and.outline`,
+`slider.horizontal.3`) — die einzige Stelle, an der Symbolnamen als Tokens vorliegen.
+Werkzeugsymbole stehen verstreut in `AnnotationEditor`.
+
+## Erscheinungsbild der Fenster
+
+| Fenster | Erscheinung |
+|---|---|
+| Annotations-Editor | dunkel, Markenfarben |
+| Onboarding | dunkel, Markenfarben, Vollflächen-Verlauf |
+| „Über" | dunkel, Markenfarben |
+| Einstellungen | **systemnativ**, folgt der Systemeinstellung hell/dunkel |
+| Verlauf-Browser | **systemnativ** |
+| OCR-Ergebnis | `.hudWindow` — systemgesteuert |
+
+---
+
+## Fehlbestand
+
+**FB-DS-01 · README und CHANGELOG beschreiben die Einstellungen falsch.** Beide nennen
+sie ein „dark-themed four-tab preferences window" mit „Mika+ brand aesthetic"
+(`CHANGELOG.md`, Eintrag 3.4.0; `README.md`, Abschnitt *Features*). Der Code sagt etwas
+anderes: `Sources/Preferences/` enthält **keinen einzigen** Verweis auf `MikaPlus`, und
+der Dateikopf von `PreferencesStyles.swift` lautet „native macOS style". Der Commit
+`a43683a` („Redesign Preferences UI with native macOS System Settings layout") hat das
+Erscheinungsbild geändert, ohne dass die Dokumentation nachgezogen wurde.
+
+Das ist die Abweichung zwischen Versprechen und Bestand, nach der die Kartierung sucht.
+Zu klären ist, welche Seite falsch ist — das Fenster oder der Text darüber. Gehört in die
+Spec von **B11**.
+
+**FB-DS-02 · Zwei Oberflächen ohne Markenbezug.** Einstellungen und Verlauf-Browser
+benutzen ausschließlich Systemfarben, während Editor, Onboarding, „Über" und die Panels
+die dunkle Markenpalette tragen. Ob das eine bewusste Trennung ist („Systemdialoge sehen
+nach System aus") oder ein liegengebliebener Umbau, sagt der Code nicht.
+
+**FB-DS-03 · Keine Tokens für Typografie, Abstände und Radien.** Farben sind sauber
+zentralisiert, alles andere steht als Zahl an der Verwendungsstelle: 12 verschiedene
+Schriftdefinitionen, 8 Abstandswerte, 4 Radien. Zwei Titelgrößen (20/22) und zwei
+Abschnittsabstände (20/24) erfüllen dieselbe Rolle.
+
+**FB-DS-04 · Kein Hell-Modus für die Markenoberflächen.** `MikaPlus` definiert feste
+sRGB-Werte ohne Dynamik. Editor, Onboarding und „Über" bleiben dunkel, auch wenn das
+System auf hell steht — während Einstellungen und Verlauf mitwechseln. Bei hellem System
+zeigt die App also zwei Erscheinungsbilder nebeneinander.
+
+**FB-DS-05 · Kontrast ungeprüft.** `textSecondary` (`#9FE1CB`) auf `darkBg` (`#1A1A2E`)
+und `tealPrimary` (`#1D9E75`) als Akzent sind nirgends gegen ein Kontrastziel geprüft.
+Für eine App ohne Barrierefreiheits-Anspruch im PRD ist das kein Verstoß, aber es ist
+auch keine bewusste Entscheidung.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,0 +1,162 @@
+# Mika+ScreenSnap — Product Requirements Document
+
+Stand: 2026-08-25 · Stufe Datenschutz: A · Stack-Profil: `swiftui-macos`
+Artefaktpfad: `docs/`
+
+> **Rückwirkend erfasst.** Dieses Dokument beschreibt, was Version 3.4.1 tut — nicht,
+> was geplant war. Es entstand über `sdd-erfassen` aus Code, `CLAUDE.md`, `README.md`,
+> `CHANGELOG.md` und der Marketingseite in `web/`, nicht aus einem Briefing.
+
+## Vision
+
+Mika+ScreenSnap nimmt den Bildschirm auf und öffnet das Ergebnis sofort in einem Editor,
+statt es auf dem Schreibtisch abzulegen. Wer einen Screenshot macht, will in aller Regel
+etwas daran zeigen: einen Pfeil, eine Beschriftung, ein verpixeltes Passwort. Genau
+dieser Schritt liegt hier zwischen Tastendruck und Zwischenablage — nicht in einer
+zweiten App.
+
+Dazu kommen vier Werkzeuge, die dieselbe Bildschirmaufnahme für etwas anderes benutzen:
+Text erkennen, Farbe abgreifen, Pixel messen, ein Bild dauerhaft im Vordergrund halten.
+
+## Zielgruppe
+
+| Gruppe | Situation | Was sie hier will |
+|---|---|---|
+| Der Autor selbst | tägliche Arbeit an macOS-Projekten, mehrmals stündlich ein Screenshot | ein Werkzeug, das genau so funktioniert, wie er es will — ohne Kompromiss an fremde Produktentscheidungen |
+| Zufällige Nutzerinnen und Nutzer | fanden das Projekt auf GitHub, suchen einen Ersatz für `⇧⌘4` | eine App, die installiert einfach läuft — kein Konto, keine Cloud, keine Nachfragen |
+
+Die zweite Gruppe ist **Nebenprodukt, nicht Auftraggeber.** Das ist eine
+Produktentscheidung mit Folgen: Bei einem Zielkonflikt gewinnt der Eigenbedarf. Wer
+Features für die zweite Gruppe fordert, argumentiert gegen den Zweck.
+
+## Im Scope
+
+- Bildschirmaufnahme in drei Formen: Vollbild, gezogener Bereich, einzelnes Fenster
+- Annotationseditor, der sich nach jeder Aufnahme selbst öffnet — 11 Werkzeuge, Undo/Redo, Zoom/Pan
+- Unkenntlichmachen von Bildinhalten durch Weichzeichnen und Verpixeln
+- Texterkennung aus einem Bildschirmbereich, Ergebnis in der Zwischenablage
+- Farbpipette mit Lupe, Farbverlauf und Palette
+- Pixelmessung als Vollbild-Overlay und als Werkzeug im Editor
+- Screenshots als schwebendes Fenster anheften, über Neustarts hinweg
+- Automatisches Sichern jeder Aufnahme plus durchsuchbarer Verlauf
+- Frei belegbare systemweite Tastenkombinationen
+- Ausschlussliste: benannte Apps erscheinen in keiner Aufnahme
+- Ersteinrichtung, die durch die Bildschirmaufnahme-Berechtigung führt
+- Selbstaktualisierung über Sparkle, Direktvertrieb als notarisiertes DMG
+
+## Nicht im Scope
+
+- **Cloud und Konten** (bestätigt 2026-08-25) — keine Anmeldung, kein Backend, keine
+  Synchronisation, keine Analyse des Nutzungsverhaltens. Alles bleibt auf dem Rechner.
+  Das ist der Grund, warum die Datenschutzseite in `web/app/privacy/` behaupten darf, die
+  App wisse nichts über ihre Nutzer — und warum jede Funktion, die das ändern würde, hier
+  zuerst diskutiert werden muss.
+
+Was **nicht** als Nicht-Ziel bestätigt ist, aber im Bestand fehlt — Bildschirmvideo,
+Bildbearbeitung über Annotation hinaus, App-Store-Vertrieb —, steht unter *Offene Punkte*.
+Fehlen allein ist kein Vorsatz.
+
+## Erfolgskriterien
+
+- **Keine Abstürze, keine Fehlerberichte.** Der Maßstab ist Stabilität, nicht Verbreitung:
+  Eine App, die im Hintergrund liegt und bei jedem Tastendruck funktioniert, hat ihren
+  Zweck erfüllt.
+- Nachprüfbar über GitHub Issues und die Absturzberichte unter
+  `~/Library/Logs/DiagnosticReports/` — beides ohne Telemetrie, passend zur Stufe A.
+
+## Rahmenbedingungen
+
+| Thema | Entscheidung |
+|---|---|
+| Stack-Profil | `swiftui-macos` — Details in `~/.claude/sdd/stacks/swiftui-macos.md` |
+| Sprache/Version | Swift 6.0, strict concurrency, `@MainActor`-Isolation durchgehend |
+| Zielplattform | macOS 14.0 (Sonoma) aufwärts, **arm64 ausschließlich** (das ausgelieferte Binary ist nicht universal) |
+| Projektform | reines Swift Package, kein Xcode-Projekt |
+| Backend | **keins** |
+| Umgebungen | nur lokal — es gibt keine Test- oder Produktivumgebung, nur gebaute Bundles |
+| Datenhaltung | `UserDefaults` für Einstellungen · `~/Pictures/MikaScreenSnap/` für Aufnahmen · `~/Library/Application Support/MikaScreenSnap/PinnedScreenshots/` für angeheftete Bilder |
+| Sandbox | **aus** (`com.apple.security.app-sandbox = false`) — nötig für ScreenCaptureKit über Fremdfenster und Carbon-Hotkeys; schließt den App Store aus und macht Direktvertrieb zur Folge, nicht zur Wahl |
+| Berechtigungen | Bildschirmaufnahme (Screen Recording) — ohne sie ist die App funktionslos |
+| Externe Dienste | **Sparkle-Appcast** auf `raw.githubusercontent.com` — überträgt beim Update-Check das, was Sparkle standardmäßig sendet; empfängt Feed und DMG. Sonst kein Netzwerkverkehr |
+| Vertrieb | notarisiertes DMG als GitHub-Release, Update über Sparkle-Appcast auf `main` |
+| Sprachen | Oberfläche englisch · OCR erkennt Deutsch, Englisch, Französisch |
+| Monetarisierung | keine — MIT-Lizenz, kostenlos |
+
+## Datenschutz — Kurzfassung
+
+**Stufe A, weil kein Datum den Rechner verlässt.** Die App hat keine Konten, kein
+Backend, keine Analyse und keinen Netzwerkpfad außer dem Sparkle-Update-Check. OCR läuft
+über Apples Vision-Framework auf dem Gerät, die Farbpipette liest lokale Pixel. Ein Grep
+über `Sources/` findet kein `URLSession` und keine `URLRequest` — die Zusage der
+Datenschutzseite ist im Code belegbar.
+
+**Die Einstufung darf trotzdem nicht in Sorglosigkeit umschlagen.** Was diese App
+verarbeitet, ist inhaltlich das Sensibelste, was ein Rechner hergibt: alles, was auf dem
+Bildschirm steht. Ein Screenshot kann Gesundheitsdaten, Chats, Passwörter und fremde
+Personendaten enthalten — Kategorien, die anderswo Stufe C auslösen würden. Stufe A gilt
+hier allein deshalb, weil diese Inhalte das Gerät nie verlassen und niemand außer der
+Person am Rechner sie zu Gesicht bekommt.
+
+Daraus folgen App-weite Regeln, die in jeder Feature-Spec konkretisiert werden:
+
+- **Kein Bildinhalt geht ins Log.** Weder Pixel, noch erkannter Text, noch Dateinamen
+  mit erkennbarem Inhalt. `CaptureLog` protokolliert Fehler, keine Daten.
+- **Kein Bildinhalt verlässt das Gerät.** Nicht an Sparkle, nicht an einen Crash-Melder,
+  nirgendwohin. Jede künftige Funktion, die das bräuchte, hebt Stufe A auf.
+- **Was der Nutzer unkenntlich macht, bleibt unkenntlich.** Ein verpixelter Bereich darf
+  im Export nicht rekonstruierbar sein — und kein Nebenpfad darf das unbearbeitete
+  Original ablegen, ohne dass die Person das weiß.
+- **Die Ausschlussliste ist eine Zusage, keine Bequemlichkeit.** Eine dort eingetragene
+  App darf in keiner Aufnahme auftauchen — auch nicht in der Farbpipette, auch nicht im OCR.
+- **Lokale Ablagen sind unverschlüsselt.** Aufnahmen liegen im Klartext in
+  `~/Pictures/MikaScreenSnap/`, angeheftete Bilder in `Application Support`. Das ist der
+  Normalfall für macOS-Nutzdaten, aber es ist eine bewusste Entscheidung und keine
+  Selbstverständlichkeit.
+
+Der Katalog aus `~/.claude/sdd/sicherheit.md` gilt nach Stufe A verkürzt auf die
+Abschnitte 4 (Missbrauch und Kosten) und 6 (Geheimnisse) — **erweitert um Abschnitt 1**,
+weil die Frage „landen Daten in Logs" hier trotz Stufe A scharf gestellt werden muss.
+
+## Feature-Roadmap
+
+Kein Plan, sondern ein **Inventar**: Alle 15 Einträge existieren im ausgelieferten Code
+und stehen auf Status `bestand`. Die Prioritäten beschreiben, was die App ohne den
+jeweiligen Eintrag noch wäre.
+
+| ID | Feature | Prio | Kurzbeschreibung | Abhängig von |
+|---|---|---|---|---|
+| B01 | Bildschirmaufnahme | P0 | Vollbild, gezogener Bereich oder einzelnes Fenster über ScreenCaptureKit | — |
+| B02 | App-Ausschluss von Aufnahmen | P0 | benannte Apps erscheinen in keiner Aufnahme | B01 |
+| B03 | Anmerkungs-Editor | P0 | Pfeil, Rechteck, Ellipse, Linie, Freihand, Text, Hervorheben, Auswahl; Undo/Redo, Zoom/Pan | B01 |
+| B04 | Bereiche zensieren | P0 | Weichzeichnen und Verpixeln sensibler Bildstellen | B03 |
+| B05 | Bildschirmtext erfassen (OCR) | P1 | Text aus einem Bereich erkennen und in die Zwischenablage legen | B01, B02 |
+| B06 | Farbpipette | P1 | Pixelfarbe mit Lupe abgreifen, HEX kopieren, Verlauf und Palette | B01, B02 |
+| B07 | Lineal / Bildschirm vermessen | P1 | Pixelabstände messen — als Overlay und als Editorwerkzeug | B03 |
+| B08 | Screenshots anheften | P1 | Bild als schwebendes Fenster halten, über Neustarts hinweg | B01, B03 |
+| B09 | Screenshot-Verlauf | P0 | jede Aufnahme automatisch sichern, durchsuchbar anzeigen | B01 |
+| B10 | Tastenkombinationen | P0 | sieben systemweite Hotkeys über Carbon, frei belegbar | B01 |
+| B11 | Einstellungen | P0 | vier Tabs: Speicherort, Format, Ton, Zeichen-Standards, Speicherplatz, Zurücksetzen | B01, B09, B10 |
+| B12 | Ersteinrichtung | P1 | dreistufiger Erststart mit Berechtigungsanfrage und Shortcut-Übersicht | B01, B13 |
+| B13 | Automatischer Start bei Login | P2 | Anmeldeobjekt über `SMAppService` | — |
+| B14 | Automatische Updates | P1 | Sparkle prüft den Appcast und installiert neue Versionen | — |
+| B15 | Menüleisten-Hub & Programminfo | P0 | Statusleistensymbol als einziger Einstiegspunkt, „Über"-Fenster | alle |
+
+**Erfassungsreihenfolge:** B01 → B02 → B04 → B09 → B05 → B06 → B08 → B14 → B12 → B03 → B10 → B11 → B13 → B07 → B15
+
+Begründung steht unter der Tabelle in `features/index.md` — sie folgt dem Risiko, nicht
+der Nummer.
+
+## Offene Punkte
+
+- **OF-01** (2026-08-25) — Sind Bildschirmvideo/GIF, weitergehende Bildbearbeitung und
+  App-Store-Vertrieb bewusste Nicht-Ziele oder nur bisher nicht gebaut? Der Bestand sagt
+  darüber nichts. Bis zur Klärung stehen sie **nicht** unter *Nicht im Scope* — eine Lücke
+  ist ein Befund, kein Vorsatz.
+- **OF-02** (2026-08-25) — Das ausgelieferte Binary ist arm64-only, die Website sagt das
+  ehrlich („Apple silicon"). Ist Intel-Unterstützung aufgegeben oder nie beabsichtigt gewesen?
+- **OF-03** (2026-08-25) — Der Sparkle-Feed zeigt seit `db55d1f` auf `main`; Installationen
+  bis einschließlich 3.4.1 haben `master` fest einkompiliert. Bis der letzte dieser
+  Installationen aktualisiert ist, muss `main:master` mitgepusht werden. Wann darf das enden?
+- **OF-04** (2026-08-25) — Es existieren **keine Tests** (`Tests/` fehlt). Für die
+  Rückerfassung heißt das: Jedes Akzeptanzkriterium braucht in der QA einen manuellen
+  Nachweis oder einen neu geschriebenen Test. Soll `swift test` als Ziel etabliert werden?

--- a/features/index.md
+++ b/features/index.md
@@ -1,0 +1,83 @@
+# Features
+
+Stand: 2026-08-25 · Stack-Profil: `swiftui-macos` · Artefaktpfad: `docs/`
+
+Alle Einträge sind **Bestand**: Sie existieren im ausgelieferten Code (Version 3.4.1) und
+sind nie durch die SDD-Kette gelaufen. Das `B`-Präfix hält das dauerhaft sichtbar — bei
+einem Fehler in `B04` ist die Spec eine Rekonstruktion und kann selbst falsch sein.
+
+| ID | Feature | Prio | Status | Abhängig von | Zuletzt |
+|---|---|---|---|---|---|
+| B01 | Bildschirmaufnahme | P0 | bestand | — | — |
+| B02 | App-Ausschluss von Aufnahmen | P0 | bestand | B01 | — |
+| B03 | Anmerkungs-Editor | P0 | bestand | B01 | — |
+| B04 | Bereiche zensieren | P0 | bestand | B03 | — |
+| B05 | Bildschirmtext erfassen (OCR) | P1 | bestand | B01, B02 | — |
+| B06 | Farbpipette | P1 | bestand | B01, B02 | — |
+| B07 | Lineal / Bildschirm vermessen | P1 | bestand | B03 | — |
+| B08 | Screenshots anheften | P1 | bestand | B01, B03 | — |
+| B09 | Screenshot-Verlauf | P0 | bestand | B01 | — |
+| B10 | Tastenkombinationen | P0 | bestand | B01 | — |
+| B11 | Einstellungen | P0 | bestand | B01, B09, B10 | — |
+| B12 | Ersteinrichtung | P1 | bestand | B01, B13 | — |
+| B13 | Automatischer Start bei Login | P2 | bestand | — | — |
+| B14 | Automatische Updates | P1 | bestand | — | — |
+| B15 | Menüleisten-Hub & Programminfo | P0 | bestand | alle | — |
+
+## Erfassungsreihenfolge
+
+**B01 → B02 → B04 → B09 → B05 → B06 → B08 → B14 → B12 → B03 → B10 → B11 → B13 → B07 → B15**
+
+Nach Risiko, nicht nach Nummer. Die Rückerfassung ist die Eintrittskarte für `sdd-qa`,
+und die QA ist an einem Bestandsprojekt ein Sicherheitsaudit — wer mit der Darstellung
+anfängt, prüft zuletzt, was zuerst brennen kann.
+
+| Rang | Features | Warum hier |
+|---|---|---|
+| 1 | B01, B02 | lesen über ScreenCaptureKit die Bildschirminhalte **jeder** laufenden App. B02 trägt die einzige Zugriffsregel der Anwendung: Was ausgeschlossen ist, darf nirgends auftauchen — auch nicht in B05 und B06 |
+| 2 | B04, B09 | zusammen, weil die entscheidende Frage nur über beide zu beantworten ist: **Liegt das unverpixelte Original im Verlauf, nachdem der Nutzer etwas zensiert hat?** Wer beide getrennt prüft, findet das nie |
+| 3 | B05, B06 | lesen ebenfalls den gesamten Bildschirm — OCR erkennt Text, den es nicht erkennen sollte; die Pipette snapshottet alle Displays für ein einziges Pixel |
+| 4 | B08 | legt Bildschirminhalte dauerhaft ab und stellt sie beim Start wieder her. Der schwerste Befund der Kartierung sitzt hier (FB-DM-01) |
+| 5 | B14 | einziger Netzwerkpfad der App — und Sparkle installiert ausführbaren Code. Ein Fehler in der Signaturprüfung wiegt schwerer als jeder Darstellungsfehler |
+| 6 | B12 | steuert den Berechtigungsfluss: Was hier schiefgeht, entscheidet, ob B01 überhaupt darf |
+| 7 | B03, B10, B11 | nehmen Eingaben entgegen und schreiben Dateien, lesen aber nichts von fremden Fenstern |
+| 8 | B13, B07, B15 | Systemdienst, Messung und Navigation — geringstes Risiko |
+
+B03 steht bewusst **hinter** B04, obwohl es dessen Vorstufe ist: Der Editor als Ganzes ist
+Werkzeug, das Zensieren ist eine Datenschutzzusage. Für die Rückerfassung von B04 reicht
+das Wissen über den Editor aus dem Code; umgekehrt gilt das nicht.
+
+## Umfang
+
+Fünfzehn Features, fünfzehn Sitzungen. Das ist kein Argument dagegen, aber es sollte
+niemand überrascht sein. Jede Sitzung wird einzeln aufgerufen:
+
+```
+/sdd-erfassen B01
+```
+
+Danach `/sdd-qa B01`. Was die QA findet, entscheidet über den weiteren Weg — ein
+kritischer oder hoher Befund unterbricht die Erfassung, bis die Reparatur ausgeliefert
+ist, weil er Code betrifft, der in diesem Moment läuft.
+
+## Bereits bekannte Befunde
+
+Aus der Kartierung, jeweils verifiziert und dem Feature zugeordnet, in dessen Spec sie
+unter *Fehlbestand* gehören. Sie sind **keine** Akzeptanzkriterien.
+
+| Befund | Feature | Grad (vorläufig) | Kurz |
+|---|---|---|---|
+| FB-DM-01 | B08 | hoch | angeheftete Bilder werden nie gelöscht, sammeln sich unsichtbar an, geschlossene Pins kehren zurück |
+| FB-AS-03 | B03, B05, B08, B09, B13 | mittel | sechs `print()` in Fehlerpfaden — der Nutzer erfährt nicht, wenn das Sichern fehlschlägt |
+| FB-DM-03 | B06 | mittel | `resetAll()` löscht Farbverlauf und Palette nicht |
+| FB-DS-01 | B11 | mittel | README und CHANGELOG beschreiben die Einstellungen als dunkel; der Code ist systemnativ |
+| FB-DM-02 | B11 | mittel | drei Einstellungen ohne jede Wirkung |
+| FB-AS-02 | B01, B12 | mittel | fehlende Berechtigung wird angezeigt, blockiert aber nichts — der Weg führt durch einen Fehlversuch |
+| FB-DM-04 | B09 | niedrig | `HistoryItem.id` bei jedem Start neu, `date` ist das Änderungsdatum |
+| FB-DM-05 | B03 | niedrig | `AnnotationSnapshot.data` untypisiert, Fehler fallen erst zur Laufzeit auf |
+| FB-DM-06 | projektweit | niedrig | keine Schemaversion in `UserDefaults`, kein Migrationspfad |
+| FB-DS-02 bis -05 | B11, projektweit | niedrig | Markenpalette nur teilweise angewandt, keine Tokens, kein Hell-Modus, Kontrast ungeprüft |
+| FB-AS-01, FB-AS-04 | B12, projektweit | niedrig | Onboarding schwer wiederauffindbar, keine Fensterwiederherstellung |
+
+Die Grade sind **vorläufig** — gesetzt beim Lesen, nicht beim Prüfen. `sdd-qa` bewertet
+sie neu und schreibt sie nach `features/befunde.md` fort.


### PR DESCRIPTION
Phase 1 of `sdd-erfassen`: the four project documents and the feature index, reconstructed
out of the code of 3.4.1 rather than out of intent. **No source file is touched** — this is
documentation plus one section added to `CLAUDE.md` so the remaining `sdd-` skills find the
artefact path.

## What is here

| File | Content |
|---|---|
| `docs/prd.md` | Vision, audience, scope, privacy tier A with reasoning, four open points |
| `docs/datenmodell.md` | UserDefaults, filesystem, in-memory state — there is no database |
| `docs/design-system.md` | Colours, typography, spacing, components as they actually are |
| `docs/app-shell.md` | Menu bar, window families, panel levels, post-capture flow |
| `features/index.md` | Fifteen features on status `bestand`, ordered by risk |

Features carry a `B` prefix (`B01`…`B15`). They existed before the chain, so they were never
built against a requirement — their specs are reconstructions and can themselves be wrong.
That distinction matters when hunting a bug: for `B04` the spec is a guess, for a future `04`
it would be the contract.

## Privacy tier A — with a caveat

The derivation is unambiguous: no accounts, no backend, no `URLSession` anywhere in `Sources/`.
The claim on the privacy page in `web/app/privacy/` is verifiable in the code.

It should not turn into complacency. What this app processes is the most sensitive thing a
machine holds — everything on screen. Tier A applies only because none of it leaves the
device. Section 1 of the security catalogue ("does anything land in logs?") is therefore kept
in, although tier A would allow dropping it.

## Findings recorded, not fixed

Each is verified, filed under *Fehlbestand* against its feature, and carries a provisional
severity. `sdd-qa` reassesses them.

- **`FB-DM-01` (high) — pinned screenshots are never deleted.** Every pin writes a PNG to
  `~/Library/Application Support/MikaScreenSnap/PinnedScreenshots/`. There is no `removeItem`
  call anywhere; closing only calls `orderOut(nil)`. `maxPins = 20` bounds open panels, not
  files. `restorePins` sorts alphabetically over timestamped names and so restores the twenty
  *oldest* — a deliberately closed pin can return. Neither `storageUsage()` nor `clearAll()`
  knows the directory, both going through `historyManager`, so the user can neither see nor
  clear this data.
- **`FB-AS-03` (medium) — six `print()` calls survive in error paths.** 3.4.1 moved logging to
  `OSLog`, but only in the capture path. In an `LSUIElement` bundle the rest reach nobody: when
  auto-save fails, the user is not told.
- **`FB-DS-01` (medium) — the docs describe the preferences window wrongly.** README and
  CHANGELOG call it dark-themed and branded; `Sources/Preferences/` holds no `MikaPlus`
  reference at all. Commit `a43683a` moved it to the native System Settings layout and the prose
  never followed. Which side is wrong is a question for `B11`.
- **`FB-DM-03` (medium)** — `resetAll()` keeps a hand-maintained key list that omits
  `colorHistory` and `colorPalette`; both survive a reset.
- **`FB-DM-02` (medium)** — `floatingPreviewEnabled`, `previewDismissDuration` and
  `showToolbarLabels` are stored, loaded, reset and offered in the UI, but read by nothing.

Six further low-severity findings are listed in `features/index.md`.

## Capture order

`B01 → B02 → B04 → B09 → B05 → B06 → B08 → B14 → B12 → B03 → B10 → B11 → B13 → B07 → B15`

By risk, not by number — the QA on an existing project is a security audit, so whatever can
burn first is documented first. `B04` (redaction) and `B09` (history) sit together deliberately:
one question is only answerable across both — **does the unredacted original sit in the history
after the user blurs something?** Auto-save hangs off `postCapture`, redaction happens afterwards
in the editor. Checked separately, nobody would find it.

## Open points

Four, recorded honestly rather than guessed: whether video capture, image editing and App Store
distribution are deliberate non-goals or merely unbuilt; whether Intel support was dropped or
never intended; when the `main:master` push for pre-3.4.1 installs may stop; and whether
`swift test` should become a target — there are currently no tests at all, so every acceptance
criterion will need a manual proof or a newly written test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)