### PR TITLE
Reconstruct all fifteen features (SDD phase 2)

### DIFF
--- a/docs/datenmodell.md
+++ b/docs/datenmodell.md
@@ -22,7 +22,7 @@ jeweils per `didSet`.
 | `imageFormat` | String | `PNG` | `PNG` oder `JPEG` |
 | `jpegQuality` | CGFloat | `0.85` | nur bei JPEG wirksam |
 | `hasCompletedOnboarding` | Bool | `false` | steuert den Erststart-Flow |
-| `permissionSkipped` | Bool | `false` | Berechtigung im Onboarding übersprungen |
+| `permissionSkipped` | Bool | `false` | **wirkungslos**, siehe Fehlbestand |
 | `captureSoundEnabled` | Bool | `true` | Auslöseton **— wird konsumiert** |
 | `floatingPreviewEnabled` | Bool | `false` | **wirkungslos**, siehe Fehlbestand |
 | `previewDismissDuration` | Int | `5` | **wirkungslos**, siehe Fehlbestand |
@@ -206,12 +206,16 @@ Gemessen an der Datenschutzregel des PRD („was der Nutzer unkenntlich macht, b
 unkenntlich" und „lokale Ablagen sind eine bewusste Entscheidung") ist das der schwerste
 Einzelbefund der Kartierung. Gehört in die Spec von **B08**.
 
-**FB-DM-02 · Drei Einstellungen ohne Wirkung.** `floatingPreviewEnabled`,
+**FB-DM-02 · Vier Schlüssel ohne Wirkung.** `floatingPreviewEnabled`,
 `previewDismissDuration` und `showToolbarLabels` werden gespeichert, geladen,
 zurückgesetzt und in der Oberfläche angeboten — aber von keinem Feature gelesen. Die
 Gegenprobe mit `captureSoundEnabled`, `rememberLastTool` und `defaultAnnotationTool`
 zeigt, dass die übrigen Schalter sehr wohl greifen. Der Nutzer stellt etwas ein, das
 nichts tut. Gehört in die Spec von **B11**.
+
+Hinzu kommt `permissionSkipped`: geschrieben in `Onboarding/PermissionScreen.swift:63`,
+gelesen von niemandem. Anders als die drei anderen taucht er in keiner Oberfläche auf —
+er ist ein Vermerk, auf den nie zurückgegriffen wird. Gehört in die Spec von **B12**.
 
 **FB-DM-03 · `resetAll()` erfasst Farbverlauf und Palette nicht.** Die Schlüsselliste in
 `AppPreferences.swift:135` ist von Hand gepflegt; `colorHistory` und `colorPalette`
@@ -228,6 +232,17 @@ verschiebt es. Gehört in die Spec von **B09**.
 Schlüsseln, die jede Annotation für sich definiert. Ein falscher Schlüssel oder ein
 Typwechsel scheitert stumm zur Laufzeit statt beim Übersetzen — bei einem Undo-Pfad, der
 selten läuft, fällt das lange nicht auf. Gehört in die Spec von **B03**.
+
+**FB-DM-07 · `resetAll()` erfasst Sparkles Schlüssel nicht.** Das
+Aktualisierungswerk führt eigene Einträge in den Benutzereinstellungen — Zeitpunkt der
+letzten Prüfung, automatische Prüfung, übersprungene Fassungen. Die von Hand gepflegte
+Liste in `AppPreferences.swift:135` kennt sie nicht. Folge: *Reset All Preferences* setzt
+die Aktualisierungseinstellungen nicht zurück. Gehört in die Spec von **B11**.
+
+**FB-DM-08 · Die Standard-Strichstärke steht nicht zur Auswahl.**
+`AppPreferences.swift:114` und `:162` setzen `3.0`; die Auswahl in
+`Preferences/AnnotationTabView.swift:64-66` bietet `2`, `4` und `6`. Folge: Beim ersten
+Öffnen zeigt die Auswahl keinen ausgewählten Wert. Gehört in die Spec von **B11**.
 
 **FB-DM-06 · Kein Migrationspfad für die Einstellungen.** Es gibt keine Schemaversion in
 `UserDefaults`. Das Stack-Profil `swiftui-macos` benennt das ausdrücklich als Risiko:

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -101,8 +101,14 @@ Daraus folgen App-weite Regeln, die in jeder Feature-Spec konkretisiert werden:
 
 - **Kein Bildinhalt geht ins Log.** Weder Pixel, noch erkannter Text, noch Dateinamen
   mit erkennbarem Inhalt. `CaptureLog` protokolliert Fehler, keine Daten.
-- **Kein Bildinhalt verlässt das Gerät.** Nicht an Sparkle, nicht an einen Crash-Melder,
-  nirgendwohin. Jede künftige Funktion, die das bräuchte, hebt Stufe A auf.
+- **Kein Bildinhalt verlässt das Gerät — mit einer Einschränkung, die bei der
+  Rückerfassung gefunden wurde.** Die Anwendung selbst baut außer dem Sparkle-Update-Check
+  keine Verbindung auf. Sie legt jedoch Bilder, erkannten Text und Farbwerte in die
+  allgemeine Zwischenablage, ohne sie als vertraulich zu kennzeichnen. Ist die
+  geräteübergreifende Zwischenablage aktiviert, überträgt **macOS** diese Inhalte an die
+  anderen Geräte des Nutzers. Das ist keine Übertragung der Anwendung, aber eine Folge ihres
+  Verhaltens — und die Zusage muss so genau formuliert bleiben. Fundstellen und
+  Kriterien: B03/AK-33, B05/AK-17, B06/AK-16.
 - **Was der Nutzer unkenntlich macht, bleibt unkenntlich.** Ein verpixelter Bereich darf
   im Export nicht rekonstruierbar sein — und kein Nebenpfad darf das unbearbeitete
   Original ablegen, ohne dass die Person das weiß.
@@ -160,3 +166,12 @@ der Nummer.
 - **OF-04** (2026-08-25) — Es existieren **keine Tests** (`Tests/` fehlt). Für die
   Rückerfassung heißt das: Jedes Akzeptanzkriterium braucht in der QA einen manuellen
   Nachweis oder einen neu geschriebenen Test. Soll `swift test` als Ziel etabliert werden?
+- **OF-05** (2026-08-25, aus der Rückerfassung) — Soll die Zwischenablage als vertraulich
+  gekennzeichnet werden, damit erkannter Text und Screenshots nicht über die
+  geräteübergreifende Zwischenablage weitergereicht werden? Das ist die einzige Stelle, an
+  der Nutzerinhalte den Rechner verlassen können. Betrifft B03, B05 und B06.
+- **OF-06** (2026-08-25, aus der Rückerfassung) — Die Anwendung fordert die
+  Bildschirmaufnahme-Berechtigung nie an (`CGRequestScreenCaptureAccess` kommt nirgends
+  vor), und der Aufruf, der sie in die Systemliste einträgt, läuft beim Erststart nicht.
+  Soll das geändert werden? Betrifft B01, B12 und B15 und ist der wahrscheinlichste Grund
+  für einen misslungenen ersten Start.

--- a/features/B01-bildschirmaufnahme/design.md
+++ b/features/B01-bildschirmaufnahme/design.md
@@ -1,0 +1,161 @@
+# B01 · Bildschirmaufnahme — Systemdesign
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · Stack-Profil: `swiftui-macos`
+
+**Kein Code in diesem Dokument.** Beschrieben ist der Aufbau, wie er ist — nicht, wie er
+sein sollte.
+
+## Überblick
+
+Alle vier Aufnahmearten laufen über eine Klasse, `CaptureEngine`. Sie baut für jede
+Aufnahme einen Inhaltsfilter, in dem steht, was aufgenommen wird und was ausgeschlossen
+bleibt, und übergibt ihn an ScreenCaptureKit. Zwei Arten sind sofortig (Vollbild,
+vorderstes Fenster), zwei brauchen erst eine Auswahl am Bildschirm (Bereich, Fenster) —
+diese legen ein Overlay über jedes Display, warten auf Maus oder `Escape` und nehmen erst
+danach auf.
+
+Alle vier enden an derselben Stelle: einer gemeinsamen Nachbereitung, die den Ton spielt,
+an den Verlauf übergibt und den Editor öffnet. Das ist der einzige Weg nach draußen —
+eine Aufnahme, die diese Stelle nicht erreicht, existiert für den Nutzer nicht.
+
+## Einstiegspunkte
+
+| Auslöser | Weg | Interaktion |
+|---|---|---|
+| `⌃⇧⌘3` · *Capture Full Screen* | Vollbild | keine |
+| `⌃⇧⌘4` · *Capture Area* | Bereichsauswahl | ziehen |
+| *Capture Window…* (nur Menü) | Fensterauswahl | zeigen und klicken |
+| `⌃⇧⌘5` · *Capture Frontmost Window* | vorderstes Fenster | keine |
+
+## Komponentenstruktur
+
+```
+CaptureEngine                          hält alle vier Wege und die Filterlogik
+├── Filterung
+│   ├── excludedWindows(…)             eigene Fenster + Ausschlussliste + Zeiger-Overlay
+│   ├── isPointerOverlay(…)            erkennt den Bedienungshilfen-Zeiger
+│   └── selectableWindows(…)           Ziele der Fensterauswahl, vorne nach hinten
+├── Aufnahme
+│   ├── captureFullScreen()            Filter über Display, ohne Ausschnitt
+│   ├── captureArea(rect:)             Filter über Display, mit Ausschnitt
+│   ├── captureWindow()                sucht das vorderste Fenster und ruft ↓
+│   └── captureWindow(_ window:)       Filter über genau ein Fenster
+├── Auswahl-Oberflächen
+│   ├── AreaSelectionPanel             je Display eines, borderless, .screenSaver
+│   │   └── AreaSelectionView          Verdunkelung, Ausschnitt, Größenanzeige
+│   └── WindowSelectionController      Panels je Display + globaler ESC-Beobachter
+│       ├── WindowTarget               Fenster, Rahmen, Programmname, Symbol
+│       └── WindowSelectionPanel       Hervorhebung des Fensters unter dem Zeiger
+└── postCapture(_:)                    Ton · automatisches Sichern · Editor öffnen
+```
+
+`ScreenGeometry` steht daneben: eine Erweiterung von `NSScreen`, die zwischen AppKit
+(Ursprung unten links) und CoreGraphics (Ursprung oben links) umrechnet — bezogen auf das
+Display, dem der AppKit-Ursprung gehört, ausdrücklich **nicht** auf `NSScreen.main`.
+
+## Datenmodell
+
+Keine Persistenz. Die Aufnahme entsteht als `CGImage`, wird zu `NSImage` und dann
+weitergereicht. Der einzige gehaltene Zustand ist `AppState.lastCapture`.
+
+### `WindowTarget` — flüchtig, nur während der Fensterauswahl
+
+| Feld | Typ | Bedeutung |
+|---|---|---|
+| `scWindow` | `SCWindow` | das Ziel selbst |
+| `globalFrame` | `NSRect` | Rahmen in globalen AppKit-Koordinaten |
+| `appName` | `String` | Anzeigename des Programms |
+| `icon` | `NSImage?` | Programmsymbol, über die Prozess-ID geholt |
+
+Die Umrechnung des Rahmens läuft über `ScreenGeometry` — der Fensterpfad benutzt also,
+was der Bereichspfad ungenutzt lässt (siehe *Erkennbare Entscheidungen*, Zeile 6).
+
+## Zugriffsregeln
+
+Es gibt keine Rollen und keine Datenbank. Die einzige Zugriffsregel ist die
+Systemberechtigung — und die Ausschlussliste, die B02 pflegt und dieses Feature anwendet.
+
+| Wer | Darf aufnehmen | Erzwungen durch |
+|---|---|---|
+| Die Anwendung | alles, was das System freigibt | macOS-Bildschirmaufnahme-Berechtigung, geprüft über `CGPreflightScreenCaptureAccess()` |
+| — | **nicht**: Fenster ausgeschlossener Apps | eigener Filter, bei jedem Aufruf neu gebildet |
+| — | **nicht**: eigene Fenster | Filter über die eigene Prozess-ID |
+| — | **nicht**: Bedienungshilfen-Zeiger | Erkennung über Titel „Cursor", leere Bundle-ID, Ebene > 100 |
+
+Die Berechtigung ist eine Alles-oder-nichts-Entscheidung des Systems: Ohne sie schlägt
+jede Aufnahme fehl, mit ihr ist jeder Bildschirminhalt lesbar. Eine Abstufung sieht macOS
+nicht vor.
+
+## Missbrauchsschutz
+
+| Endpunkt | Limit | Warum |
+|---|---|---|
+| alle vier Aufnahmearten | **keins** | rein lokal, kostet kein Geld, ruft keinen fremden Dienst — Abschnitt 4 des Sicherheitskatalogs trifft nicht zu |
+
+## Externe Dienste
+
+**Keine.** Dieses Feature spricht ausschließlich mit dem Betriebssystem.
+
+## Erkennbare Entscheidungen
+
+Was im Code bewusst gewählt wurde, mit der Alternative, die es gegeben hätte. Wo die
+Begründung nicht rekonstruierbar ist, steht das.
+
+| # | Entscheidung | Alternative | Warum so |
+|---|---|---|---|
+| 1 | ScreenCaptureKit für alles | `CGWindowListCreateImage` | ab macOS 14 der einzige unterstützte Weg; 3.4.1 hat den letzten Rest ersetzt |
+| 2 | Fensterreihenfolge über den Ursprungsindex stabilisiert | nur nach Ebene sortieren | `Array.sorted` ist nicht stabil, und alle normalen Fenster teilen Ebene 0 — ohne den Index wäre die Reihenfolge zufällig |
+| 3 | Ebenen 0–19 als Fensterziele | alle Ebenen | schließt Schreibtisch und Rückwand (stark negativ) ebenso aus wie Dock, Menüleiste (24), Statussymbole (25) und offene Menüs (101) |
+| 4 | Mindestgröße 40 × 40 Punkte | keine Untergrenze | hält Hilfsfenster und Schatten-Fenster aus der Auswahl |
+| 5 | Zeiger-Overlay über drei Merkmale erkannt | nur über die Bundle-ID | 3.4.1: WindowServer meldet mitunter gar kein besitzendes Programm, dann greift die Bundle-ID-Prüfung nicht |
+| 6 | Fensterpfad rechnet über `ScreenGeometry`, Vollbild- und Bereichspfad nicht | überall dieselbe Umrechnung | **Grund nicht erkennbar.** Der Fensterpfad wurde in 3.4.1 überarbeitet, die anderen beiden nicht — das erklärt den Unterschied, rechtfertigt ihn aber nicht (siehe FB-02) |
+| 7 | 100 ms Pause zwischen Auswahl und Aufnahme | auf das Verschwinden der Panels warten | **Grund nicht dokumentiert.** Erkennbar soll das Overlay weg sein, bevor aufgenommen wird; ein fester Wert statt einer Zusicherung |
+| 8 | Fenster werden nicht deckend aufgenommen | wie Vollbild deckend | erhält Transparenz und runde Ecken, statt sie schwarz zu hinterlegen |
+| 9 | Vollbild rechnet die Pixelgröße fest mit Faktor 2 | `pointPixelScale` des Filters | **Grund nicht erkennbar**, vermutlich Annahme „Retina immer" — siehe AK-03 |
+
+## Abdeckung der Akzeptanzkriterien
+
+| AK | Erfüllt durch | Anmerkung |
+|---|---|---|
+| AK-01 | `captureFullScreen` → `postCapture` | |
+| AK-02 ⚠ | `content.displays.first` | keine Displaywahl vorhanden |
+| AK-03 ⚠ | feste Multiplikation mit 2 | falsch bei Skalierung ≠ 2 |
+| AK-04 | `startAreaSelection` über `NSScreen.screens` | ein Panel je Display |
+| AK-05 | `AreaSelectionView.draw` + `drawSizeLabel` | |
+| AK-06 | `AreaSelectionView.keyDown`, Tastencode 53 | |
+| AK-07 | Schwelle > 3 Punkte in `mouseUp` | |
+| AK-08 ⚠ | `captureArea` gegen `displays.first` | Mehrschirm-Fehler |
+| AK-09 ⚠ | `NSScreen.main?.backingScaleFactor` | folgt dem Schlüsselfenster |
+| AK-10 | `WindowSelectionPanel` + `WindowTarget` | |
+| AK-11 | `onSelect` → `captureWindow(_:)` | |
+| AK-12 | globaler ESC-Beobachter, Rechtsklick im Panel | |
+| AK-13 | `captureWindow()` über `frontmostApplication` | |
+| AK-14 | `SCContentFilter.contentRect` + `.pointPixelScale` | in 3.4.1 korrigiert |
+| AK-15 | Titelprüfung entfernt (3.4.1) | |
+| AK-16 | Mindestgröße in `selectableWindows` | |
+| AK-17 | `nonTargetBundleIdentifiers` | |
+| AK-18 | `postCapture` | einziger Ausgang aller vier Wege |
+| AK-19 | `postCapture`, Systemton „Tink" | respektiert `captureSoundEnabled` |
+| AK-20 | `postCapture` → `historyManager.autoSave` | Umsetzung in B09 |
+| AK-21 | `isPointerOverlay` + `showsCursor = false` | |
+| AK-22 | `CaptureLog.report` → `OSLog` + Kurzmeldung | |
+| AK-23 | `CaptureLog.message(for:action:)`, Fehlercode −3801 | |
+| AK-24 | `excludedWindows` in allen vier Wegen | Liste kommt aus B02 |
+| AK-25 | `CaptureLog` protokolliert nur Fehlertexte | keine Bildinhalte |
+| AK-26 | kein Netzwerkaufruf im Feature | belegbar durch Suche nach `URLSession` |
+| AK-27 | Filter über die eigene Prozess-ID | |
+
+Keine Zeile ohne Zuordnung, keine Komponente ohne Kriterium — mit einer Ausnahme:
+`startMeasurement(appState:)` liegt in derselben Datei, gehört aber zu **B07** und
+benutzt seinen Parameter nicht (FB-05).
+
+## Übergabe an die QA
+
+Worauf besonders zu achten ist:
+
+1. **Mehrschirmbetrieb.** AK-02, AK-03, AK-08 und AK-09 sind die vier ⚠-Kriterien und
+   hängen zusammen. Ein zweites Display mit abweichender Skalierung reproduziert alle vier.
+2. **Die Ausschlussliste** (AK-24) muss in **jedem** der vier Wege greifen, nicht nur im
+   geprüften. Sie ist die einzige Datenschutzzusage dieses Features.
+3. **Der Berechtigungsfall** (AK-23, FB-03) — ohne erteilte Berechtigung, aus dem Menü
+   und über jeden der sieben Hotkeys.

--- a/features/B01-bildschirmaufnahme/spec.md
+++ b/features/B01-bildschirmaufnahme/spec.md
@@ -1,0 +1,214 @@
+# B01 · Bildschirmaufnahme — Spezifikation
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+
+> Beschrieben ist, **was Version 3.4.1 tut** — nicht, was sie tun sollte. Kriterien mit ⚠
+> beschreiben Verhalten, das fragwürdig aussieht; sie sind bewusst als Kriterium
+> aufgenommen, damit `sdd-qa` sie reproduziert, und stehen zur Klärung.
+
+## Zweck
+
+Der Nutzer nimmt den Bildschirminhalt auf — ganz, als gezogenen Bereich oder als
+einzelnes Fenster — ohne die Anwendung zu wechseln, in der er gerade arbeitet. Jede
+Aufnahme landet unmittelbar im Annotationseditor.
+
+## Abhängigkeiten
+
+| Braucht | Status | Warum |
+|---|---|---|
+| B02 App-Ausschluss | `bestand` | liefert die Liste der Fenster, die nie erscheinen dürfen |
+| B10 Tastenkombinationen | `bestand` | löst drei der vier Aufnahmearten aus |
+| B12 Ersteinrichtung | `bestand` | führt zur Bildschirmaufnahme-Berechtigung, ohne die nichts geht |
+| B03 Annotationseditor | `bestand` | ist das Ziel jeder Aufnahme |
+| B09 Verlauf | `bestand` | sichert jede Aufnahme automatisch |
+
+## User Stories
+
+- **US-01** · Als Nutzer möchte ich den ganzen Bildschirm aufnehmen, ohne vorher etwas
+  auszuwählen, damit ein Tastendruck genügt.
+- **US-02** · Als Nutzer möchte ich einen Bereich aufziehen und dabei sehen, wie groß er
+  in Pixeln ist, damit ich genau den Ausschnitt bekomme, den ich brauche.
+- **US-03** · Als Nutzer möchte ich ein einzelnes Fenster aufnehmen, ohne den Hintergrund
+  mitzunehmen, damit das Ergebnis ohne Nachbearbeitung brauchbar ist.
+- **US-04** · Als Nutzer möchte ich beim Fenstermodus sehen, welches Fenster ich treffe,
+  bevor ich klicke, damit ich nicht das falsche erwische.
+- **US-05** · Als Nutzer möchte ich erkennen, wenn eine Aufnahme fehlschlägt, damit ich
+  nicht auf ein Bild warte, das nie kommt.
+
+## Nicht im Scope
+
+- Bildschirmvideo und GIF — nicht vorhanden; ob bewusst, ist offen (`docs/prd.md`, OF-01)
+- Zeitverzögerte Aufnahme — nicht vorhanden
+- Scrollende Aufnahme ganzer Seiten — nicht vorhanden
+- Die Ausschlussliste selbst gehört zu **B02**, hier wird sie nur angewandt
+
+## Akzeptanzkriterien
+
+### Vollbild
+
+- **AK-01** · Angenommen, die Bildschirmaufnahme-Berechtigung ist erteilt, wenn `⌃⇧⌘3`
+  gedrückt oder *Capture Full Screen* im Menü gewählt wird, dann wird der Bildschirm ohne
+  weitere Rückfrage aufgenommen und der Annotationseditor öffnet sich mit dem Ergebnis.
+- **AK-02** ⚠ · Angenommen, zwei Displays sind angeschlossen, wenn eine Vollbildaufnahme
+  ausgelöst wird, dann wird **immer das von ScreenCaptureKit zuerst gelieferte Display**
+  aufgenommen — unabhängig davon, wo der Mauszeiger steht oder welches Fenster aktiv ist.
+  *(`CaptureEngine.swift:120` nimmt `content.displays.first`. Es gibt keine Auswahl und
+  keinen Hinweis. Zur Klärung vorgelegt.)*
+- **AK-03** ⚠ · Angenommen, das aufgenommene Display hat keinen Retina-Faktor 2, wenn eine
+  Vollbildaufnahme ausgelöst wird, dann entsteht ein Bild mit der doppelten Pixelzahl der
+  tatsächlichen Auflösung.
+  *(`CaptureEngine.swift:130` multipliziert die Displaygröße fest mit 2, statt
+  `pointPixelScale` des Filters zu benutzen — dieselbe Fehlerklasse, die 3.4.1 für
+  Fensteraufnahmen behoben hat. Zur Klärung vorgelegt.)*
+
+### Bereich
+
+- **AK-04** · Angenommen, `⌃⇧⌘4` wird gedrückt, wenn die Auswahl erscheint, dann liegt
+  über **jedem** angeschlossenen Display eine abgedunkelte Fläche mit Fadenkreuz-Zeiger.
+- **AK-05** · Angenommen, die Bereichsauswahl ist aktiv, wenn mit gedrückter Maustaste
+  gezogen wird, dann ist der gewählte Bereich unverdunkelt, von einer gestrichelten weißen
+  Linie umgeben, und daneben steht laufend die Größe im Format `<Breite> × <Höhe> px`.
+- **AK-06** · Angenommen, die Bereichsauswahl ist aktiv, wenn `Escape` gedrückt wird, dann
+  verschwindet die Auswahl ohne Aufnahme.
+- **AK-07** · Angenommen, die Bereichsauswahl ist aktiv, wenn ein Bereich kleiner als
+  4 × 4 Punkte gezogen wird, dann gilt das als Abbruch und es entsteht keine Aufnahme.
+- **AK-08** ⚠ · Angenommen, zwei Displays sind angeschlossen, wenn ein Bereich auf dem
+  **zweiten** Display gezogen wird, dann entsteht **nicht** der gewählte Ausschnitt: Die
+  Auswahl wird gegen das erste Display gerechnet.
+  *(`CaptureEngine.swift:150-160` filtert auf `displays.first` und rechnet den y-Versatz
+  gegen dessen Höhe, während die Auswahl globale AppKit-Koordinaten über alle Displays
+  liefert. Die Anwendung besitzt in `ScreenGeometry.swift` genau die Umrechnung, die hier
+  fehlt — sie wird an dieser Stelle nicht benutzt. Zur Klärung vorgelegt.)*
+- **AK-09** ⚠ · Angenommen, das Display, auf dem gewählt wurde, hat einen anderen
+  Skalierungsfaktor als das Display mit dem Tastaturfokus, wenn die Aufnahme entsteht,
+  dann hat sie die falsche Auflösung.
+  *(`CaptureEngine.swift:162` benutzt `NSScreen.main?.backingScaleFactor`. `NSScreen.main`
+  folgt dem Schlüsselfenster, nicht der Maus — der Dateikommentar in
+  `ScreenGeometry.swift:12` benennt genau dieses Problem. Zur Klärung vorgelegt.)*
+
+### Fenster
+
+- **AK-10** · Angenommen, mehrere Fenster sind offen, wenn *Capture Window…* im Menü
+  gewählt wird, dann wird das Fenster unter dem Mauszeiger hervorgehoben und mit Symbol,
+  Programmname und Pixelgröße beschriftet.
+- **AK-11** · Angenommen, die Fensterauswahl ist aktiv, wenn auf ein hervorgehobenes
+  Fenster geklickt wird, dann wird genau dieses Fenster aufgenommen — ohne Hintergrund
+  und ohne die Auswahl-Oberfläche.
+- **AK-12** · Angenommen, die Fensterauswahl ist aktiv, wenn `Escape` oder die rechte
+  Maustaste betätigt wird, dann bricht die Auswahl ohne Aufnahme ab.
+- **AK-13** · Angenommen, `⌃⇧⌘5` wird gedrückt, wenn ein anderes Programm im Vordergrund
+  ist, dann wird dessen vorderstes Fenster ohne Rückfrage aufgenommen.
+- **AK-14** · Angenommen, ein Fenster liegt auf einem Display mit anderem
+  Skalierungsfaktor, wenn es aufgenommen wird, dann entspricht die Auflösung dem Display,
+  auf dem es tatsächlich liegt.
+  *(Seit 3.4.1 über `SCContentFilter.contentRect` und `.pointPixelScale` — im Fensterpfad
+  korrekt gelöst, anders als in AK-03 und AK-09.)*
+- **AK-15** · Angenommen, ein Fenster hat keinen Titel, wenn die Fensterauswahl aufgebaut
+  wird, dann erscheint es trotzdem als wählbares Ziel.
+- **AK-16** · Angenommen, ein Fenster ist schmaler oder niedriger als 40 Punkte, wenn die
+  Fensterauswahl aufgebaut wird, dann erscheint es **nicht** als Ziel.
+- **AK-17** · Angenommen, Dock, Stage Manager, Schreibtischhintergrund, Mitteilungszentrale
+  oder Kontrollzentrum sind sichtbar, wenn die Fensterauswahl aufgebaut wird, dann sind sie
+  **keine** wählbaren Ziele.
+
+### Alle Aufnahmearten
+
+- **AK-18** · Angenommen, eine Aufnahme ist entstanden, wenn sie fertig ist, dann öffnet
+  sich der Annotationseditor mit dem Bild — bei jeder Aufnahmeart, ausnahmslos.
+- **AK-19** · Angenommen, der Auslöseton ist aktiviert (Standard), wenn eine Aufnahme
+  entsteht, dann erklingt der Systemton „Tink".
+- **AK-20** · Angenommen, das automatische Sichern ist aktiviert (Standard), wenn eine
+  Aufnahme entsteht, dann liegt sie danach als Datei im eingestellten Ordner.
+- **AK-21** · Angenommen, ein vergrößerter oder eingefärbter Mauszeiger ist in den
+  Bedienungshilfen aktiviert, wenn eine Aufnahme entsteht, dann ist der Zeiger **nicht**
+  im Bild.
+- **AK-22** · Angenommen, die Aufnahme schlägt fehl, wenn der Fehler auftritt, dann
+  erscheint eine Kurzmeldung am Bildschirm und der Fehler steht unter dem Subsystem
+  `com.mika.mikaplusscreensnap` in der Konsole.
+- **AK-23** · Angenommen, die Bildschirmaufnahme-Berechtigung fehlt, wenn eine Aufnahme
+  ausgelöst wird, dann erscheint die Meldung „Screen Recording permission required".
+
+### Datenschutz und Missbrauchsschutz
+
+Katalog: `~/.claude/sdd/sicherheit.md`, Stufe A (`docs/prd.md`) — Abschnitte 4 und 6
+verkürzt, Abschnitt 1 (Logs) ausdrücklich in Kraft.
+
+- **AK-24** · Angenommen, eine App steht auf der Ausschlussliste, wenn eine Aufnahme
+  jedweder Art entsteht, dann ist kein Fenster dieser App darin enthalten.
+- **AK-25** · Angenommen, eine Aufnahme entsteht, wenn sie fertig ist, dann enthalten die
+  Protokolle weder Bildinhalte noch erkannten Text noch den Namen des aufgenommenen
+  Fensters.
+- **AK-26** · Angenommen, eine Aufnahme entsteht, wenn sie fertig ist, dann verlässt kein
+  Byte davon den Rechner.
+- **AK-27** · Angenommen, die Anwendung nimmt auf, wenn die Aufnahme entsteht, dann sind
+  eigene Fenster der Anwendung (Auswahl-Overlays, Editor, Panels) nicht enthalten.
+
+*Zu Abschnitt 4 des Katalogs (Rate Limits): trifft nicht zu — die Aufnahme kostet kein
+Geld, ruft keinen fremden Dienst und ist rein lokal. Zu Abschnitt 6 (Geheimnisse):
+trifft nicht zu — dieses Feature braucht keine Schlüssel.*
+
+## Edge Cases
+
+- **EC-01** · Kein Display gefunden → Meldung „No display available", keine Aufnahme.
+- **EC-02** · Kein aufnehmbares Fenster vorhanden → Meldung „No window to capture".
+- **EC-03** · Fenster mit leerem Inhaltsrechteck → Meldung „Window has no capturable
+  content", keine Aufnahme.
+- **EC-04** · Fenster wird zwischen Auswahl und Klick geschlossen → die Aufnahme schlägt
+  fehl und meldet sich als Kurzmeldung.
+- **EC-05** · Fenster liegt über zwei Displays → wird als **ein** Ziel behandelt und
+  vollständig aufgenommen.
+- **EC-06** · Bereichsauswahl aktiv, während der Bildschirmschoner startet → Panels liegen
+  auf `.screenSaver`-Ebene; Verhalten ungeprüft.
+- **EC-07** · Aufnahme wird ausgelöst, während bereits eine Auswahl läuft → die alte
+  Auswahl wird verworfen (`dismissAreaSelection` bzw. `dismissWindowSelection` zuerst).
+
+## Fehlbestand
+
+Nicht vorhanden, aus dem Code belegt. **Kein Kriterium** — `sdd-qa` prüft nichts davon als
+bestanden, sondern nimmt es als Suchliste.
+
+- **FB-01 · Kein Display-Bezug bei Vollbild und Bereich.** `CaptureEngine.swift:120` und
+  `:150` verwenden `content.displays.first`. Es gibt keinen Weg, ein anderes Display zu
+  wählen, und keinen Hinweis darauf, dass nur eines aufgenommen wird. Folge: Auf
+  Mehrschirm-Arbeitsplätzen nimmt die App regelmäßig den falschen Bildschirm auf, und die
+  Bereichsauswahl liefert einen falschen Ausschnitt (AK-08).
+- **FB-02 · `ScreenGeometry` wird im Aufnahmepfad nicht benutzt.**
+  `ScreenGeometry.swift:11-19` existiert genau für die korrekte Umrechnung über mehrere
+  Displays und warnt im Kommentar ausdrücklich vor `NSScreen.main`.
+  `CaptureEngine.swift:162` und `:335` benutzen trotzdem
+  `NSScreen.main?.backingScaleFactor`. Folge: Die vorhandene Lösung greift an der Stelle
+  nicht, für die sie geschrieben wurde.
+- **FB-03 · Erkennt keine fehlende Berechtigung, bevor es zu spät ist.** Die
+  Aufnahmebefehle sind auch ohne Berechtigung auslösbar; der Fehlschlag wird erst danach
+  gemeldet. `MikaScreenSnapApp.swift:159` zeigt zwar einen Warneintrag im Menü, blockiert
+  aber nichts. Folge: Der Weg zur Berechtigung führt durch einen misslungenen Versuch.
+- **FB-04 · Keine Tests.** Es existiert kein `Tests/`-Verzeichnis. Die Koordinaten- und
+  Skalierungslogik in `CaptureEngine` und `ScreenGeometry` ist reine Rechnung ohne UI und
+  damit gut testbar — geprüft wird sie nirgends. Folge: Genau die Fehlerklasse, die 3.4.1
+  im Fensterpfad behoben hat, ist im Bereichs- und Vollbildpfad unbemerkt geblieben.
+- **FB-05 · `startMeasurement(appState:)` ignoriert seinen Parameter.**
+  `CaptureEngine.swift:395` nimmt `appState` entgegen und benutzt es nicht. Folge: keine
+  unmittelbare, aber die Ausschlussliste greift dadurch in B07 nicht.
+
+## Offene Fragen
+
+- **OF-01** · Soll die Vollbildaufnahme das Display unter dem Mauszeiger nehmen, alle
+  Displays zu einem Bild verbinden, oder weiterhin nur das erste? — entscheidet der Autor.
+- **OF-02** · Soll die Bereichsauswahl über Displaygrenzen hinweg funktionieren, oder
+  reicht es, sie auf das Display zu beschränken, auf dem gezogen wurde? — entscheidet der
+  Autor.
+- **OF-03** · Sollen Aufnahmebefehle bei fehlender Berechtigung deaktiviert sein, statt
+  fehlzuschlagen? — entscheidet der Autor, betrifft auch B12.
+
+## Decision Log
+
+Rekonstruiert aus Code und `CHANGELOG.md`; wo die Absicht nicht belegbar ist, steht das so.
+
+| # | Frage | Entscheidung | Begründung |
+|---|---|---|---|
+| 1 | Wie wird aufgenommen? | ScreenCaptureKit statt `CGWindowListCreateImage` | 3.4.1 hat den letzten Rest der veralteten API ersetzt; SCK ist ab macOS 14 der einzige unterstützte Weg |
+| 2 | Wie wird das vorderste Fenster gefunden? | `NSWorkspace.frontmostApplication`, sonst das vorderste der Liste | Die App aktiviert sich nie (`.accessory`), also bleibt beim Hotkey die vorherige App vorn |
+| 3 | Welche Fenster sind Ziele? | Ebenen 0–19, mindestens 40 × 40 Punkte, ohne Dock/Stage Manager/Wallpaper | 3.4.1 hat den vorherigen Filter ersetzt, der die hinterste statt der vordersten Ebene wählte und titellose Fenster ausschloss |
+| 4 | Wie wird der Zeiger unterdrückt? | `showsCursor = false` plus eigene Erkennung des „Cursor"-Fensters | `showsCursor` unterdrückt nur den Hardware-Zeiger; Bedienungshilfen-Zeiger sind gewöhnliche Fenster |
+| 5 | Warum 100 ms Verzögerung vor der Aufnahme? | fest verdrahtete Pause nach dem Schließen der Overlays | Grund nicht dokumentiert, erkennbar: die eigenen Panels sollen verschwunden sein, bevor aufgenommen wird |
+| 6 | Warum `shouldBeOpaque = false` nur bei Fenstern? | Fenster behalten ihre Transparenz, Vollbild und Bereich nicht | Erkennbar bewusst: ein Fenster mit runden Ecken soll keinen schwarzen Rand bekommen |

--- a/features/B02-app-ausschluss/design.md
+++ b/features/B02-app-ausschluss/design.md
@@ -1,0 +1,117 @@
+# B02 · App-Ausschluss von Aufnahmen — Systemdesign
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · Stack-Profil: `swiftui-macos`
+
+**Kein Code in diesem Dokument.**
+
+## Überblick
+
+Der Nutzer wählt in den Einstellungen Programme aus einer Liste. Gespeichert werden nur
+deren Bundle-Kennungen, als Menge in den Benutzereinstellungen. Bei **jeder** Aufnahme
+baut B01 daraus die Liste der Fenster, die ScreenCaptureKit auslassen soll — die Prüfung
+findet also zum Aufnahmezeitpunkt statt, nicht beim Speichern.
+
+Die Liste der auswählbaren Programme wird bei jedem Öffnen frisch von ScreenCaptureKit
+geholt und mit der bestehenden Auswahl zusammengeführt, damit ein ausgewähltes, aber
+gerade nicht laufendes Programm nicht verschwindet.
+
+## Komponentenstruktur
+
+```
+GeneralTabView
+└── ExcludedAppsSection              Abschnitt „Privacy"
+    ├── Zusammenfassung              „None" · „1 app" · „<n> apps"
+    ├── Schaltfläche „Choose…"
+    └── ExcludedAppsPicker           als Blatt (sheet), 420 × 400
+        ├── ExcludedAppsManager      lädt und mischt die Programmliste
+        ├── Liste mit Schaltern      Name + Bundle-Kennung je Zeile
+        ├── „Refresh"                lädt die Liste neu
+        └── „Done"                   schließt; gespeichert wird laufend
+```
+
+Angewandt wird die Liste außerhalb dieses Baums, in `CaptureEngine.excludedWindows` —
+dort, wo B01, B05 und B06 ihre Filter bauen.
+
+## Datenmodell
+
+### Gespeichert
+
+| Schlüssel | Typ | Standard | Bedeutung |
+|---|---|---|---|
+| `excludedBundleIdentifiers` | `[String]` in den Benutzereinstellungen, im Speicher `Set<String>` | drei Bedienungshilfen-Dienste | Programme, die in keiner Aufnahme erscheinen |
+
+Standardwerte: `com.apple.inputmethod.AssistiveControl` (Bedienungshilfen-Tastatur),
+`com.apple.DwellControl` (Verweilsteuerung), `com.apple.AccessibilityVisualsAgent`
+(Zoom-Darstellung).
+
+**Wichtig:** Nur ein *fehlender* Schlüssel fällt auf die Standardwerte zurück. Eine
+ausdrücklich geleerte Liste bleibt leer.
+
+### Flüchtig
+
+`CapturableApp` — Bundle-Kennung (zugleich Identität) und Anzeigename. Existiert nur,
+solange die Auswahl offen ist.
+
+## Zugriffsregeln
+
+| Wer | Darf lesen | Darf schreiben | Erzwungen durch |
+|---|---|---|---|
+| Der Nutzer | die Liste laufender Programme | seine Auswahl | Systemberechtigung Bildschirmaufnahme |
+| B01, B05, B06 | die Auswahl | — | lesen sie bei jeder Aufnahme neu |
+
+Die Regel wirkt **nicht** in der Anwendung, sondern in ScreenCaptureKit: Die Fenster
+werden dem Systemdienst als Ausschlussliste übergeben, bevor das Bild entsteht. Damit
+existiert der ausgeschlossene Inhalt zu keinem Zeitpunkt im Prozess der Anwendung — das
+ist deutlich stärker als nachträgliches Übermalen.
+
+## Missbrauchsschutz
+
+Nicht anwendbar — kein Endpunkt, keine Kosten, keine Netzwerkaufrufe.
+
+## Externe Dienste
+
+Keine.
+
+## Erkennbare Entscheidungen
+
+| # | Entscheidung | Alternative | Warum so |
+|---|---|---|---|
+| 1 | Ausschluss über die ScreenCaptureKit-Filterliste | nachträgliches Schwärzen im Bild | der Inhalt entsteht gar nicht erst — ein Fehler beim Schwärzen wäre ein Datenleck, ein Fehler beim Filtern nur ein fehlendes Fenster |
+| 2 | Bundle-Kennung als Schlüssel | Fenster-ID oder Prozess-ID | beide wechseln bei jedem Programmstart |
+| 3 | Menge statt Liste | Array | Reihenfolge bedeutungslos, Doppelte unmöglich |
+| 4 | Geleerte Liste bleibt leer | immer auf Standard zurückfallen | ausdrücklich kommentiert — sonst käme jeder entfernte Eintrag beim Neustart zurück |
+| 5 | Liste bei jedem Öffnen neu laden | einmal beim Start | laufende Programme ändern sich ständig |
+| 6 | Auswahl ohne Bestätigungsschritt | „Übernehmen"-Schaltfläche | folgt dem Muster der übrigen Einstellungen |
+| 7 | Auswahl beschränkt auf laufende Programme | Auswahl aus `/Applications` | **Grund nicht erkennbar** — siehe FB-01 |
+
+## Abdeckung der Akzeptanzkriterien
+
+| AK | Erfüllt durch | Anmerkung |
+|---|---|---|
+| AK-01 | `ExcludedAppsPicker` + `ExcludedAppsManager.refresh` | Sortierung über `localizedStandardCompare` |
+| AK-02 | Bindung schreibt direkt in die Einstellungen | |
+| AK-03 | `CaptureEngine.excludedWindows` in allen vier Aufnahmewegen | Umsetzung in B01 |
+| AK-04 | derselbe Aufruf in `startColorPicker` und `captureAreaForOCR` | Umsetzung in B05, B06 |
+| AK-05 | `excludedSummary` | |
+| AK-06 | `defaultExcludedBundleIdentifiers` | |
+| AK-07 | Rückfall nur bei fehlendem Schlüssel | |
+| AK-08 | Einmischen bereits ausgewählter Kennungen in `refresh` | |
+| AK-09 | Leerzustand des Pickers | greift, wenn `SCShareableContent` fehlschlägt |
+| AK-10 ⚠ | Liste stammt aus laufenden Programmen | siehe FB-01 |
+| AK-11 ⚠ | — | **keine Komponente**: es gibt keine Rückmeldung |
+| AK-12 | gespeichert wird nur die Kennung | |
+| AK-13 | kein Protokollaufruf im Feature | |
+| AK-14 | `resetAll()` entfernt den Schlüssel, danach greifen die Standardwerte | |
+
+AK-11 hat bewusst keine Zuordnung: Das Kriterium beschreibt, dass etwas **nicht**
+existiert. Es steht hier, damit die QA es nicht als erfüllt durchwinkt.
+
+## Übergabe an die QA
+
+1. **AK-03 und AK-04 sind der Kern.** Sie müssen in allen vier Aufnahmewegen **und** in
+   Pipette und Texterkennung geprüft werden — es genügt nicht, einen zu prüfen. Ein
+   ausgeschlossenes Fenster, das im OCR-Pfad doch erscheint, ist ein Datenleck.
+2. **AK-07** ist leicht zu übersehen und leicht zu brechen: Liste leeren, Anwendung neu
+   starten, prüfen dass sie leer bleibt.
+3. **FB-03** — ein Fenster ohne besitzendes Programm über die Liste auszuschließen ist
+   nicht möglich. Ob das in der Praxis vorkommt, sollte die QA feststellen.

--- a/features/B02-app-ausschluss/spec.md
+++ b/features/B02-app-ausschluss/spec.md
@@ -1,0 +1,133 @@
+# B02 · App-Ausschluss von Aufnahmen — Spezifikation
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+
+> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ beschreiben Verhalten, das
+> fragwürdig aussieht, und stehen zur Klärung.
+
+## Zweck
+
+Der Nutzer benennt Programme, deren Fenster in keiner Aufnahme erscheinen — die
+Bildschirmtastatur, ein Passwortmanager, ein Chatfenster. Was einmal ausgeschlossen ist,
+bleibt es, ohne dass vor jeder Aufnahme daran gedacht werden muss.
+
+Dies ist die **einzige Zugriffsregel der gesamten Anwendung**. Alles andere ist
+Darstellung oder Verarbeitung; hier entscheidet der Nutzer, was die App nicht sehen darf.
+
+## Abhängigkeiten
+
+| Braucht | Status | Warum |
+|---|---|---|
+| B01 Bildschirmaufnahme | `bestand` | wendet die Liste an — ohne B01 wirkt sie nirgends |
+| B11 Einstellungen | `bestand` | beherbergt die Auswahl im Reiter *General* |
+
+## User Stories
+
+- **US-01** · Als Nutzer möchte ich Programme dauerhaft von Aufnahmen ausschließen, damit
+  ich nicht bei jedem Screenshot daran denken muss.
+- **US-02** · Als Nutzer möchte ich sehen, wie viele Programme ausgeschlossen sind, ohne
+  die Liste zu öffnen.
+- **US-03** · Als Nutzer möchte ich, dass Bedienungshilfen-Überlagerungen von vornherein
+  ausgeschlossen sind, damit ich es nicht selbst herausfinden muss.
+
+## Nicht im Scope
+
+- Ausschluss einzelner Fenster statt ganzer Programme — nicht vorhanden
+- Zeitgesteuerter oder bedingter Ausschluss — nicht vorhanden
+- Die Anwendung ihrer Liste gehört zu **B01**, hier wird sie nur gepflegt
+
+## Akzeptanzkriterien
+
+- **AK-01** · Angenommen, die Einstellungen sind offen, wenn im Reiter *General* unter
+  *Privacy* auf *Choose…* geklickt wird, dann erscheint eine Liste der aufnehmbaren
+  Programme mit Namen und Bundle-Kennung, alphabetisch sortiert.
+- **AK-02** · Angenommen, die Liste ist offen, wenn ein Programm eingeschaltet wird, dann
+  ist die Auswahl sofort gespeichert — ohne Bestätigungsschritt.
+- **AK-03** · Angenommen, ein Programm ist ausgeschlossen, wenn eine Aufnahme jedweder Art
+  entsteht, dann ist kein Fenster dieses Programms darin enthalten.
+- **AK-04** · Angenommen, ein Programm ist ausgeschlossen, wenn die Farbpipette oder die
+  Texterkennung benutzt wird, dann ist dieses Programm auch dort nicht sichtbar.
+- **AK-05** · Angenommen, Programme sind ausgeschlossen, wenn die Einstellungen geöffnet
+  werden, dann steht neben *Exclude apps from capture* deren Anzahl („None", „1 app",
+  „<n> apps").
+- **AK-06** · Angenommen, die Anwendung wird zum ersten Mal gestartet, wenn die
+  Ausschlussliste gelesen wird, dann sind die Bedienungshilfen-Tastatur, die
+  Verweilsteuerung und der Zoom-Darstellungsdienst bereits ausgeschlossen.
+- **AK-07** · Angenommen, der Nutzer entfernt **alle** Einträge aus der Liste, wenn die
+  Anwendung neu startet, dann bleibt die Liste leer — die Standardwerte kehren nicht
+  zurück.
+- **AK-08** · Angenommen, ein ausgeschlossenes Programm läuft gerade nicht, wenn die Liste
+  geöffnet wird, dann erscheint es trotzdem und bleibt ausgewählt.
+- **AK-09** · Angenommen, die Bildschirmaufnahme-Berechtigung fehlt, wenn die Liste
+  geöffnet wird, dann erscheint der Hinweis „No capturable apps found. Grant Screen
+  Recording permission and try again."
+- **AK-10** ⚠ · Angenommen, ein Programm läuft nicht und stand nie auf der Liste, wenn die
+  Auswahl geöffnet wird, dann ist es **nicht auswählbar**.
+  *(`ExcludedAppsManager.swift:33` baut die Liste aus `SCShareableContent.current`, also
+  aus laufenden Programmen. Ein Passwortmanager lässt sich nicht vorbeugend ausschließen,
+  solange er geschlossen ist. Zur Klärung vorgelegt.)*
+- **AK-11** ⚠ · Angenommen, die Auswahl wird geändert, wenn danach eine Aufnahme entsteht,
+  dann gibt es **keine Rückmeldung darüber, dass der Ausschluss gegriffen hat**.
+  *(Der Nutzer sieht nur das fertige Bild. Ob ein Fenster fehlt, weil es ausgeschlossen war
+  oder weil es nicht offen war, ist nicht unterscheidbar. Zur Klärung vorgelegt.)*
+
+### Datenschutz und Missbrauchsschutz
+
+Stufe A, Abschnitt 1 des Katalogs ausdrücklich in Kraft.
+
+- **AK-12** · Angenommen, die Ausschlussliste wird geändert, wenn gespeichert wird, dann
+  enthält sie ausschließlich Bundle-Kennungen — keine Fenstertitel, keine Inhalte.
+- **AK-13** · Angenommen, die Liste wird aufgebaut, wenn die laufenden Programme gelesen
+  werden, dann landet nichts davon in einem Protokoll.
+- **AK-14** · Angenommen, *Reset All Preferences* wird ausgeführt, wenn die Anwendung
+  danach liest, dann steht die Ausschlussliste wieder auf den drei Standardwerten.
+
+*Abschnitt 4 (Rate Limits) und Abschnitt 6 (Geheimnisse): treffen nicht zu — keine
+Kosten, kein fremder Dienst, keine Schlüssel.*
+
+## Edge Cases
+
+- **EC-01** · Programm ohne Bundle-Kennung oder ohne Namen → erscheint nicht in der Liste.
+- **EC-02** · Die Anwendung selbst → erscheint nie in der Liste (eigene Prozess-ID gefiltert).
+- **EC-03** · Ausgeschlossenes Programm startet nach dem Öffnen der Liste → erscheint erst
+  nach *Refresh*.
+- **EC-04** · Ausgeschlossenes Programm wird deinstalliert → bleibt als Bundle-Kennung in
+  der Liste, der Name fällt auf die Kennung zurück.
+- **EC-05** · Fenster ohne besitzendes Programm (WindowServer) → vom Ausschluss **nicht**
+  erfasst; nur die gesonderte Zeiger-Erkennung in B01 greift.
+
+## Fehlbestand
+
+- **FB-01 · Nur laufende Programme sind auswählbar.**
+  `ExcludedAppsManager.swift:33` liest `SCShareableContent.current`. Folge: Vorbeugender
+  Ausschluss ist unmöglich — genau bei einem Passwortmanager, den man selten offen hat,
+  ist das die falsche Einschränkung. Ein Auswahldialog über `/Applications` gibt es nicht.
+- **FB-02 · Der Ausschluss ist nicht nachprüfbar.** Es gibt keine Anzeige, keine Markierung
+  am Ergebnis und keinen Testweg. Folge: Eine Zusage, auf die sich der Nutzer verlässt,
+  ohne sie überprüfen zu können — und ohne Tests (siehe FB-04) auch ohne automatischen
+  Nachweis.
+- **FB-03 · Der Ausschluss greift nicht bei Fenstern ohne besitzendes Programm.**
+  `CaptureEngine.swift:19` bricht mit `guard let app = window.owningApplication` ab.
+  Folge: Systemüberlagerungen, die WindowServer ohne Programmbezug zeichnet, sind über
+  diese Liste nicht ausschließbar. Für den Zeiger gibt es eine Sonderbehandlung, für alles
+  Übrige nicht.
+- **FB-04 · Keine Tests.** Die Filterlogik ist reine Mengenoperation und damit gut prüfbar;
+  geprüft wird sie nicht. Folge: Die einzige Zugriffsregel der Anwendung hat keinen
+  automatischen Nachweis.
+
+## Offene Fragen
+
+- **OF-01** · Soll ein Programm auch dann ausschließbar sein, wenn es nicht läuft? —
+  entscheidet der Autor.
+- **OF-02** · Soll die Anwendung sichtbar machen, dass ein Ausschluss gegriffen hat? —
+  entscheidet der Autor.
+
+## Decision Log
+
+| # | Frage | Entscheidung | Begründung |
+|---|---|---|---|
+| 1 | Ausschluss nach Programm oder Fenster? | nach Programm (Bundle-Kennung) | überlebt Neustarts des Programms; Fenster-IDs tun das nicht |
+| 2 | Was ist voreingestellt? | drei Bedienungshilfen-Dienste | sie liegen über allem und landeten sonst in jeder Aufnahme |
+| 3 | Was passiert bei einer leer geräumten Liste? | sie bleibt leer | ausdrücklich im Code vermerkt: nur ein **fehlender** Schlüssel fällt auf die Standardwerte zurück — sonst käme das Weggenommene bei jedem Start zurück |
+| 4 | Woher kommt die Auswahlliste? | aus den laufenden Programmen | **Grund nicht erkennbar**; naheliegend ist, dass ScreenCaptureKit ohnehin gefragt werden muss (siehe FB-01) |
+| 5 | Wie wird eine nicht laufende Auswahl dargestellt? | eingemischt, Name über `NSWorkspace` | ausdrücklich kommentiert: eine bestehende Auswahl soll nicht unbemerkt aus der Liste fallen |

--- a/features/B03-anmerkungs-editor/design.md
+++ b/features/B03-anmerkungs-editor/design.md
@@ -1,0 +1,142 @@
+# B03 · Anmerkungs-Editor — Systemdesign
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · Stack-Profil: `swiftui-macos`
+
+**Kein Code in diesem Dokument.**
+
+## Überblick
+
+Der Editor besteht aus drei Teilen: zwei SwiftUI-Leisten (oben, unten) und dazwischen einer
+AppKit-Zeichenfläche. Die Zeichenfläche ist der Kern; sie hält eine affine Abbildung
+zwischen **Bildpixeln** und **Ansichtspunkten** und rechnet jedes Mausereignis in
+Bildkoordinaten um, bevor es an das aktive Werkzeug geht.
+
+Daraus folgt die zentrale Eigenschaft: **Werkzeuge und Anmerkungen kennen nur Bildpixel.**
+Vergrößerung und Verschiebung sind allein Sache der Abbildung — ein Werkzeug muss davon
+nichts wissen.
+
+Anmerkungen zeichnen sich selbst. Der Renderer legt das Originalbild an und lässt jede
+Anmerkung nach Reihenfolge darüberzeichnen; dieselbe Vorschrift gilt für die Bildschirm-
+darstellung und den Export, weshalb beide zwangsläufig übereinstimmen.
+
+## Komponentenstruktur
+
+```
+AnnotationEditorWindowController      .titled .closable .resizable .miniaturizable
+├── AnnotationToolbar (SwiftUI)       Werkzeuge · 6 Farben + freie Wahl · 3 Stärken
+│                                     · Extract Text (B05) · Pin (B08)
+├── AnnotationCanvasView (AppKit)     der Kern
+│   ├── tools[DrawingToolType]        11 Werkzeuge, in setupTools() angemeldet
+│   ├── imageTransform                Bildpixel ↔ Ansichtspunkte
+│   ├── viewToImage / imageToView     Umrechnung je Ereignis
+│   ├── Beobachter für die Leertaste  Verschiebemodus
+│   ├── Schachbrett                   hinter transparenten Bildern
+│   └── draw(_:)                      Bild · Anmerkungen (nach zIndex) · Werkzeugvorschau
+├── AnnotationBottomBar (SwiftUI)     Zoomstufe · Bildmaße · Kopieren/Sichern/Anheften
+└── Tastaturbeobachter                Kürzel, sofern kein Textfeld aktiv ist
+
+AnnotationStore                       Anmerkungen · Auswahl · Farbe · Stärke · Zoom
+                                      · Verschiebung · UndoManager
+AnnotationRenderer                    flaches Rendern in voller Auflösung
+```
+
+Die elf Werkzeuge erfüllen dasselbe Protokoll: Maus gedrückt, gezogen, losgelassen, plus
+eine Vorschau. Die Zeichenfläche verteilt nur; sie kennt kein Werkzeug im Einzelnen.
+
+## Datenmodell
+
+Ausführlich in `docs/datenmodell.md`, Abschnitt 3. Kurz:
+
+`AnnotationStore` hält Anmerkungen, Auswahl, aktuelle Farbe und Stärke, aktives Werkzeug,
+Vergrößerung, Verschiebung, einen Änderungsvermerk und den Rückgängig-Verwalter.
+**Nichts davon wird gespeichert.**
+
+Neun Anmerkungsarten erfüllen ein gemeinsames Protokoll mit Identität, Art, Umriss, Farbe,
+Strichstärke, Auswahlzustand und Reihenfolge, dazu Treffertest, Zeichnen, Verschieben,
+Skalieren sowie Momentaufnahme und Wiederherstellung für das Rückgängigmachen.
+
+## Zugriffsregeln
+
+Keine Rollen. Bemerkenswert ist allein der Umgang mit dem Bild:
+
+| Zustand | Wo liegt das Bild |
+|---|---|
+| während der Bearbeitung | im Arbeitsspeicher, unverändert; Anmerkungen liegen daneben |
+| beim Export | einmalig flach gerendert, das Ergebnis geht nach draußen |
+| nach dem Schließen | Anmerkungen verworfen; die Originaldatei aus B09 bleibt |
+
+## Missbrauchsschutz
+
+Nicht anwendbar — keine Endpunkte, keine Kosten.
+
+## Externe Dienste
+
+Keine. Mittelbar berührt: die geräteübergreifende Zwischenablage des Systems (AK-33).
+
+## Erkennbare Entscheidungen
+
+| # | Entscheidung | Alternative | Warum so |
+|---|---|---|---|
+| 1 | Werkzeuge arbeiten in Bildpixeln | in Ansichtspunkten | Anmerkungen bleiben bei jeder Vergrößerung an Ort und Stelle; die Umrechnung liegt an einer Stelle |
+| 2 | Anmerkungen zeichnen sich selbst | ein Renderer mit Fallunterscheidung | Bildschirm und Export benutzen zwangsläufig dieselbe Vorschrift |
+| 3 | Reihenfolge über `zIndex`, stabil sortiert | Reihenfolge im Feld | gleiche Werte behalten die Einfügereihenfolge |
+| 4 | Zeichenfläche in AppKit, Leisten in SwiftUI | alles in SwiftUI | Mausereignisse und Zeichenkontext sind in AppKit unmittelbar zugänglich |
+| 5 | Eigener Beobachter für die Leertaste | `flagsChanged` | ausdrücklich kommentiert: `flagsChanged` meldet die Leertaste nicht |
+| 6 | Tastaturkürzel werden bei aktivem Textfeld nicht abgefangen | immer abfangen | sonst ließe sich der Buchstabe „b" nicht tippen |
+| 7 | Editor schließt nach Kopieren und Sichern | offen lassen | der Editor ist ein Durchgangsschritt |
+| 8 | `⌘S` sichert auf den Schreibtisch und kopiert zusätzlich | in den eingestellten Ordner sichern | **Grund nicht erkennbar** (FB-02, FB-03) |
+| 9 | Export immer PNG | Format aus den Einstellungen | **Grund nicht erkennbar** (FB-02) |
+
+## Abdeckung der Akzeptanzkriterien
+
+| AK | Erfüllt durch | Anmerkung |
+|---|---|---|
+| AK-01 | Fenstergröße aus dem Bild, auf 80 % begrenzt | |
+| AK-02 | Toolbar · Canvas · BottomBar | |
+| AK-03 | Übernahme der Standardwerte beim Aufbau | Umsetzung in B11 |
+| AK-04 | Rückschreiben beim Schließen, sofern eingeschaltet | |
+| AK-05 | Zuordnungstabelle im Tastaturbeobachter | 11 Werkzeuge |
+| AK-06 | Werkzeugvorschau + Anlegen beim Loslassen | |
+| AK-07 | Winkelraster in Pfeil- und Linienwerkzeug | |
+| AK-08 | Umschalt-Zwang in Rechteck und Ellipse | |
+| AK-09 | Catmull-Rom-Glättung im Freihandwerkzeug | |
+| AK-10 | Textwerkzeug + eingebettetes Textfeld | |
+| AK-11 | Sonderbehandlung, wenn ein Textfeld aktiv ist | |
+| AK-12 | dieselbe Sonderbehandlung | |
+| AK-13 | sechs Systemfarben + freie Wahl | siehe `docs/design-system.md` |
+| AK-14 | drei Stärken (2/4/6) | |
+| AK-15 | Auswahlwerkzeug mit acht Griffen | |
+| AK-16 | `moved(by:)` und `resized(from:to:)` je Anmerkung | |
+| AK-17 | Tastencodes 51 und 117 | |
+| AK-18 | `UndoManager` mit Momentaufnahmen | |
+| AK-19 | Sortierung nach `zIndex` | |
+| AK-20 | `zoomIn` · `zoomOut` · `zoomToFit` | |
+| AK-21 | Aufziehgeste auf der Zeichenfläche | |
+| AK-22 | Leertastenbeobachter + Verschiebemodus | |
+| AK-23 | `viewToImage` je Ereignis | **das tragende Kriterium des Features** |
+| AK-24 | Schachbrett hinter dem Bild | |
+| AK-25 | `renderFinalImage` → Zwischenablage → schließen | |
+| AK-26 ⚠ | `save()` — Schreibtisch **und** Zwischenablage | |
+| AK-27 ⚠ | `saveToFile` schreibt immer PNG | |
+| AK-28 | `NSSavePanel` | |
+| AK-29 | Schnellweg bei leerem Anmerkungsstand | |
+| AK-30 | Rückfrage bei ungesicherten Änderungen | |
+| AK-31 ⚠ | Zeitstempel auf die Sekunde | |
+| AK-32 | flaches Rendern | |
+| AK-33 ⚠ | allgemeine Zwischenablage ohne Markierung | ganzes Bild |
+| AK-34 ⚠ | `print()` + bedingungsloses Schließen | stiller Datenverlust |
+| AK-35 | kein Speicherpfad für Anmerkungen | bewusst (FB-01) |
+
+## Übergabe an die QA
+
+1. **AK-34 zuerst** — es ist der einzige Punkt in diesem Feature, der Daten verliert:
+   Zielordner unzugänglich machen (etwa den Schreibtisch schreibgeschützt), `⌘S` drücken,
+   beobachten. Erwartung nach Aktenlage: Der Editor schließt sich, die Datei existiert
+   nicht, es erscheint keine Meldung.
+2. **AK-23 systematisch prüfen.** Bei dreifacher Vergrößerung und verschobenem Ausschnitt
+   eine Anmerkung setzen, dann exportieren und die Position im Ergebnis vergleichen. Ohne
+   Tests (FB-08) ist das der einzige Nachweis für die Umrechnung, an der alles hängt.
+3. **AK-26, AK-27 und AK-31** beschreiben zusammen, dass das Sichern im Editor anderen
+   Regeln folgt als das automatische Sichern. Zu klären ist, ob das gewollt ist.
+4. **AK-33** gemeinsam mit B05/AK-17 prüfen — hier geht das vollständige Bild über den
+   Systemdienst hinaus.

--- a/features/B03-anmerkungs-editor/spec.md
+++ b/features/B03-anmerkungs-editor/spec.md
@@ -1,0 +1,212 @@
+# B03 · Anmerkungs-Editor — Spezifikation
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+
+> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+>
+> Zensieren (Weichzeichnen, Verpixeln) ist als **B04** gesondert erfasst, das Lineal als
+> **B07**. Hier stehen der Rahmen, die neun übrigen Werkzeuge, Zoom, Auswahl und Ausgabe.
+
+## Zweck
+
+Nach jeder Aufnahme öffnet sich ein Fenster, in dem der Nutzer das Bild beschriften kann —
+Pfeile, Rahmen, Text, Hervorhebungen — und aus dem heraus er es kopiert, sichert oder
+anheftet. Der Editor ist der Weg jeder Aufnahme nach draußen.
+
+## Abhängigkeiten
+
+| Braucht | Status | Warum |
+|---|---|---|
+| B01 Bildschirmaufnahme | `bestand` | liefert das Bild und öffnet den Editor |
+| B04 Zensieren | `bestand` | zwei der elf Werkzeuge |
+| B07 Lineal | `bestand` | ein weiteres Werkzeug |
+| B05 Texterkennung | `bestand` | Schaltfläche *Extract Text* |
+| B08 Anheften | `bestand` | Schaltfläche *Pin* |
+| B09 Verlauf | `bestand` | zweiter Einstiegsweg über *Open in Editor* |
+| B11 Einstellungen | `bestand` | Standardwerkzeug, -farbe, -strichstärke |
+
+## User Stories
+
+- **US-01** · Als Nutzer möchte ich direkt nach der Aufnahme zeichnen können, ohne eine
+  zweite Anwendung zu öffnen.
+- **US-02** · Als Nutzer möchte ich Gezeichnetes nachträglich auswählen, verschieben,
+  skalieren und löschen.
+- US-03 · Als Nutzer möchte ich jeden Schritt rückgängig machen können.
+- **US-04** · Als Nutzer möchte ich in ein Bild hineinzoomen, um genau zu treffen.
+- **US-05** · Als Nutzer möchte ich das Ergebnis mit einem Tastendruck in der
+  Zwischenablage haben.
+
+## Nicht im Scope
+
+- Ebenen, Gruppierung, Ausrichtungshilfen — nicht vorhanden
+- Speichern eines bearbeitbaren Projektstands — nicht vorhanden, siehe FB-01
+- Zuschneiden oder Drehen des Bildes — nicht vorhanden
+- Farbkorrektur, Filter — nicht vorhanden
+
+## Akzeptanzkriterien
+
+### Rahmen
+
+- **AK-01** · Angenommen, eine Aufnahme ist entstanden, wenn sie fertig ist, dann öffnet
+  sich der Editor mit dem Bild, höchstens 80 % der Bildschirmgröße einnehmend.
+- **AK-02** · Angenommen, der Editor ist offen, wenn er angezeigt wird, dann liegt oben eine
+  Werkzeugleiste, in der Mitte die Zeichenfläche und unten eine Leiste mit Zoomstufe,
+  Bildmaßen und Ausgabeschaltflächen.
+- **AK-03** · Angenommen, der Editor öffnet sich, wenn Standardwerte eingestellt sind, dann
+  sind Werkzeug, Farbe und Strichstärke daraus übernommen.
+- **AK-04** · Angenommen, *Remember last tool* ist eingeschaltet (Standard), wenn der Editor
+  geschlossen wird, dann wird das zuletzt benutzte Werkzeug zum neuen Standard.
+
+### Werkzeuge
+
+- **AK-05** · Angenommen, der Editor ist offen, wenn eine der Tasten `V A R E L F T H B X M`
+  gedrückt wird, dann wechselt das Werkzeug entsprechend (Auswahl, Pfeil, Rechteck, Ellipse,
+  Linie, Freihand, Text, Hervorheben, Weichzeichnen, Verpixeln, Messen).
+- **AK-06** · Angenommen, ein Zeichenwerkzeug ist aktiv, wenn gezogen wird, dann erscheint
+  während des Ziehens eine Vorschau und beim Loslassen die fertige Anmerkung.
+- **AK-07** · Angenommen, Pfeil oder Linie sind aktiv, wenn mit gedrückter Umschalttaste
+  gezogen wird, dann rastet der Winkel in 45-Grad-Schritten ein.
+- **AK-08** · Angenommen, Rechteck oder Ellipse sind aktiv, wenn mit gedrückter
+  Umschalttaste gezogen wird, dann entstehen Quadrat beziehungsweise Kreis.
+- **AK-09** · Angenommen, das Freihandwerkzeug ist aktiv, wenn gezogen wird, dann entsteht
+  eine geglättete Kurve statt eines Streckenzugs.
+- **AK-10** · Angenommen, das Textwerkzeug ist aktiv, wenn in das Bild geklickt wird, dann
+  erscheint ein Eingabefeld; der eingegebene Text bleibt mit farblich hinterlegter Fläche
+  stehen.
+- **AK-11** · Angenommen, ein Textfeld ist in Bearbeitung, wenn `Escape` gedrückt wird, dann
+  wird die Eingabe abgeschlossen — der Editor schließt sich **nicht**.
+- **AK-12** · Angenommen, ein Textfeld ist in Bearbeitung, wenn eine Werkzeugtaste gedrückt
+  wird, dann wird sie als Text eingegeben und wechselt das Werkzeug nicht.
+- **AK-13** · Angenommen, sechs Farbvorgaben und eine freie Farbwahl stehen bereit, wenn
+  eine davon gewählt wird, dann zeichnen alle folgenden Anmerkungen in dieser Farbe.
+- **AK-14** · Angenommen, drei Strichstärken (2, 4, 6 Punkte) stehen bereit, wenn eine
+  gewählt wird, dann gilt sie für alle folgenden Anmerkungen.
+
+### Auswahl und Bearbeitung
+
+- **AK-15** · Angenommen, das Auswahlwerkzeug ist aktiv, wenn auf eine Anmerkung geklickt
+  wird, dann ist sie ausgewählt und von acht Griffen umgeben.
+- **AK-16** · Angenommen, eine Anmerkung ist ausgewählt, wenn sie gezogen wird, dann wird sie
+  verschoben; wenn ein Griff gezogen wird, wird sie skaliert.
+- **AK-17** · Angenommen, eine Anmerkung ist ausgewählt, wenn `Entf` oder `Rückschritt`
+  gedrückt wird, dann wird sie entfernt.
+- **AK-18** · Angenommen, Anmerkungen wurden erstellt, wenn `⌘Z` gedrückt wird, dann wird der
+  jeweils letzte Schritt rückgängig gemacht; `⇧⌘Z` stellt ihn wieder her.
+- **AK-19** · Angenommen, mehrere Anmerkungen überlappen, wenn gezeichnet wird, dann liegt
+  die zuletzt erstellte oben.
+
+### Zoom und Verschieben
+
+- **AK-20** · Angenommen, der Editor ist offen, wenn `⌘+` oder `⌘-` gedrückt wird, dann
+  ändert sich die Vergrößerung; `⌘0` stellt die Einpassung wieder her.
+- **AK-21** · Angenommen, ein Trackpad ist vorhanden, wenn darauf aufgezogen wird, dann
+  ändert sich die Vergrößerung stufenlos.
+- **AK-22** · Angenommen, die Leertaste wird gehalten, wenn gezogen wird, dann verschiebt
+  sich der Bildausschnitt statt zu zeichnen.
+- **AK-23** · Angenommen, die Vergrößerung ist verändert, wenn gezeichnet wird, dann liegt
+  die Anmerkung an der Stelle des Bildes, auf die geklickt wurde — unabhängig von
+  Vergrößerung und Verschiebung.
+- **AK-24** · Angenommen, ein Bild mit Transparenz ist geöffnet, wenn es angezeigt wird,
+  dann liegt ein Schachbrettmuster dahinter.
+
+### Ausgabe
+
+- **AK-25** · Angenommen, Anmerkungen bestehen, wenn `⌘C` gedrückt wird, dann liegt das
+  fertig gerenderte Bild in der Zwischenablage und der Editor schließt sich.
+- **AK-26** ⚠ · Angenommen, `⌘S` wird gedrückt, wenn die Aktion ausgeführt wird, dann wird
+  das Bild **auf den Schreibtisch** gesichert — nicht in den eingestellten Verlaufsordner —
+  **und zusätzlich in die Zwischenablage gelegt**.
+  *(`AnnotationEditor.swift:300-306` ruft beides. Der Speicherort ist fest der Schreibtisch
+  (`ClipboardManager.swift:18`) und ignoriert die Einstellung. Zur Klärung vorgelegt.)*
+- **AK-27** ⚠ · Angenommen, `⌘S` oder *Save As* werden benutzt, wenn die Datei entsteht, dann
+  ist sie **immer PNG** — auch wenn in den Einstellungen JPEG gewählt ist.
+  *(`ClipboardManager.swift:33` schreibt ausschließlich PNG. Der Verlauf beachtet die
+  Einstellung, der Editor nicht. Zur Klärung vorgelegt.)*
+- **AK-28** · Angenommen, `⇧⌘S` wird gedrückt, wenn der Dialog erscheint, dann kann Ort und
+  Name frei gewählt werden.
+- **AK-29** · Angenommen, keine Anmerkungen bestehen, wenn `Escape` gedrückt wird, dann wird
+  das unveränderte Bild in die Zwischenablage gelegt und der Editor schließt sich.
+- **AK-30** · Angenommen, Anmerkungen bestehen und sind ungesichert, wenn `Escape` gedrückt
+  wird, dann erscheint die Rückfrage „Discard Changes?".
+- **AK-31** ⚠ · Angenommen, zwei Bilder werden innerhalb derselben Sekunde mit `⌘S`
+  gesichert, wenn beide geschrieben werden, dann **überschreibt das zweite das erste**.
+  *(`ClipboardManager.swift:14` bildet den Namen mit Sekundengenauigkeit — dieselbe
+  Fehlerklasse wie B09/AK-07. Zur Klärung vorgelegt.)*
+
+### Datenschutz und Missbrauchsschutz
+
+Stufe A, Abschnitt 1 ausdrücklich in Kraft.
+
+- **AK-32** · Angenommen, ein Bild wird ausgegeben, wenn gerendert wird, dann enthält das
+  Ergebnis alle Anmerkungen flach eingerechnet — keine Ebenen, keine wiederherstellbaren
+  Originalbereiche.
+- **AK-33** ⚠ · Angenommen, ein Bild wird in die Zwischenablage gelegt, wenn die
+  geräteübergreifende Zwischenablage aktiv ist, dann überträgt das System **den gesamten
+  Screenshot** an die anderen Geräte des Nutzers.
+  *(`ClipboardManager.swift:8`, ohne Vertraulichkeitsmarkierung. Gewichtiger als bei B05,
+  weil es um das vollständige Bild geht. Zur Klärung vorgelegt.)*
+- **AK-34** ⚠ · Angenommen, das Sichern schlägt fehl, wenn der Fehler auftritt, dann erfährt
+  der Nutzer nichts — der Editor schließt sich trotzdem.
+  *(`ClipboardManager.swift:32` und `:40` schreiben in ein `print()`; `save()` ruft
+  anschließend `close()` unabhängig vom Ergebnis. Zur Klärung vorgelegt — dies bedeutet
+  stillen Datenverlust.)*
+- **AK-35** · Angenommen, Anmerkungen bestehen, wenn der Editor geschlossen wird, dann
+  werden sie nirgends gespeichert.
+
+## Edge Cases
+
+- **EC-01** · Sehr großes Bild → Fenster auf 80 % der Bildschirmgröße begrenzt.
+- **EC-02** · Anmerkung außerhalb des Bildes gezeichnet → wird gezeichnet, aber beim Export
+  auf die Bildfläche beschnitten.
+- **EC-03** · Leeres Textfeld bestätigt → es entsteht keine Anmerkung.
+- **EC-04** · Rückgängig über den Anfang hinaus → keine Wirkung.
+- **EC-05** · Editor geschlossen, während die Texterkennung läuft → das Ergebnisfenster
+  erscheint dennoch.
+- **EC-06** · Anheften bei erreichter Obergrenze → der Editor schließt sich, kein Fenster
+  erscheint (B08/AK-11).
+
+## Fehlbestand
+
+- **FB-01 · Kein bearbeitbarer Projektstand.** Anmerkungen leben ausschließlich im
+  Arbeitsspeicher (`AnnotationStore`). Folge: Ein geschlossener Editor verliert alles; ein
+  exportiertes PNG ist nicht wieder bearbeitbar. *Open in Editor* aus dem Verlauf öffnet
+  das Originalbild ohne die früheren Anmerkungen.
+- **FB-02 · `⌘S` sichert an einen festen Ort und im festen Format.** Fundstellen:
+  `ClipboardManager.swift:18` (Schreibtisch), `:33` (immer PNG). Folge: Die Einstellungen
+  zu Ordner und Format gelten nur für das automatische Sichern; der Nutzer hat zwei Orte
+  mit unterschiedlichem Verhalten.
+- **FB-03 · `⌘S` kopiert zusätzlich in die Zwischenablage.** Fundstelle:
+  `AnnotationEditor.swift:304`. Folge: Ein Sichern überschreibt unerwartet den
+  Zwischenablageinhalt.
+- **FB-04 · Fehlgeschlagenes Sichern bleibt unbemerkt und schließt trotzdem.** Fundstellen:
+  `ClipboardManager.swift:32`, `:40`, `AnnotationEditor.swift:306`. Folge: stiller
+  Datenverlust — die schwerste Ausprägung des projektweiten Befunds FB-AS-03.
+- **FB-05 · Namenskollision beim Sichern auf den Schreibtisch.** Fundstelle:
+  `ClipboardManager.swift:14`. Wie B09/FB-02.
+- **FB-06 · `AnnotationSnapshot.data` ist untypisiert.** Fundstelle:
+  `AnnotationModels.swift:104`. Folge: Fehler im Rückgängig-Pfad fallen erst zur Laufzeit
+  auf, und nur wenn genau dieser Pfad läuft.
+- **FB-07 · Die Zwischenablage ist nicht als vertraulich markiert.** Fundstelle:
+  `ClipboardManager.swift:6-9`. Folge: siehe AK-33.
+- **FB-08 · Keine Tests.** Die Koordinatenumrechnung zwischen Ansicht und Bildpixeln
+  (`viewToImage`, `imageToView`) ist reine Rechnung und ideal prüfbar — sie trägt AK-23,
+  von dem jede Anmerkung abhängt.
+
+## Offene Fragen
+
+- **OF-01** · Soll `⌘S` in den eingestellten Ordner sichern und das eingestellte Format
+  benutzen? — entscheidet der Autor.
+- **OF-02** · Soll `⌘S` weiterhin zusätzlich kopieren? — entscheidet der Autor.
+- **OF-03** · Soll es einen bearbeitbaren Projektstand geben? — entscheidet der Autor.
+
+## Decision Log
+
+| # | Frage | Entscheidung | Begründung |
+|---|---|---|---|
+| 1 | Wie sind Anmerkungen aufgebaut? | Protokoll, jede zeichnet sich selbst | neue Werkzeuge kommen hinzu, ohne den Renderer zu ändern |
+| 2 | In welchem Koordinatenraum wird gearbeitet? | in Bildpixeln, Darstellung über eine affine Abbildung | Anmerkungen bleiben unabhängig von Vergrößerung und Fenstergröße richtig platziert |
+| 3 | Wie funktioniert Rückgängig? | `UndoManager` mit Momentaufnahmen je Anmerkung | Bordmittel; der Preis ist die untypisierte Ablage (FB-06) |
+| 4 | Werkzeugleiste in SwiftUI, Zeichenfläche in AppKit | alles in einem | Zeichnen mit Mausereignissen ist in AppKit direkter; die Leisten sind eingebettete SwiftUI-Ansichten |
+| 5 | Wie wird die Leertaste erkannt? | eigener Ereignisbeobachter | ausdrücklich kommentiert: `flagsChanged` meldet die Leertaste nicht |
+| 6 | Warum schließt der Editor nach Kopieren und Sichern? | Aufnahme ist ein Durchgangsvorgang | erkennbar bewusst — der Editor ist kein Arbeitsplatz, sondern ein Zwischenschritt |
+| 7 | `⌘S` auf den Schreibtisch statt in den Verlaufsordner | in den eingestellten Ordner | **Grund nicht erkennbar** (FB-02) |

--- a/features/B04-bereiche-zensieren/design.md
+++ b/features/B04-bereiche-zensieren/design.md
@@ -1,0 +1,127 @@
+# B04 · Bereiche zensieren — Systemdesign
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · Stack-Profil: `swiftui-macos`
+
+**Kein Code in diesem Dokument.**
+
+## Überblick
+
+Zensur ist in dieser Anwendung keine Bildänderung, sondern eine **Annotation wie jede
+andere** — ein Rechteck mit einer Zeichenvorschrift. Die Vorschrift lautet: Nimm den
+Ausschnitt aus dem Originalbild, schicke ihn durch einen Systemfilter, zeichne das
+Ergebnis an dieselbe Stelle.
+
+Daraus folgt alles Weitere. Die Zensur ist rückgängig zu machen, verschiebbar und
+skalierbar, weil das Original bis zum Export erhalten bleibt. Beim Export wird flach
+gerendert — die Ausgabedatei enthält keine Ebenen und kein Original mehr.
+
+Sie folgt daraus aber auch in einer unerwünschten Richtung: Das Original ist zum
+Zensurzeitpunkt **bereits auf die Festplatte geschrieben** (siehe *Zugriffsregeln*).
+
+## Komponentenstruktur
+
+```
+AnnotationCanvasView                  verteilt Mausereignisse an das aktive Werkzeug
+├── BlurTool                          Rechteck ziehen → BlurAnnotation
+│   └── drawPreview                   gestrichelte weiße Linie während des Ziehens
+└── PixelateTool                      Rechteck ziehen → PixelateAnnotation
+    └── drawPreview                   dieselbe Vorschau
+
+AnnotationStore                       hält die Annotationen, verwaltet Undo
+├── BlurAnnotation                    Rechteck + Radius (15)
+└── PixelateAnnotation                Rechteck + Blockgröße (10)
+
+AnnotationRenderer.renderFinalImage   zeichnet Original, dann alle Annotationen nach zIndex
+```
+
+Beide Werkzeuge sind bis auf den Filter identisch aufgebaut — gleiche Mindestgröße, gleiche
+Vorschau, gleiche Ereignisbehandlung.
+
+## Datenmodell
+
+### `BlurAnnotation` / `PixelateAnnotation` — flüchtig, nur im Speicher
+
+| Feld | Typ | Standard | Bedeutung |
+|---|---|---|---|
+| `id` | `UUID` | neu | Identität für Auswahl und Undo |
+| `rect` | `CGRect` | — | zensierter Bereich, **in Bildpixeln** |
+| `radius` (Blur) | `CGFloat` | `15.0` | Stärke der Unschärfe |
+| `blockSize` (Pixelate) | `CGFloat` | `10.0` | Kantenlänge eines Blocks |
+| `zIndex` | `Int` | `0` | Zeichenreihenfolge |
+| `color`, `strokeWidth` | — | `.clear`, `0` | vom Protokoll gefordert, hier bedeutungslos |
+
+Nichts davon wird persistiert. Nach dem Schließen des Editors existiert nur noch das
+gerenderte Ergebnis — und die zuvor automatisch gesicherte Originaldatei.
+
+## Zugriffsregeln
+
+Keine Rollen. Die einzige relevante Regel ist die über den **Verbleib der Originaldaten**,
+und sie ist die schwächste Stelle des Features:
+
+| Zeitpunkt | Wo liegt das unzensierte Original |
+|---|---|
+| unmittelbar nach der Aufnahme | im Arbeitsspeicher **und** als Datei im Verlaufsordner |
+| während der Bearbeitung | ebenso — die Zensur überdeckt es nur beim Zeichnen |
+| nach dem Export | im Arbeitsspeicher freigegeben, **die Datei bleibt** |
+| nach dem Schließen des Editors | **die Datei bleibt, unbefristet** |
+
+Die zensierte Fassung entsteht ausschließlich in dem Moment, in dem der Nutzer exportiert.
+Die automatisch gesicherte Fassung wird davon nicht berührt — siehe FB-01.
+
+## Missbrauchsschutz
+
+Nicht anwendbar — keine Endpunkte, keine Kosten, keine Netzwerkaufrufe.
+
+## Externe Dienste
+
+Keine. Beide Filter sind Systemfilter von CoreImage und arbeiten auf dem Gerät.
+
+## Erkennbare Entscheidungen
+
+| # | Entscheidung | Alternative | Warum so |
+|---|---|---|---|
+| 1 | Zensur als umkehrbare Annotation | das Bild sofort dauerhaft verändern | erlaubt Undo, Verschieben, Skalieren — der Preis ist, dass das Original bis zum Export vorliegt |
+| 2 | Ausschnitt bei jedem Zeichnen neu aus dem Original | einmal verfremden und zwischenspeichern | keine Qualitätsverluste beim Verschieben; dafür wird bei jedem Neuzeichnen gefiltert |
+| 3 | Zuschneiden auf die Bildgrenzen vor dem Filtern | ungeprüft filtern | verhindert Abstürze bei Bereichen über dem Bildrand |
+| 4 | Zeichenkontext auf den Bereich beschnitten | ohne Beschnitt zeichnen | verhindert, dass die Unschärfe über den gewählten Bereich hinausblutet |
+| 5 | Feste Stärkewerte, keine Oberfläche dafür | einstellbar über die Werkzeugleiste | **Grund nicht erkennbar** |
+| 6 | Keine Kantenfortsetzung vor dem Weichzeichnen | `clampedToExtent` vor dem Filter | **Grund nicht erkennbar** — Wirkung siehe FB-02 |
+| 7 | Zwei Verfahren statt einem | nur Verpixeln | Grund nicht dokumentiert; erkennbar eine Wahlmöglichkeit für den Nutzer, nicht eine Abstufung der Sicherheit |
+
+## Abdeckung der Akzeptanzkriterien
+
+| AK | Erfüllt durch | Anmerkung |
+|---|---|---|
+| AK-01 | `BlurTool.cursor`, Werkzeugwahl im Editor | Taste `B` |
+| AK-02 | `BlurTool.drawPreview` → `BlurAnnotation` | |
+| AK-03 | `PixelateTool` → `PixelateAnnotation` | Taste `X` |
+| AK-04 | Mindestgröße > 2 in `mouseUp` | |
+| AK-05 | `AnnotationStore.addAnnotation` mit Undo-Eintrag | |
+| AK-06 | `moved(by:)` und `resized(from:to:)` | Auswahlwerkzeug aus B03 |
+| AK-07 | `AnnotationRenderer.renderFinalImage` in allen vier Ausgabewegen | belegt in `AnnotationEditor` |
+| AK-08 | Schnittmenge mit den Bildgrenzen vor dem Filtern | |
+| AK-09 ⚠ | feste Standardwerte in beiden Annotationen | keine Einstellung vorhanden |
+| AK-10 ⚠ | `CIGaussianBlur` ohne Kantenfortsetzung | Kanten schwächer verfremdet |
+| AK-11 | flaches Rendern beim Export | keine Ebenen im Ergebnis |
+| AK-12 ⚠ | **keine Komponente** | die Originaldatei entsteht in B01/B09 und wird nie ersetzt |
+| AK-13 | `renderFinalImage` vor `copyToClipboard` | |
+
+AK-12 hat bewusst keine Zuordnung: Das Kriterium beschreibt, was **fehlt**. Es steht hier,
+damit die QA es reproduziert und nicht als erfüllt durchwinkt.
+
+## Übergabe an die QA
+
+Dieses Feature ist als **Sicherheitsprüfung** zu behandeln, nicht als Funktionsprüfung.
+
+1. **AK-12 zuerst.** Ein Passwort auf den Bildschirm bringen, aufnehmen, verpixeln,
+   exportieren — dann `~/Pictures/MikaScreenSnap/` öffnen. Das erwartete Ergebnis nach
+   Aktenlage: Das Passwort ist dort lesbar. Wenn ja, ist der Befund kritisch und die
+   Erfassung pausiert, bis die Reparatur ausgeliefert ist.
+2. **AK-09 und AK-10 messbar prüfen.** Die Anwendung hat die Texterkennung an Bord: Text
+   ins Bild, zensieren, exportieren, Texterkennung auf das Ergebnis ansetzen. Erkennt sie
+   noch etwas, ist die Zensur unwirksam. Das ist ein automatisierbarer Nachweis und der
+   einzige, der die Frage wirklich beantwortet.
+3. **Randlage gesondert prüfen** (AK-10): Text so platzieren, dass er genau an der Kante
+   des zensierten Bereichs liegt.
+4. **EC-03** — überlappende Zensuren verstärken sich nicht. Prüfen, ob das in der Praxis
+   zu einem schwächer zensierten Bereich führt als erwartet.

--- a/features/B04-bereiche-zensieren/spec.md
+++ b/features/B04-bereiche-zensieren/spec.md
@@ -1,0 +1,153 @@
+# B04 · Bereiche zensieren — Spezifikation
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+
+> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ beschreiben Verhalten, das
+> fragwürdig aussieht, und stehen zur Klärung.
+>
+> **Dieses Feature ist eine Datenschutzzusage, kein Zeichenwerkzeug.** Wer einen Bereich
+> verpixelt, verlässt sich darauf, dass der Inhalt danach weg ist. Jede Abweichung davon
+> ist ein Datenleck, nicht ein Darstellungsfehler — das ist der Maßstab für alles Folgende.
+
+## Zweck
+
+Der Nutzer macht Teile einer Aufnahme unkenntlich — ein Passwort, einen Namen, ein
+Gesicht — bevor er sie weitergibt. Zwei Verfahren stehen bereit: Weichzeichnen und
+Verpixeln.
+
+## Abhängigkeiten
+
+| Braucht | Status | Warum |
+|---|---|---|
+| B03 Annotationseditor | `bestand` | beherbergt die Werkzeuge, das Undo und den Export |
+| B01 Bildschirmaufnahme | `bestand` | liefert das Bild |
+| B09 Verlauf | `bestand` | **sichert das Original, bevor zensiert werden kann** — siehe FB-01 |
+
+## User Stories
+
+- **US-01** · Als Nutzer möchte ich ein Rechteck über einem Passwort aufziehen und es
+  unlesbar machen, damit ich den Screenshot weitergeben kann.
+- **US-02** · Als Nutzer möchte ich zwischen Weichzeichnen und Verpixeln wählen, damit ich
+  das Verfahren nehmen kann, das im jeweiligen Bild besser aussieht.
+- **US-03** · Als Nutzer möchte ich einen zensierten Bereich verschieben und in der Größe
+  ändern können, damit ich ihn nicht neu ziehen muss.
+
+## Nicht im Scope
+
+- Automatisches Erkennen sensibler Inhalte (Gesichter, Kartennummern) — nicht vorhanden
+- Zensieren nicht-rechteckiger Bereiche — nicht vorhanden
+- Einstellbare Stärke der Zensur — nicht vorhanden, siehe AK-09
+- Der Export selbst gehört zu **B03**
+
+## Akzeptanzkriterien
+
+- **AK-01** · Angenommen, der Editor ist offen, wenn `B` gedrückt oder das Weichzeichnen
+  in der Werkzeugleiste gewählt wird, dann folgt dem Zeiger ein Fadenkreuz.
+- **AK-02** · Angenommen, das Weichzeichnen ist aktiv, wenn ein Rechteck aufgezogen wird,
+  dann ist der Bereich während des Ziehens durch eine gestrichelte weiße Linie
+  gekennzeichnet und nach dem Loslassen weichgezeichnet.
+- **AK-03** · Angenommen, das Verpixeln ist aktiv (`X`), wenn ein Rechteck aufgezogen wird,
+  dann ist der Bereich nach dem Loslassen in Blöcke zerlegt.
+- **AK-04** · Angenommen, ein Rechteck kleiner als 3 × 3 Bildpunkte wird gezogen, wenn
+  losgelassen wird, dann entsteht **keine** Zensur.
+- **AK-05** · Angenommen, ein Bereich ist zensiert, wenn `⌘Z` gedrückt wird, dann ist der
+  Originalinhalt wieder sichtbar.
+- **AK-06** · Angenommen, ein Bereich ist zensiert, wenn er mit dem Auswahlwerkzeug
+  verschoben oder in der Größe geändert wird, dann wandert die Zensur mit und zeigt den
+  Inhalt an der neuen Stelle verfremdet.
+- **AK-07** · Angenommen, ein Bereich ist zensiert, wenn das Bild kopiert, gesichert oder
+  angeheftet wird, dann ist der Bereich im Ergebnis unkenntlich — bei allen vier
+  Ausgabewegen (`⌘C`, `⌘S`, `⇧⌘S`, Anheften).
+- **AK-08** · Angenommen, ein zensierter Bereich ragt über den Bildrand hinaus, wenn
+  gerendert wird, dann wird nur der Teil innerhalb des Bildes verfremdet und es entsteht
+  kein Fehler.
+
+### Wirksamkeit der Zensur
+
+- **AK-09** ⚠ · Angenommen, ein Bereich wird zensiert, wenn er gerendert wird, dann ist die
+  Stärke **fest**: Weichzeichnen mit Radius 15, Verpixeln mit Blockgröße 10 — jeweils in
+  **Bildpixeln**, nicht in Bildschirmpunkten.
+  *(`AnnotationModels.swift:872` und `:956`. Bei einer Retina-Aufnahme entspricht
+  Blockgröße 10 nur 5 Bildschirmpunkten — die Zensur ist dort also feiner als auf einem
+  nicht skalierten Bildschirm. Es gibt keine Einstellung. Zur Klärung vorgelegt: Reicht
+  das, um kleine Schrift unlesbar zu machen?)*
+- **AK-10** ⚠ · Angenommen, ein Bereich wird weichgezeichnet, wenn er gerendert wird, dann
+  ist die Unschärfe **an den Rändern des Bereichs schwächer als in der Mitte**.
+  *(`AnnotationModels.swift:895` wendet `CIGaussianBlur` auf den zugeschnittenen Ausschnitt
+  an, ohne die Kanten vorher fortzusetzen (`clampedToExtent`). Der Filter mischt am Rand
+  mit dem transparenten Außenraum, wodurch dort weniger Originalinformation zerstört wird.
+  Zur Klärung vorgelegt: Ist Text am Rand eines weichgezeichneten Bereichs noch lesbar
+  oder rekonstruierbar?)*
+
+### Datenschutz und Missbrauchsschutz
+
+Stufe A, Abschnitt 1 des Katalogs ausdrücklich in Kraft. Für dieses Feature ist der
+Katalog **nicht** verkürzt: Es ist die einzige Stelle, an der die Anwendung dem Nutzer
+eine inhaltliche Zusage über seine Daten macht.
+
+- **AK-11** · Angenommen, ein Bereich ist zensiert, wenn das Ergebnis exportiert wird, dann
+  enthält die Ausgabedatei die Originalpixel des Bereichs **nicht mehr** — auch nicht in
+  Metadaten, Ebenen oder Vorschaubildern.
+- **AK-12** ⚠ · Angenommen, der Nutzer zensiert einen Bereich und exportiert das Bild, wenn
+  danach der Verlaufsordner geöffnet wird, dann liegt dort **die unzensierte
+  Originalaufnahme**.
+  *(`CaptureEngine.swift:427` ruft `historyManager.autoSave(image)` mit dem Originalbild,
+  **bevor** der Editor überhaupt öffnet. Kein Pfad ersetzt oder löscht diese Datei später.
+  Das exportierte Bild ist zensiert, die automatisch gesicherte Datei nicht. Zur Klärung
+  vorgelegt — dies ist der schwerwiegendste Einzelbefund der gesamten Erfassung.)*
+- **AK-13** · Angenommen, ein Bereich ist zensiert, wenn das Bild in die Zwischenablage
+  kopiert wird, dann enthält die Zwischenablage nur das gerenderte, zensierte Bild.
+
+## Edge Cases
+
+- **EC-01** · Zensur vollständig außerhalb des Bildes → wird nicht gezeichnet, kein Fehler.
+- **EC-02** · Zensur über die gesamte Bildfläche → funktioniert, das ganze Bild wird
+  verfremdet.
+- **EC-03** · Mehrere überlappende Zensuren → jede zeichnet aus dem **Original**, nicht aus
+  dem Ergebnis der vorherigen; überlappende Bereiche werden also nicht doppelt verfremdet.
+- **EC-04** · Zensur wird auf null Breite oder Höhe skaliert → wird nicht gezeichnet.
+- **EC-05** · Zensur und danach `⌘Z`, `⇧⌘Z`, dann Export → das Wiederherstellen muss die
+  Zensur wieder wirksam machen.
+
+## Fehlbestand
+
+- **FB-01 · Die unzensierte Originalaufnahme bleibt dauerhaft auf der Festplatte.**
+  Fundstelle: `CaptureEngine.swift:427` (`postCapture` sichert vor dem Öffnen des Editors),
+  `AppPreferences.swift:168` (`saveImage`). Folge: **Die Zensur schützt das Weitergegebene,
+  nicht das Gespeicherte.** Wer ein Passwort verpixelt und den Screenshot verschickt, hat
+  das unverpixelte Bild weiterhin in `~/Pictures/MikaScreenSnap/` liegen — sichtbar für
+  jeden mit Zugriff auf den Rechner, in jedem Backup, in jeder Cloud-Synchronisation dieses
+  Ordners. Der Nutzer wird darauf an keiner Stelle hingewiesen.
+- **FB-02 · Weichzeichnen ohne Kantenfortsetzung.** Fundstelle:
+  `AnnotationModels.swift:891-899`. Folge: Am Rand des Bereichs ist die Unschärfe
+  schwächer; ein Wort, das genau an der Kante liegt, kann teilweise lesbar bleiben. Der
+  übliche Weg — die Kanten vor dem Filtern fortzusetzen — wird nicht gegangen.
+- **FB-03 · Die Zensurstärke ist nicht einstellbar und nicht auflösungsbezogen.**
+  Fundstelle: `AnnotationModels.swift:872`, `:956`. Folge: Bei hoher Auflösung ist die
+  Zensur relativ schwächer, ohne dass der Nutzer gegensteuern kann.
+- **FB-04 · Keine Warnung vor unwirksamer Zensur.** Es gibt keine Prüfung, ob der zensierte
+  Bereich noch Kontrastkanten enthält, und keinen Hinweis auf FB-01. Folge: Der Nutzer hat
+  keinen Anlass zu misstrauen.
+- **FB-05 · Keine Tests.** Die Wirksamkeit einer Zensur ist maschinell prüfbar — etwa indem
+  Text ins Bild gerendert, zensiert und anschließend die Texterkennung darauf angesetzt
+  wird. Die Anwendung hat die Texterkennung bereits an Bord (B05). Geprüft wird nichts.
+
+## Offene Fragen
+
+- **OF-01** · Soll das automatische Sichern erst **nach** dem Schließen des Editors
+  geschehen, oder soll die Originaldatei beim Export ersetzt werden? — entscheidet der
+  Autor. Betrifft B09 unmittelbar.
+- **OF-02** · Soll die Zensurstärke einstellbar sein? — entscheidet der Autor.
+- **OF-03** · Ist Weichzeichnen als Zensurverfahren überhaupt zulässig, oder sollte nur
+  Verpixeln angeboten werden? — entscheidet der Autor. Weichzeichnen gilt allgemein als
+  das schwächere Verfahren.
+
+## Decision Log
+
+| # | Frage | Entscheidung | Begründung |
+|---|---|---|---|
+| 1 | Zensur als Annotation oder als Bildänderung? | als Annotation | umkehrbar über das gewöhnliche Undo; das Original bleibt bis zum Export erhalten |
+| 2 | Woher kommt der Inhalt des zensierten Bereichs? | aus dem Originalbild, bei jedem Zeichnen neu | erlaubt Verschieben und Skalieren ohne Qualitätsverlust — hat aber zur Folge, dass sich überlappende Zensuren nicht verstärken (EC-03) |
+| 3 | Welche Filter? | `CIGaussianBlur` und `CIPixellate` | Systemfilter, keine eigene Implementierung |
+| 4 | Feste Stärke | Radius 15 · Blockgröße 10 | **Grund nicht erkennbar** — keine Herleitung im Code, keine Einstellung |
+| 5 | Warum kein `clampedToExtent` vor dem Weichzeichnen? | — | **Grund nicht erkennbar**; erkennbar ist nur, dass auf die Originalausdehnung zurückgeschnitten wird (siehe FB-02) |

--- a/features/B05-bildschirmtext-erfassen/design.md
+++ b/features/B05-bildschirmtext-erfassen/design.md
@@ -1,0 +1,122 @@
+# B05 · Bildschirmtext erfassen (OCR) — Systemdesign
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · Stack-Profil: `swiftui-macos`
+
+**Kein Code in diesem Dokument.**
+
+## Überblick
+
+Die Texterkennung ist kein eigener Aufnahmeweg, sondern eine **Abzweigung**: Sie benutzt
+dieselbe Bereichsauswahl und denselben Aufnahmecode wie B01, gibt das Ergebnis aber nicht
+an den Editor weiter, sondern an Apples Vision-Framework. Was zurückkommt, ist eine
+Zeichenkette.
+
+Der zweite Weg führt durch den bereits geöffneten Editor: Dort wird nicht neu aufgenommen,
+sondern ein Ausschnitt aus dem vorhandenen Bild genommen. Beide Wege enden im selben
+Ergebnisfenster — nur der Umgang mit der Zwischenablage unterscheidet sich.
+
+## Komponentenstruktur
+
+```
+Weg 1 — vom Bildschirm (⇧⌘6)
+CaptureEngine.startTextCapture         Bereichsauswahl über alle Displays
+└── captureAreaForOCR(rect:)           aufnehmen → erkennen → kopieren → anzeigen
+    ├── OCREngine.recognizeText        Vision, auf dem Gerät
+    ├── NSPasteboard.general           automatisch
+    └── OCRResultPanel                 HUD-Fenster
+
+Weg 2 — im Editor
+AnnotationEditor                       Schaltfläche „Extract Text"
+├── AnnotationCanvasView               Auswahlmodus mit eigener Darstellung
+└── performOCROnRegion(rect:)          zuschneiden → erkennen → anzeigen
+    └── OCRResultPanel                 dasselbe Fenster, ohne Kopieren
+
+OCRResultPanel
+├── NSTextView                         erkannter Text, scrollbar
+├── „Copy"                             Text in die Zwischenablage
+├── „Copy as Markdown"                 Text als Codeblock
+└── Zeitgeber 10 s                     pausiert, solange der Zeiger darüber liegt
+```
+
+## Datenmodell
+
+Kein persistenter Zustand. Der erkannte Text existiert als Zeichenkette im
+Ergebnisfenster und in der Zwischenablage.
+
+**Die Zwischenablage ist die einzige Ablage dieses Features** — und die einzige, die die
+Anwendung nicht kontrolliert: Ihr Inhalt ist für jedes andere Programm lesbar und wird bei
+aktivierter geräteübergreifender Zwischenablage vom System an andere Geräte des Nutzers
+übertragen.
+
+## Zugriffsregeln
+
+| Wer | Darf lesen | Erzwungen durch |
+|---|---|---|
+| Die Anwendung | jeden Bildschirmbereich, den der Nutzer wählt | Systemberechtigung Bildschirmaufnahme |
+| — | **nicht**: ausgeschlossene Programme | Filter aus B02, angewandt vor der Aufnahme |
+| Andere Programme | den erkannten Text, sobald er in der Zwischenablage liegt | **nichts** — siehe AK-17 |
+
+## Missbrauchsschutz
+
+| Vorgang | Limit | Anmerkung |
+|---|---|---|
+| Texterkennung | **keins** | läuft lokal, kostet nichts; Abschnitt 4 des Katalogs trifft nicht zu |
+
+Anzumerken bleibt: Ein großer Bereich beschäftigt die Erkennung spürbar lange, ohne dass
+es eine Fortschrittsanzeige oder einen Abbruch gibt.
+
+## Externe Dienste
+
+**Keine.** Vision arbeitet auf dem Gerät.
+
+Mittelbar berührt wird jedoch ein Systemdienst: Die geräteübergreifende Zwischenablage
+überträgt den erkannten Text über iCloud an andere Geräte desselben Kontos, sofern der
+Nutzer sie aktiviert hat. Das ist keine Übertragung der Anwendung, aber eine Folge ihres
+Verhaltens — und deshalb hier vermerkt.
+
+## Erkennbare Entscheidungen
+
+| # | Entscheidung | Alternative | Warum so |
+|---|---|---|---|
+| 1 | Vision auf dem Gerät | Cloud-Erkennungsdienst | keine Übertragung, keine Kosten, keine Schlüssel — Voraussetzung für Stufe A |
+| 2 | Erkennung auf einer Hintergrundwarteschlange, Ergebnis über Fortsetzung | synchron | hält die Oberfläche frei |
+| 3 | Nur der beste Kandidat je Zeile | mehrere Kandidaten anbieten | einfaches Ergebnis; der Gütewert geht verloren (FB-03) |
+| 4 | Zeilen mit Zeilenumbruch verbunden | Layout nachbilden | Vision liefert keine Struktur, nur Beobachtungen |
+| 5 | Eigenes HUD-Fenster statt einer Kurzmeldung | Toast wie bei der Farbwahl | Text muss lesbar und auswählbar sein, eine Kurzmeldung reicht dafür nicht |
+| 6 | Automatisches Kopieren nur bei Weg 1 | in beiden Wegen | **Grund nicht erkennbar** — vermutlich Versehen (FB-02) |
+| 7 | Zwischenablage ohne Vertraulichkeitsmarkierung | wie bei Passwortverwaltungen markieren | **Grund nicht erkennbar** — vermutlich nicht bedacht (FB-06) |
+
+## Abdeckung der Akzeptanzkriterien
+
+| AK | Erfüllt durch | Anmerkung |
+|---|---|---|
+| AK-01 | `startTextCapture` → `AreaSelectionPanel` je Display | dieselbe Auswahl wie B01 |
+| AK-02 | `OCRResultPanel` | |
+| AK-03 | Kopieren in `captureAreaForOCR` | |
+| AK-04 | Systemton, respektiert `captureSoundEnabled` | nur bei nicht leerem Ergebnis |
+| AK-05 ⚠ | **keine Komponente** — der Leerfall ist nicht behandelt | |
+| AK-06 | `isOCRSelectionMode` in der Zeichenfläche | |
+| AK-07 | `performOCROnRegion` | |
+| AK-08 ⚠ | **keine Komponente** — Weg 2 kopiert nicht | |
+| AK-09 | `recognitionLevel = .accurate`, drei Sprachen, Sprachkorrektur | |
+| AK-10 | Verbinden der Beobachtungen mit Zeilenumbruch | |
+| AK-11 | Zeitgeber, 10 Sekunden | |
+| AK-12 | Mauskontakt-Verfolgung im Panel | |
+| AK-13 | `copyAsMarkdown` | |
+| AK-14 | Vision, lokal | belegbar: kein Netzwerkaufruf im Feature |
+| AK-15 | Filter aus B02 in `captureAreaForOCR` | **gilt nur für Weg 1** — Weg 2 arbeitet auf einem bereits gefilterten Bild |
+| AK-16 | kein Protokollaufruf mit Textbezug | |
+| AK-17 ⚠ | allgemeine Zwischenablage ohne Markierung | Übertragung durch den Systemdienst |
+| AK-18 | `CaptureLog.report` in Weg 1 | Weg 2 hat nur ein `print()` |
+
+## Übergabe an die QA
+
+1. **AK-17 ist der schwerste Punkt** und zugleich der, der am ehesten übersehen wird: Er
+   widerspricht der PRD-Zusage, dass kein Byte den Rechner verlässt. Zu prüfen mit
+   aktivierter geräteübergreifender Zwischenablage und einem zweiten Apple-Gerät.
+2. **AK-15 in beiden Wegen prüfen.** Bei Weg 2 ist die Filterung mittelbar — das Bild kam
+   schon gefiltert aus B01. Sollte sich das je ändern, fällt es hier zuerst auf.
+3. **AK-05 und AK-08** sind leicht zu reproduzieren und beschreiben beide fehlende
+   Rückmeldung.
+4. Die Erkennung eignet sich als **Messwerkzeug für B04**: Zensierten Text durch die
+   Erkennung schicken. Findet sie etwas, ist die Zensur unwirksam.

--- a/features/B05-bildschirmtext-erfassen/spec.md
+++ b/features/B05-bildschirmtext-erfassen/spec.md
@@ -1,0 +1,164 @@
+# B05 · Bildschirmtext erfassen (OCR) — Spezifikation
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+
+> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+
+## Zweck
+
+Der Nutzer zieht einen Rahmen um Text, der auf dem Bildschirm steht — in einem Bild, einem
+Video, einem PDF ohne Textebene — und hat ihn danach als Text zur Verfügung. Ohne
+Abtippen, ohne fremden Dienst.
+
+## Abhängigkeiten
+
+| Braucht | Status | Warum |
+|---|---|---|
+| B01 Bildschirmaufnahme | `bestand` | liefert Bereichsauswahl und Bildausschnitt |
+| B02 App-Ausschluss | `bestand` | ausgeschlossene Programme dürfen auch hier nicht gelesen werden |
+| B03 Annotationseditor | `bestand` | beherbergt den zweiten Einstiegsweg |
+| B10 Tastenkombinationen | `bestand` | `⇧⌘6` |
+
+## User Stories
+
+- **US-01** · Als Nutzer möchte ich Text aus einem Bildbereich herausziehen, damit ich ihn
+  weiterverwenden kann, ohne ihn abzutippen.
+- **US-02** · Als Nutzer möchte ich das auch nachträglich aus einem bereits aufgenommenen
+  Screenshot heraus können.
+- **US-03** · Als Nutzer möchte ich den erkannten Text sehen, bevor ich ihn einfüge, damit
+  ich Erkennungsfehler bemerke.
+
+## Nicht im Scope
+
+- Erkennung von Handschrift — Vision leistet das in dieser Konfiguration nicht
+- Übersetzung des erkannten Textes — nicht vorhanden
+- Erhalt des Layouts (Tabellen, Spalten) — der Text wird zeilenweise aneinandergehängt
+- Weitere Sprachen als Deutsch, Englisch, Französisch — fest eingestellt, siehe AK-09
+
+## Akzeptanzkriterien
+
+### Weg 1 — vom Bildschirm (`⇧⌘6`)
+
+- **AK-01** · Angenommen, `⇧⌘6` wird gedrückt oder *Capture Text* gewählt, wenn die
+  Auswahl erscheint, dann liegt über jedem Display dieselbe abgedunkelte Fläche wie bei der
+  Bereichsaufnahme.
+- **AK-02** · Angenommen, ein Bereich mit Text wird gezogen, wenn losgelassen wird, dann
+  erscheint ein Fenster „Extracted Text" mit dem erkannten Text und den Schaltflächen
+  *Copy* und *Copy as Markdown*.
+- **AK-03** · Angenommen, ein Bereich mit Text wird gezogen, wenn die Erkennung fertig ist,
+  dann liegt der Text **bereits in der Zwischenablage**, ohne dass eine Schaltfläche
+  gedrückt wurde.
+- **AK-04** · Angenommen, der Auslöseton ist aktiviert, wenn Text erkannt wurde, dann
+  erklingt „Tink".
+- **AK-05** ⚠ · Angenommen, im gewählten Bereich ist **kein** Text zu erkennen, wenn die
+  Erkennung fertig ist, dann geschieht **nichts**: kein Fenster, kein Ton, keine Meldung.
+  *(`CaptureEngine.swift:358` führt alles innerhalb von `if !recognizedText.isEmpty` aus.
+  Der Nutzer kann nicht unterscheiden, ob die Erkennung nichts fand oder die Funktion nicht
+  ausgelöst hat. Zur Klärung vorgelegt.)*
+
+### Weg 2 — im Editor
+
+- **AK-06** · Angenommen, der Editor ist offen, wenn *Extract Text* in der Werkzeugleiste
+  gewählt wird, dann wechselt der Editor in einen Auswahlmodus mit sichtbarer Rückmeldung.
+- **AK-07** · Angenommen, der Auswahlmodus ist aktiv, wenn ein Bereich gezogen wird, dann
+  erscheint dasselbe Ergebnisfenster wie bei Weg 1.
+- **AK-08** ⚠ · Angenommen, Text wird im Editor erkannt, wenn das Fenster erscheint, dann
+  liegt der Text **nicht** in der Zwischenablage — anders als bei Weg 1.
+  *(`AnnotationEditor.swift:262` öffnet nur das Ergebnisfenster. Zwei Wege desselben
+  Features verhalten sich unterschiedlich. Zur Klärung vorgelegt.)*
+
+### Erkennung
+
+- **AK-09** · Angenommen, Text in Deutsch, Englisch oder Französisch liegt im Bereich, wenn
+  die Erkennung läuft, dann wird er mit Sprachkorrektur und der genauen Erkennungsstufe
+  gelesen.
+- **AK-10** · Angenommen, mehrere Textzeilen liegen im Bereich, wenn das Ergebnis gebildet
+  wird, dann sind sie durch Zeilenumbrüche getrennt, in der Reihenfolge, die Vision liefert.
+- **AK-11** · Angenommen, das Ergebnisfenster ist offen, wenn zehn Sekunden vergehen, ohne
+  dass der Zeiger darüber liegt, dann schließt es sich selbst.
+- **AK-12** · Angenommen, der Zeiger liegt über dem Ergebnisfenster, wenn die zehn Sekunden
+  ablaufen würden, dann bleibt es offen.
+- **AK-13** · Angenommen, das Ergebnisfenster ist offen, wenn *Copy as Markdown* gedrückt
+  wird, dann liegt der Text als Markdown-Codeblock in der Zwischenablage.
+
+### Datenschutz und Missbrauchsschutz
+
+Stufe A, Abschnitt 1 des Katalogs ausdrücklich in Kraft. **Dieses Feature liest fremde
+Bildschirminhalte in Textform** — es kann Passwörter, Nachrichten und Gesundheitsdaten
+erfassen, die zufällig im gewählten Rahmen liegen.
+
+- **AK-14** · Angenommen, ein Bereich wird erkannt, wenn Vision arbeitet, dann geschieht
+  das vollständig auf dem Gerät — kein Netzwerkaufruf, kein fremder Dienst.
+- **AK-15** · Angenommen, ein Programm steht auf der Ausschlussliste, wenn ein Bereich
+  darüber gezogen wird, dann ist dessen Inhalt nicht Teil des erkannten Textes.
+- **AK-16** · Angenommen, Text wird erkannt, wenn der Vorgang abgeschlossen ist, dann steht
+  weder der Text noch ein Teil davon in einem Protokoll.
+- **AK-17** ⚠ · Angenommen, erkannter Text wird in die Zwischenablage gelegt, wenn auf dem
+  Rechner die geräteübergreifende Zwischenablage aktiv ist, dann **überträgt macOS diesen
+  Text an die anderen Apple-Geräte des Nutzers**.
+  *(`CaptureEngine.swift:362` und `OCRResultPanel.swift:89` schreiben in die allgemeine
+  Zwischenablage ohne die Markierung, mit der Passwortverwaltungen eine Übernahme
+  unterbinden. Die Anwendung selbst überträgt nichts — der Systemdienst tut es. Das
+  schränkt die Zusage aus `docs/prd.md` ein, wonach kein Byte den Rechner verlässt. Zur
+  Klärung vorgelegt.)*
+- **AK-18** · Angenommen, die Erkennung schlägt fehl, wenn der Fehler auftritt, dann
+  erscheint bei Weg 1 eine Kurzmeldung.
+
+*Abschnitt 4 (Rate Limits): trifft nicht zu — die Erkennung läuft lokal und kostet nichts.
+Abschnitt 6 (Geheimnisse): trifft nicht zu.*
+
+## Edge Cases
+
+- **EC-01** · Bereich enthält Text in einer nicht eingestellten Sprache → wird meist
+  fehlerhaft oder gar nicht erkannt, ohne Hinweis.
+- **EC-02** · Sehr kleiner Bereich → Erkennung liefert leeres Ergebnis, siehe AK-05.
+- **EC-03** · Sehr großer Bereich (ganzer Bildschirm) → Erkennung dauert spürbar; es gibt
+  keine Fortschrittsanzeige.
+- **EC-04** · Bereich enthält Text auf gemustertem Hintergrund → Erkennungsgüte sinkt, ohne
+  dass ein Gütewert angezeigt wird (Vision liefert einen, er wird verworfen).
+- **EC-05** · Editor-Weg schlägt fehl → nur ein `print()`, der Nutzer sieht nichts.
+- **EC-06** · Mehrere Ergebnisfenster nacheinander → jedes hat seinen eigenen Zeitgeber.
+
+## Fehlbestand
+
+- **FB-01 · Leeres Ergebnis bleibt stumm.** Fundstelle: `CaptureEngine.swift:358`,
+  `AnnotationEditor.swift:261`. Folge: Der häufigste Fall — der Nutzer trifft den Text
+  knapp nicht — sieht aus wie ein Programmfehler.
+- **FB-02 · Die beiden Wege verhalten sich unterschiedlich.** Fundstelle: Weg 1 kopiert
+  automatisch (`CaptureEngine.swift:362`), Weg 2 nicht (`AnnotationEditor.swift:262`).
+  Folge: Der Nutzer kann sich nicht darauf verlassen, dass der Text in der Zwischenablage
+  liegt.
+- **FB-03 · Der Erkennungs-Gütewert wird verworfen.** Fundstelle: `OCREngine.swift:26`
+  nimmt nur `topCandidates(1).first?.string` und ignoriert die mitgelieferte Bewertung.
+  Folge: Unsichere Erkennung ist von sicherer nicht unterscheidbar.
+- **FB-04 · Die Sprachen sind fest verdrahtet.** Fundstelle: `OCREngine.swift:32`. Folge:
+  Wer regelmäßig andere Sprachen liest, kann nichts daran ändern; die Einstellungen bieten
+  dafür nichts an.
+- **FB-05 · Fehler im Editor-Weg erreichen niemanden.** Fundstelle:
+  `AnnotationEditor.swift:267` — ein `print()`. Teil des projektweiten Befunds FB-AS-03.
+- **FB-06 · Die Zwischenablage ist nicht als vertraulich markiert.** Fundstellen:
+  `CaptureEngine.swift:362`, `OCRResultPanel.swift:89` und `:98`. Folge: siehe AK-17. Der
+  übliche Weg, dies zu unterbinden, ist ein zusätzlicher Eintrag im Zwischenablage-Element,
+  den Passwortverwaltungen verwenden; er fehlt.
+- **FB-07 · Keine Tests.** Die Erkennung ist mit einem bekannten Bild und erwartetem Text
+  gut prüfbar — und wäre zugleich der Nachweis für die Wirksamkeit der Zensur in B04.
+
+## Offene Fragen
+
+- **OF-01** · Soll ein leeres Erkennungsergebnis gemeldet werden? — entscheidet der Autor.
+- **OF-02** · Soll der Editor-Weg ebenfalls automatisch kopieren? — entscheidet der Autor.
+- **OF-03** · Soll die Zwischenablage als vertraulich markiert werden, um die
+  geräteübergreifende Übernahme zu unterbinden? — entscheidet der Autor. Betrifft auch B03
+  (Bild) und B06 (Farbwert) und berührt eine Zusage im PRD.
+
+## Decision Log
+
+| # | Frage | Entscheidung | Begründung |
+|---|---|---|---|
+| 1 | Welche Texterkennung? | Apples Vision, auf dem Gerät | keine Netzwerkübertragung, keine Kosten, keine Abhängigkeit — passt zur Stufe A |
+| 2 | Erkennungsstufe | `accurate` statt `fast` | Genauigkeit vor Geschwindigkeit; die Bereiche sind klein |
+| 3 | Sprachkorrektur an | aus | verbessert zusammenhängenden Text, kann einzelne Zeichenfolgen wie Kennwörter verschlechtern |
+| 4 | Drei Sprachen | Systemsprache übernehmen | **Grund nicht erkennbar** (FB-04) |
+| 5 | Zwei Einstiegswege | nur einer | vom Bildschirm für Fremdinhalte, aus dem Editor für bereits Aufgenommenes |
+| 6 | Selbstschließendes Ergebnisfenster nach 10 s | dauerhaft offen | es ist ein Zwischenergebnis, kein Dokument — Zeitgeber pausiert bei Mauskontakt |
+| 7 | Automatisches Kopieren bei Weg 1 | erst auf Knopfdruck | erspart den zweiten Handgriff; die Abweichung in Weg 2 ist vermutlich unbeabsichtigt (FB-02) |

--- a/features/B06-farbpipette/design.md
+++ b/features/B06-farbpipette/design.md
@@ -1,0 +1,132 @@
+# B06 · Farbpipette — Systemdesign
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · Stack-Profil: `swiftui-macos`
+
+**Kein Code in diesem Dokument.**
+
+## Überblick
+
+Die Pipette arbeitet nicht auf dem lebenden Bildschirm, sondern auf einer Kopie: Beim
+Start wird jedes Display **einmal** aufgenommen und die rohen Bilddaten werden im Speicher
+gehalten. Jede Mausbewegung liest daraus ein Pixel — ein reiner Speicherzugriff, ohne
+Wartezeit.
+
+Das ist die tragende Entscheidung des Features und erklärt sein gesamtes Verhalten: die
+flüssige Lupe (kein Rundweg zum System), den Speicherbedarf und die Tatsache, dass
+bewegte Inhalte nicht mitgeführt werden.
+
+Über den Displays liegen zwei Ebenen von Fenstern: je Display eine praktisch unsichtbare
+Klickfläche, die Mausereignisse einsammelt, und darüber die Lupe.
+
+## Komponentenstruktur
+
+```
+CaptureEngine.startColorPicker         Einstiegspunkt
+├── ColorPickerEngine
+│   ├── loadSnapshots(…)               je Display eine Aufnahme, ausgeschlossene Fenster gefiltert
+│   ├── DisplaySnapshot                Rahmen · Bild · Rohdaten · Bytes je Pixel/Zeile · Skalierung
+│   └── sampleColor(at:)               globaler Punkt → PickedColor
+└── ColorLoupeController
+    ├── Klickflächen                   je Display, .screenSaver, Deckkraft 0,001
+    ├── Lupenfenster                   .screenSaver + 1, folgt dem Zeiger
+    │   └── Lupendarstellung           8-fach, Fadenkreuz, Hex/RGB/HSL
+    ├── globale Beobachter             Mausbewegung · Klick · Escape
+    └── handleClick(…)                 kopieren · in den Verlauf · bei Umschalt in die Palette
+
+ColorHistoryManager                    Verlauf (max. 10) und Palette (max. 20)
+ColorPickerToast                       „Copied #RRGGBB", .floating
+```
+
+## Datenmodell
+
+### `PickedColor` — flüchtig
+
+| Feld | Typ | Bedeutung |
+|---|---|---|
+| `nsColor` | `NSColor` | die Farbe selbst, in sRGB umgerechnet |
+| `hex` | `String` | `#RRGGBB`, **der einzige Wert, der kopiert wird** |
+| `rgb` | `(Int, Int, Int)` | 0–255, nur zur Anzeige |
+| `hsl` | `(Int, Int, Int)` | Grad und Prozent, nur zur Anzeige |
+
+### `DisplaySnapshot` — flüchtig, solange die Pipette läuft
+
+Rahmen des Displays, das aufgenommene Bild, dessen Rohdaten, Bytes je Pixel und je Zeile
+sowie die Skalierung. Die Rohdaten sind eine **vollständige, unkomprimierte Kopie des
+Bildschirminhalts**.
+
+### Gespeichert
+
+| Schlüssel | Typ | Grenze | Angezeigt |
+|---|---|---|---|
+| `colorHistory` | `[String]` | 10 | ja, im Menü |
+| `colorPalette` | `[String]` | 20 | **nein — nirgends** |
+
+Beide werden von `resetAll()` **nicht** erfasst.
+
+## Zugriffsregeln
+
+| Wer | Darf lesen | Erzwungen durch |
+|---|---|---|
+| Die Anwendung | jeden Bildschirminhalt zum Startzeitpunkt | Systemberechtigung Bildschirmaufnahme |
+| — | **nicht**: ausgeschlossene Programme | Filter aus B02, angewandt beim Schnappschuss |
+| — | **nicht**: eigene Fenster | zeitlich gelöst — der Schnappschuss entsteht vorher |
+
+Bemerkenswert ist die zeitliche Lösung: Statt die eigenen Fenster zu filtern, nimmt die
+Anwendung auf, **bevor** sie existieren. Das ist wirksam und einfacher als jeder Filter.
+
+## Missbrauchsschutz
+
+Nicht anwendbar — keine Endpunkte, keine Kosten.
+
+Anzumerken bleibt der Speicherbedarf: Die Schnappschüsse aller Displays liegen
+gleichzeitig unkomprimiert vor. Eine Obergrenze gibt es nicht.
+
+## Externe Dienste
+
+Keine.
+
+## Erkennbare Entscheidungen
+
+| # | Entscheidung | Alternative | Warum so |
+|---|---|---|---|
+| 1 | Einmaliger Schnappschuss statt fortlaufendem Lesen | je Mausbewegung neu lesen | ausdrücklich kommentiert: Synchronität — die Lupe muss ohne Wartezeit zeichnen. Preis: AK-09 |
+| 2 | Aufnahme vor dem Aufbau der Überlagerungen | eigene Fenster filtern | einfacher und sicherer |
+| 3 | Klickfläche mit Deckkraft 0,001 | völlig transparent | vollständig durchsichtige Fenster nehmen keine Mausereignisse an |
+| 4 | Lupe eine Ebene höher | dieselbe Ebene | sonst verdeckt die Klickfläche die Lupe |
+| 5 | Globale Ereignisbeobachter statt Fensterereignissen | Ereignisse im Panel behandeln | die Panels aktivieren die Anwendung nicht (`nonactivating`) |
+| 6 | Umrechnung über `ScreenGeometry` | `NSScreen.main` | 3.4.1 behoben — anders als im Bereichspfad von B01 (dort FB-02) |
+| 7 | Nur Hex wird kopiert | Auswahl anbieten | **Grund nicht erkennbar** |
+| 8 | Palette getrennt vom Verlauf | nur ein Verlauf | **Zweck nicht rekonstruierbar** — es gibt keine Anzeige (FB-01) |
+
+## Abdeckung der Akzeptanzkriterien
+
+| AK | Erfüllt durch | Anmerkung |
+|---|---|---|
+| AK-01 | `ColorLoupeController` + Lupendarstellung | 8-fach, Fadenkreuz, drei Werte |
+| AK-02 | `handleClick` → Zwischenablage → `ColorPickerToast` | |
+| AK-03 | Tastenbeobachter, Tastencode 53 | |
+| AK-04 | Untermenü *Color History* | Umsetzung in B15 |
+| AK-05 | Schaltfläche je Eintrag im Untermenü | |
+| AK-06 | Obergrenze 10 in `addColor` | |
+| AK-07 | Leerzustand des Untermenüs | |
+| AK-08 | `sampleColor(at:)` über den passenden Schnappschuss | Skalierung je Display |
+| AK-09 ⚠ | einmaliger Schnappschuss | bewusst, aber nicht gekennzeichnet |
+| AK-10 ⚠ | `addToPalette` — **ohne Anzeige** | keine lesende Komponente |
+| AK-11 | Filter aus B02 in `loadSnapshots` | |
+| AK-12 | Aufnahme vor dem Aufbau der Überlagerungen | |
+| AK-13 | Freigabe der Engine mit dem Controller | zu prüfen: hält niemand sonst eine Referenz |
+| AK-14 | kein Protokollaufruf mit Bildbezug | |
+| AK-15 ⚠ | **keine Komponente** — Schlüssel fehlen in der Rücksetzliste | |
+| AK-16 ⚠ | allgemeine Zwischenablage | wie B05/AK-17 |
+
+## Übergabe an die QA
+
+1. **AK-10 und FB-01 zuerst** — die Palette ist im README beworben und hat keine Anzeige.
+   Zu klären ist, ob die Funktion fehlt oder die Beschreibung falsch ist.
+2. **AK-09 mit einem laufenden Video prüfen**: Video starten, Pipette öffnen, warten,
+   Farbe abgreifen — und mit der tatsächlichen Bildschirmfarbe vergleichen.
+3. **AK-13 messen**, nicht lesen: Speicherverbrauch vor, während und nach der Pipette. Eine
+   nicht freigegebene Bildschirmkopie im Speicher wäre bei diesem Feature der schwerste
+   denkbare Befund.
+4. **AK-11 gesondert prüfen** — die Ausschlussliste greift hier über einen anderen Aufruf
+   als in B01.

--- a/features/B06-farbpipette/spec.md
+++ b/features/B06-farbpipette/spec.md
@@ -1,0 +1,158 @@
+# B06 · Farbpipette — Spezifikation
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+
+> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+
+## Zweck
+
+Der Nutzer greift eine Farbe von irgendeiner Stelle des Bildschirms ab — aus einem fremden
+Programm, einem Bild, einer Webseite — und hat sie als Hex-Wert in der Zwischenablage. Eine
+Lupe zeigt vergrößert, welches Pixel getroffen wird.
+
+## Abhängigkeiten
+
+| Braucht | Status | Warum |
+|---|---|---|
+| B01 Bildschirmaufnahme | `bestand` | die Aufnahme des Bildschirms ist die Datenquelle |
+| B02 App-Ausschluss | `bestand` | ausgeschlossene Programme dürfen auch hier nicht gelesen werden |
+| B10 Tastenkombinationen | `bestand` | `⇧⌘7` |
+| B15 Menüleisten-Hub | `bestand` | zeigt den Farbverlauf als Untermenü |
+
+## User Stories
+
+- **US-01** · Als Nutzer möchte ich eine Farbe vom Bildschirm abgreifen und als Hex-Wert
+  einfügen können, ohne ein Bildbearbeitungsprogramm zu öffnen.
+- **US-02** · Als Nutzer möchte ich vergrößert sehen, welches Pixel ich treffe, damit ich
+  bei feinen Verläufen nicht danebengreife.
+- **US-03** · Als Nutzer möchte ich die zuletzt abgegriffenen Farben wiederfinden, ohne sie
+  aufzuschreiben.
+
+## Nicht im Scope
+
+- Farbwerte in anderen Schreibweisen einfügen (RGB, HSL) — werden angezeigt, aber nur Hex
+  wird kopiert
+- Farbschemata erzeugen oder Kontraste prüfen — nicht vorhanden
+- Farben aus einem bereits aufgenommenen Screenshot abgreifen — nicht vorhanden
+
+## Akzeptanzkriterien
+
+- **AK-01** · Angenommen, `⇧⌘7` wird gedrückt oder *Pick Color* gewählt, wenn die Pipette
+  startet, dann folgt dem Zeiger eine Lupe mit vergrößerter Darstellung, Fadenkreuz und
+  einem Feld, das Hex-, RGB- und HSL-Wert des getroffenen Pixels zeigt.
+- **AK-02** · Angenommen, die Pipette ist aktiv, wenn geklickt wird, dann liegt der
+  Hex-Wert in der Zwischenablage, die Lupe verschwindet und eine Kurzmeldung „Copied
+  #RRGGBB" erscheint.
+- **AK-03** · Angenommen, die Pipette ist aktiv, wenn `Escape` gedrückt wird, dann bricht
+  sie ohne Kopieren ab.
+- **AK-04** · Angenommen, eine Farbe wurde abgegriffen, wenn das Menüleistensymbol
+  angeklickt wird, dann steht sie im Untermenü *Color History* mit farbigem Punkt und
+  Hex-Wert.
+- **AK-05** · Angenommen, ein Eintrag im Farbverlauf wird angeklickt, wenn die Aktion
+  ausgeführt ist, dann liegt dieser Hex-Wert in der Zwischenablage.
+- **AK-06** · Angenommen, mehr als zehn Farben wurden abgegriffen, wenn der Verlauf
+  angezeigt wird, dann enthält er nur die zehn jüngsten.
+- **AK-07** · Angenommen, noch keine Farbe wurde abgegriffen, wenn das Untermenü geöffnet
+  wird, dann steht dort „No colors picked yet".
+- **AK-08** · Angenommen, mehrere Displays sind angeschlossen, wenn die Pipette über eines
+  davon geführt wird, dann zeigt sie die Farbe des Pixels unter dem Zeiger — auf jedem
+  Display, unabhängig von der Skalierung.
+- **AK-09** ⚠ · Angenommen, die Pipette ist aktiv, wenn sich der Bildschirminhalt ändert —
+  ein Video läuft, eine Animation spielt —, dann zeigt die Lupe **weiterhin den Stand vom
+  Start der Pipette**.
+  *(`ColorPickerEngine.swift:81` nimmt beim Start je Display **einen** Schnappschuss auf und
+  liest danach nur noch daraus. Der Dateikommentar begründet das mit der Notwendigkeit,
+  synchron zu bleiben. Zur Klärung vorgelegt: Der Nutzer greift damit eine Farbe ab, die so
+  gerade nicht mehr auf dem Bildschirm steht.)*
+- **AK-10** ⚠ · Angenommen, mit gedrückter Umschalttaste wird geklickt, wenn die Aktion
+  ausgeführt ist, dann wird die Farbe zusätzlich in eine Palette aufgenommen — **die
+  nirgends angezeigt wird**. Kurzmeldung und Verhalten sind von einem gewöhnlichen Klick
+  nicht unterscheidbar.
+  *(`ColorLoupePanel.swift:137` ruft `addToPalette`; `ColorHistoryManager.palette` wird
+  gespeichert, aber von keiner Oberfläche gelesen — das Menü zeigt ausschließlich den
+  Verlauf. Der Toast lautet in beiden Fällen „Copied …". Die Funktion ist im README
+  beschrieben. Zur Klärung vorgelegt.)*
+
+### Datenschutz und Missbrauchsschutz
+
+Stufe A, Abschnitt 1 des Katalogs ausdrücklich in Kraft. **Für ein einziges Pixel nimmt
+dieses Feature den gesamten Inhalt aller Bildschirme auf** und hält ihn im Speicher.
+
+- **AK-11** · Angenommen, die Pipette startet, wenn die Schnappschüsse entstehen, dann sind
+  Fenster ausgeschlossener Programme darin nicht enthalten.
+- **AK-12** · Angenommen, die Pipette startet, wenn die Schnappschüsse entstehen, dann sind
+  eigene Fenster der Anwendung nicht enthalten — die Aufnahme erfolgt, **bevor** die
+  Überlagerungen existieren.
+- **AK-13** · Angenommen, die Pipette wird beendet oder abgebrochen, wenn aufgeräumt ist,
+  dann sind die Bildschirmaufnahmen aus dem Speicher entfernt.
+- **AK-14** · Angenommen, eine Farbe wird abgegriffen, wenn der Vorgang läuft, dann enthält
+  kein Protokoll Bildinhalte.
+- **AK-15** ⚠ · Angenommen, *Reset All Preferences* wird ausgeführt, wenn die Anwendung
+  danach startet, dann sind Farbverlauf und Palette **weiterhin vorhanden**.
+  *(`AppPreferences.swift:135` führt eine von Hand gepflegte Schlüsselliste; die Schlüssel
+  des Farbverlaufs stehen nicht darin. Zur Klärung vorgelegt.)*
+- **AK-16** ⚠ · Angenommen, ein Hex-Wert wird in die Zwischenablage gelegt, wenn die
+  geräteübergreifende Zwischenablage aktiv ist, dann überträgt das System ihn an andere
+  Geräte des Nutzers. *(Wie B05/AK-17; hier von geringer Tragweite, weil ein Farbwert kein
+  Geheimnis ist — der Vollständigkeit halber aufgenommen.)*
+
+*Abschnitt 4 (Rate Limits): trifft nicht zu. Abschnitt 6 (Geheimnisse): trifft nicht zu.*
+
+## Edge Cases
+
+- **EC-01** · Klick außerhalb aller Schnappschüsse → die Pipette bricht ohne Kopieren ab.
+- **EC-02** · Display wird während laufender Pipette abgezogen → Verhalten ungeprüft.
+- **EC-03** · Bildschirmaufnahme-Berechtigung fehlt → Kurzmeldung „Colour picker failed",
+  keine Lupe.
+- **EC-04** · Sehr viele Displays mit hoher Auflösung → alle Schnappschüsse liegen
+  gleichzeitig unkomprimiert im Speicher, siehe FB-03.
+- **EC-05** · Farbe wird zweimal abgegriffen → erscheint zweimal im Verlauf, es gibt keine
+  Zusammenfassung gleicher Werte.
+
+## Fehlbestand
+
+- **FB-01 · Die Palette hat keine Anzeige.** Fundstellen: `ColorHistoryManager.swift:16`
+  (gespeichert, höchstens 20), `ColorLoupePanel.swift:137` (befüllt),
+  `MikaScreenSnapApp.swift:219` (das Menü zeigt nur den Verlauf). Folge: Eine im README
+  beworbene Funktion („Shift+Click adds to palette") ist ohne Wirkung für den Nutzer — die
+  Daten sammeln sich, ohne je sichtbar zu werden.
+- **FB-02 · Die Lupe zeigt einen eingefrorenen Bildschirm.** Fundstelle:
+  `ColorPickerEngine.swift:81`. Folge: Bei bewegten Inhalten wird die falsche Farbe
+  abgegriffen, ohne Hinweis. Die Entscheidung ist begründet (Synchronität), die fehlende
+  Kennzeichnung nicht.
+- **FB-03 · Der gesamte Bildschirminhalt liegt unkomprimiert im Speicher.** Fundstelle:
+  `ColorPickerEngine.swift:96` hält je Display die rohen Bilddaten. Folge: Bei mehreren
+  großen Displays erheblicher Speicherbedarf, solange die Pipette aktiv ist — und eine
+  vollständige Kopie fremder Bildschirminhalte im Prozessspeicher.
+- **FB-04 · Farbverlauf und Palette überstehen das Zurücksetzen.** Fundstelle:
+  `AppPreferences.swift:135`. Folge: „Alle Einstellungen zurücksetzen" tut nicht, was es
+  sagt; abgegriffene Farben bleiben nachvollziehbar.
+- **FB-05 · Kein Weg, den Farbverlauf zu leeren.** Weder Menü noch Einstellungen bieten
+  das an; `clearPalette` existiert im Verwalter, wird aber von niemandem aufgerufen. Folge:
+  Der Verlauf lässt sich nur durch zehn neue Farben verdrängen.
+- **FB-06 · RGB und HSL werden berechnet und angezeigt, aber nie kopiert.** Fundstelle:
+  `ColorPickerEngine.swift:13-14`. Folge: Wer den RGB-Wert braucht, muss ihn abschreiben.
+- **FB-07 · Keine Tests.** Die Farbumrechnung (Hex, RGB, HSL) ist reine Rechnung und ideal
+  prüfbar; geprüft wird sie nicht.
+
+## Offene Fragen
+
+- **OF-01** · Soll die Palette eine Anzeige bekommen — oder soll Shift+Klick entfallen? —
+  entscheidet der Autor.
+- **OF-02** · Soll der Farbverlauf leerbar sein und vom Zurücksetzen erfasst werden? —
+  entscheidet der Autor.
+- **OF-03** · Soll die Lupe den Bildschirm fortlaufend neu lesen? — entscheidet der Autor;
+  die jetzige Lösung ist bewusst gewählt, die Folge (AK-09) aber unsichtbar.
+
+## Decision Log
+
+| # | Frage | Entscheidung | Begründung |
+|---|---|---|---|
+| 1 | Wie wird ein Pixel gelesen? | einmaliger Schnappschuss je Display, danach nur Speicherzugriff | ausdrücklich kommentiert: die Lupe zeichnet bei jeder Mausbewegung neu, ein Rundweg zum System je Abtastung würde ruckeln |
+| 2 | Wann wird der Schnappschuss genommen? | **bevor** die eigenen Überlagerungen existieren | sonst läge die eigene Lupe unter der Lupe |
+| 3 | Wie werden Koordinaten umgerechnet? | über `ScreenGeometry` | 3.4.1: zuvor wurde gegen das Fenster mit dem Tastaturfokus gespiegelt, was auf mehreren Displays falsch war |
+| 4 | Womit wird aufgenommen? | ScreenCaptureKit | 3.4.1: ersetzte `CGWindowListCreateImage` |
+| 5 | Wie wird die Klickfläche unsichtbar gemacht? | Deckkraft 0,001 statt völliger Transparenz | ein vollständig durchsichtiges Fenster nimmt keine Mausereignisse entgegen |
+| 6 | Welche Ebene hat die Lupe? | eine über den Klickflächen | sonst verdeckte die eigene Klickfläche die Lupe |
+| 7 | Was wird kopiert? | nur Hex | **Grund nicht erkennbar** (FB-06) |
+| 8 | Wofür die Palette? | dauerhafte Sammlung neben dem Verlauf | **Zweck nicht rekonstruierbar** — es gibt keine Anzeige dazu (FB-01) |

--- a/features/B07-lineal-vermessen/design.md
+++ b/features/B07-lineal-vermessen/design.md
@@ -1,0 +1,101 @@
+# B07 · Lineal / Bildschirm vermessen — Systemdesign
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · Stack-Profil: `swiftui-macos`
+
+**Kein Code in diesem Dokument.**
+
+## Überblick
+
+Das Feature existiert **zweimal**, in zwei getrennten Implementierungen: als
+Vollbild-Overlay, das über den Bildschirm gelegt wird, und als Werkzeug innerhalb des
+Editors. Beide bieten dieselben zwei Betriebsarten — Punkt zu Punkt und Rechteck — und
+denselben Einheitenwechsel, teilen aber keinen Code.
+
+Das Overlay ist das einzige bildschirmbezogene Feature der Anwendung, das **keine
+Bildschirmaufnahme benötigt**: Es zeichnet nur darüber und misst Koordinaten.
+
+## Komponentenstruktur
+
+```
+Ausprägung 1 — Overlay (⇧⌘8)
+CaptureEngine.startMeasurement          Parameter appState wird nicht benutzt
+└── MeasurementOverlayController
+    ├── MeasurementPanel                je Display, borderless, .screenSaver
+    ├── Tastenbeobachter                Escape schließt · Leertaste wechselt die Einheit
+    └── Messansicht
+        ├── Punkt-zu-Punkt              Klick A → Klick B
+        ├── Rechteck                    ziehen
+        ├── Hilfslinien                 waagerecht und senkrecht am Zeiger
+        └── Informationsfläche          aktuelle Einheit
+
+Ausprägung 2 — Werkzeug im Editor (M)
+MeasurementTool                          erfüllt DrawingTool
+├── mouseDown/Dragged/Up                 dieselben zwei Betriebsarten
+├── keyDown                              Leertaste wechselt die Einheit (Konflikt, FB-01)
+└── drawPreview                          **nur Vorschau** — nie im Export
+```
+
+Der entscheidende Unterschied zu allen anderen Werkzeugen: `MeasurementTool` legt **keine
+Annotation** an. Es zeichnet ausschließlich in die Vorschau, die der Renderer nicht kennt —
+deshalb ist die Nichtexportierbarkeit (AK-09) keine Prüfung, sondern eine Eigenschaft des
+Aufbaus.
+
+## Datenmodell
+
+Keine Persistenz, keine Annotation. Beide Ausprägungen halten zwei Punkte, eine Betriebsart
+und einen Wahrheitswert für die Einheit — alles nur, solange gemessen wird.
+
+## Zugriffsregeln
+
+| Wer | Darf | Erzwungen durch |
+|---|---|---|
+| Das Overlay | Mauskoordinaten lesen | keine Berechtigung nötig |
+| Das Overlay | **keine** Bildinhalte lesen | es nimmt schlicht nichts auf |
+
+Bemerkenswert: Dieses Feature läuft auch dann, wenn die Bildschirmaufnahme-Berechtigung
+fehlt.
+
+## Missbrauchsschutz
+
+Nicht anwendbar.
+
+## Externe Dienste
+
+Keine.
+
+## Erkennbare Entscheidungen
+
+| # | Entscheidung | Alternative | Warum so |
+|---|---|---|---|
+| 1 | Messungen werden nie exportiert | als Anmerkung behandeln | im Dateikopf ausdrücklich vermerkt: ein Arbeitsmittel, kein Bildinhalt |
+| 2 | Umsetzung über die Vorschau statt über eine Annotation | Annotation mit Ausschluss beim Export | die Nichtexportierbarkeit ergibt sich aus dem Aufbau und kann nicht versehentlich verloren gehen |
+| 3 | Ein Panel je Display | ein Panel über alle | folgt dem Muster der Bereichsauswahl |
+| 4 | Overlay ohne Bildschirmaufnahme | Bildschirm aufnehmen | keine Berechtigung nötig |
+| 5 | Zwei getrennte Implementierungen | gemeinsamer Kern | **Grund nicht erkennbar** (FB-04) |
+| 6 | Controller wird gehalten, ohne Rückruf zum Freigeben | wie bei der Farbpipette | **Grund nicht erkennbar** (FB-03) |
+
+## Abdeckung der Akzeptanzkriterien
+
+| AK | Erfüllt durch | Anmerkung |
+|---|---|---|
+| AK-01 | `MeasurementOverlayController` + Panels | |
+| AK-02 | Punkt-zu-Punkt-Betriebsart | |
+| AK-03 | Rechteck-Betriebsart | |
+| AK-04 | Tastenbeobachter, Tastencode 49 | |
+| AK-05 | Tastenbeobachter, Tastencode 53 | |
+| AK-06 | Informationsfläche | |
+| AK-07 | `MeasurementTool` | |
+| AK-08 | Werkzeug rechnet in Bildpixeln | Umrechnung aus B03 |
+| AK-09 | nur Vorschau, keine Annotation | Eigenschaft des Aufbaus |
+| AK-10 ⚠ | zwei Behandler für dieselbe Taste | |
+| AK-11 | keine Aufnahme im Overlay | |
+| AK-12 | kein Speicherpfad, kein Protokollaufruf | |
+
+## Übergabe an die QA
+
+1. **AK-09 in allen vier Ausgabewegen prüfen** — Kopieren, Sichern, Sichern unter,
+   Anheften. Eine sichtbare Messung im Export wäre ein Fehler mit Außenwirkung.
+2. **AK-10** reproduzieren: `M` drücken, messen, Leertaste, dann ziehen.
+3. **AK-11** ist die datenschutzrelevante Zusage: prüfen, dass das Overlay auch ohne
+   erteilte Bildschirmaufnahme-Berechtigung funktioniert. Tut es das nicht, liest es doch
+   Bildinhalte.

--- a/features/B07-lineal-vermessen/spec.md
+++ b/features/B07-lineal-vermessen/spec.md
@@ -1,0 +1,120 @@
+# B07 · Lineal / Bildschirm vermessen — Spezifikation
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+
+> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+
+## Zweck
+
+Der Nutzer misst Abstände und Flächen — entweder direkt auf dem Bildschirm über ein
+Vollbild-Overlay oder innerhalb einer bereits geöffneten Aufnahme im Editor. Messungen sind
+Hilfslinien, keine Anmerkungen: Sie erscheinen in keinem Export.
+
+## Abhängigkeiten
+
+| Braucht | Status | Warum |
+|---|---|---|
+| B03 Annotationseditor | `bestand` | beherbergt die zweite Ausprägung als Werkzeug `M` |
+| B10 Tastenkombinationen | `bestand` | `⇧⌘8` für das Overlay |
+
+## User Stories
+
+- **US-01** · Als Nutzer möchte ich den Abstand zweier Punkte auf dem Bildschirm messen,
+  ohne einen Screenshot zu machen.
+- **US-02** · Als Nutzer möchte ich die Größe eines Bereichs in Pixeln kennen.
+- **US-03** · Als Nutzer möchte ich zwischen Pixeln und Punkten umschalten.
+
+## Nicht im Scope
+
+- Messungen speichern oder exportieren — ausdrücklich nicht, siehe AK-09
+- Winkelmessung — nicht vorhanden
+- Kalibrierung auf andere Einheiten (Millimeter, Zoll) — nicht vorhanden
+
+## Akzeptanzkriterien
+
+### Vollbild-Overlay (`⇧⌘8`)
+
+- **AK-01** · Angenommen, `⇧⌘8` wird gedrückt oder *Measure* gewählt, wenn das Overlay
+  erscheint, dann liegt es über dem Bildschirm und der Zeiger wird von Hilfslinien
+  begleitet.
+- **AK-02** · Angenommen, das Overlay ist aktiv, wenn nacheinander zwei Punkte angeklickt
+  werden, dann erscheinen beide Punkte, die Verbindungslinie und der Abstand als Zahl.
+- **AK-03** · Angenommen, das Overlay ist aktiv, wenn mit gedrückter Maustaste gezogen wird,
+  dann wird ein Rechteck gemessen und Breite, Höhe und Maße werden angezeigt.
+- **AK-04** · Angenommen, das Overlay ist aktiv, wenn die Leertaste gedrückt wird, dann
+  wechselt die Anzeige zwischen Pixeln und Punkten.
+- **AK-05** · Angenommen, das Overlay ist aktiv, wenn `Escape` gedrückt wird, dann
+  verschwindet es.
+- **AK-06** · Angenommen, das Overlay ist aktiv, wenn es angezeigt wird, dann steht in einer
+  Informationsfläche, in welcher Einheit gemessen wird.
+
+### Werkzeug im Editor (`M`)
+
+- **AK-07** · Angenommen, der Editor ist offen, wenn `M` gedrückt wird, dann misst ein Klick
+  oder ein Ziehen im Bild — mit denselben zwei Betriebsarten.
+- **AK-08** · Angenommen, im Editor wird gemessen, wenn die Vergrößerung verändert wird,
+  dann bleiben die gemessenen Werte auf das Bild bezogen und ändern sich nicht.
+- **AK-09** · Angenommen, eine Messung liegt im Editor vor, wenn das Bild kopiert, gesichert
+  oder angeheftet wird, dann ist die Messung im Ergebnis **nicht** enthalten.
+- **AK-10** ⚠ · Angenommen, das Messwerkzeug ist im Editor aktiv, wenn die Leertaste gedrückt
+  wird, dann schaltet die Anzeige die Einheit um **und** der Editor wechselt gleichzeitig in
+  den Verschiebemodus.
+  *(`AnnotationCanvasView.swift:70` beobachtet die Leertaste über einen lokalen
+  Ereignisbeobachter, der das Ereignis weiterreicht; `MeasurementTool.swift:54` behandelt
+  dieselbe Taste. Ein anschließendes Ziehen verschiebt den Ausschnitt, statt zu messen. Zur
+  Klärung vorgelegt.)*
+
+### Datenschutz und Missbrauchsschutz
+
+Stufe A. Dieses Feature ist das einzige mit Bildschirmbezug, das **keine Bildinhalte
+liest**: Das Overlay zeichnet nur darüber.
+
+- **AK-11** · Angenommen, das Overlay ist aktiv, wenn gemessen wird, dann wird **kein**
+  Bildschirminhalt aufgenommen, gelesen oder gespeichert.
+- **AK-12** · Angenommen, eine Messung wird durchgeführt, wenn sie beendet ist, dann bleibt
+  nichts davon zurück — weder Datei noch Einstellung noch Protokolleintrag.
+
+*Abschnitte 4 und 6 des Katalogs: treffen nicht zu.*
+
+## Edge Cases
+
+- **EC-01** · Zwei Klicks auf denselben Punkt → Abstand 0.
+- **EC-02** · Messung über Displaygrenzen hinweg → Verhalten ungeprüft; das Overlay wird je
+  Display angelegt.
+- **EC-03** · Overlay aktiv, während eine Aufnahme ausgelöst wird → das Overlay liegt auf
+  derselben Ebene wie die Bereichsauswahl; Verhalten ungeprüft.
+- **EC-04** · Messwerkzeug im Editor, dann Werkzeugwechsel → die Messung verschwindet.
+
+## Fehlbestand
+
+- **FB-01 · Die Leertaste ist doppelt belegt.** Fundstellen:
+  `AnnotationCanvasView.swift:70`, `Tools/MeasurementTool.swift:54`. Folge: siehe AK-10.
+- **FB-02 · `startMeasurement(appState:)` benutzt seinen Parameter nicht.** Fundstelle:
+  `CaptureEngine.swift:395`. Folge: keine unmittelbare — das Overlay braucht keinen
+  Anwendungszustand. Der Parameter täuscht eine Abhängigkeit vor, die es nicht gibt.
+- **FB-03 · Der Controller des Overlays wird gehalten, aber nie freigegeben.** Fundstelle:
+  `CaptureEngine.swift:396` weist `measurementController` zu; anders als bei der Farbpipette
+  gibt es keinen Rückruf, der die Zuweisung nach dem Schließen zurücknimmt. Folge: Der
+  zuletzt benutzte Controller bleibt bis zum nächsten Messvorgang im Speicher — geringe
+  Menge, aber ein Muster, das bei der Farbpipette bewusst anders gelöst ist.
+- **FB-04 · Zwei getrennte Implementierungen derselben Sache.** `MeasurementOverlay.swift`
+  (362 Zeilen) und `Tools/MeasurementTool.swift` (160 Zeilen) berechnen und zeichnen
+  dasselbe auf verschiedene Weise. Folge: Eine Änderung an der Darstellung muss an zwei
+  Stellen erfolgen; Abweichungen fallen nicht auf.
+- **FB-05 · Keine Tests.** Abstandsberechnung und Einheitenumrechnung sind reine Rechnung.
+
+## Offene Fragen
+
+- **OF-01** · Soll die Leertaste im Messwerkzeug die Einheit umschalten oder verschieben? —
+  entscheidet der Autor.
+- **OF-02** · Sollen die beiden Ausprägungen zusammengeführt werden? — entscheidet der
+  Autor; das wäre ein eigenes Feature mit eigener Nummer, kein Nachtrag hier.
+
+## Decision Log
+
+| # | Frage | Entscheidung | Begründung |
+|---|---|---|---|
+| 1 | Messungen als Anmerkung oder als Hilfslinie? | Hilfslinie, nicht exportiert | eine Messung ist ein Arbeitsmittel, kein Bildinhalt — ausdrücklich im Dateikopf vermerkt |
+| 2 | Zwei Ausprägungen | nur das Overlay | auf dem Bildschirm messen und im Bild messen sind verschiedene Vorgänge |
+| 3 | Leertaste für den Einheitenwechsel | eine Buchstabentaste | im Overlay naheliegend — im Editor kollidiert sie (FB-01) |
+| 4 | Overlay ohne Bildaufnahme | Bildschirm aufnehmen und darauf messen | braucht keine Bildschirmaufnahme-Berechtigung für diesen Weg |

--- a/features/B08-screenshots-anheften/design.md
+++ b/features/B08-screenshots-anheften/design.md
@@ -1,0 +1,125 @@
+# B08 · Screenshots anheften — Systemdesign
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · Stack-Profil: `swiftui-macos`
+
+**Kein Code in diesem Dokument.**
+
+## Überblick
+
+Ein angehefteter Screenshot ist ein rahmenloses, nicht aktivierendes Panel auf der
+schwebenden Ebene, das ein Bild anzeigt und Maus­ereignisse selbst auswertet: Ziehen
+verschiebt, Umschalt+Ziehen skaliert, Scrollen ändert die Durchsichtigkeit.
+
+Parallel dazu schreibt die Anwendung das Bild als PNG in einen eigenen Ordner unterhalb
+von *Application Support*. Beim Start liest sie diesen Ordner aus und stellt bis zu zwanzig
+Bilder wieder her. Dieser Schreibvorgang hat **kein Gegenstück**: Es gibt keinen Pfad, der
+je eine dieser Dateien entfernt.
+
+## Komponentenstruktur
+
+```
+PinnedScreenshotManager               (statisch, kein Zustand außer der Obergrenze)
+├── pinImage(_:appState:)             Obergrenze prüfen → Panel → Liste → Datei schreiben
+├── unpinPanel(_:appState:)           Fenster ausblenden, aus der Liste nehmen
+├── unpinAll(appState:)               dito für alle
+├── restorePins(appState:)            Ordner lesen, alphabetisch, erste 20 wiederherstellen
+└── savePinnedImage(_:)               PNG mit Zeitstempel auf Millisekunden
+
+PinnedScreenshotPanel                 rahmenlos, nicht aktivierend, .floating
+├── Bilddarstellung                   höchstens 400 Punkte breit
+├── Schaltfläche zum Schließen        erscheint bei Mauskontakt
+├── Ziehen / Umschalt+Ziehen          verschieben / skalieren (mindestens 100 Punkte)
+├── Scrollrad                         Durchsichtigkeit 20–100 %
+├── Doppelklick                       schließen
+└── Kontextmenü                       Kopieren · Sichern · Editor · Durchsichtigkeit · Schließen
+
+AppState.pinnedPanels                 Liste der offenen Fenster — Grundlage des Untermenüs
+```
+
+## Datenmodell
+
+### Auf der Festplatte
+
+| Was | Wo | Benennung | Gelöscht durch |
+|---|---|---|---|
+| PNG des angehefteten Bildes | `~/Library/Application Support/MikaScreenSnap/PinnedScreenshots/` | `pin_JJJJ-MM-TT_HH-mm-ss-SSS.png` | **nichts** |
+
+Gespeichert wird ausschließlich das Bild. Es gibt keine Begleitdatei und keinen Eintrag in
+den Einstellungen — also auch keine Position, Größe oder Durchsichtigkeit.
+
+### Im Speicher
+
+`AppState.pinnedPanels`: die Liste der offenen Fenster. Sie und der Ordnerinhalt laufen
+auseinander, sobald ein Fenster geschlossen wird — das Fenster verschwindet aus der Liste,
+die Datei bleibt.
+
+## Zugriffsregeln
+
+| Wer | Darf lesen | Darf schreiben | Erzwungen durch |
+|---|---|---|---|
+| Die Anwendung | den Ablageordner | anlegen — **nie löschen** | Dateirechte, keine Sandbox |
+| Der Nutzer | denselben Ordner, wenn er ihn findet | über den Finder | — |
+
+Der Ordner liegt in der Benutzerbibliothek, die der Finder standardmäßig ausblendet. Weder
+Einstellungen noch Menü verweisen darauf. **Der Nutzer kann diese Daten in der Anwendung
+weder sehen noch entfernen.**
+
+## Missbrauchsschutz
+
+| Vorgang | Limit | Anmerkung |
+|---|---|---|
+| gleichzeitig offene Fenster | 20 | ohne Rückmeldung bei Überschreitung (FB-04) |
+| Dateien im Ablageordner | **keins** | wächst unbegrenzt (FB-01) |
+
+## Externe Dienste
+
+Keine.
+
+## Erkennbare Entscheidungen
+
+| # | Entscheidung | Alternative | Warum so |
+|---|---|---|---|
+| 1 | Rahmenloses, nicht aktivierendes Panel | gewöhnliches Fenster | ein angehefteter Screenshot soll den Arbeitsfluss nicht unterbrechen |
+| 2 | `.floating` statt `.screenSaver` | höhere Ebene | über gewöhnlichen Fenstern, aber unter Auswahl-Overlays — sonst läge ein Pin über der Bereichsauswahl |
+| 3 | Ablage in *Application Support* | im Bilderordner beim Verlauf | Programmdaten, die der Nutzer nicht selbst verwaltet — die Folge ist, dass er sie auch nicht findet |
+| 4 | Zeitstempel mit Millisekunden | auf die Sekunde | verhindert Namenskollisionen (im Verlauf fehlt das, siehe B09/FB-02) |
+| 5 | Wiederherstellung alphabetisch, erste 20 | nach Änderungsdatum, jüngste zuerst | **Grund nicht erkennbar** — die Folge (AK-14) wirkt unbeabsichtigt |
+| 6 | Nur das Bild sichern | Anordnung mitsichern | **Grund nicht erkennbar** (FB-03) |
+| 7 | Kein Löschpfad | beim Schließen entfernen | **Grund nicht erkennbar** (FB-01) |
+
+## Abdeckung der Akzeptanzkriterien
+
+| AK | Erfüllt durch | Anmerkung |
+|---|---|---|
+| AK-01 | `pinImage` aus dem Editor | |
+| AK-02 | Skalierung im Panel-Initialisierer | |
+| AK-03 | Ziehen im Panel | |
+| AK-04 | Umschalt+Ziehen, Untergrenze 100 | |
+| AK-05 | Scrollrad, 0,2–1,0 | |
+| AK-06 | Mauskontakt-Verfolgung | |
+| AK-07 | Kontextmenü, fünf Einträge | |
+| AK-08 | Doppelklick | |
+| AK-09 | Untermenü über `AppState.pinnedPanels` | Umsetzung in B15 |
+| AK-10 | `restorePins` beim Start | Anordnung geht verloren |
+| AK-11 ⚠ | `print()` bei Erreichen der Obergrenze | keine sichtbare Rückmeldung |
+| AK-12 ⚠ | `savePinnedImage` ohne Prüfung der Einstellung | |
+| AK-13 ⚠ | **keine Komponente** — es gibt keinen Löschpfad | |
+| AK-14 ⚠ | alphabetische Sortierung in `restorePins` | |
+| AK-15 ⚠ | **keine Komponente** — die Speicherverwaltung kennt den Ordner nicht | |
+| AK-16 | kein Protokollaufruf mit Bildbezug | |
+| AK-17 | kein Netzwerkaufruf im Feature | |
+
+Fünf ⚠-Kriterien, davon drei ohne jede Zuordnung. Das ist kein Darstellungsproblem: Es
+sind drei Stellen, an denen etwas fehlt, das es geben müsste.
+
+## Übergabe an die QA
+
+1. **AK-13 zuerst und mit Zählung.** Ordner leeren, zehnmal anheften und schließen,
+   Dateien zählen. Erwartung nach Aktenlage: zehn Dateien, null offene Fenster.
+2. **AK-14 danach**: 25 Bilder anheften, Anwendung neu starten, prüfen **welche** zwanzig
+   zurückkehren. Erwartung: die ältesten.
+3. **AK-12**: automatisches Sichern abschalten, anheften, Ordner prüfen.
+4. **AK-15**: Speicheranzeige mit dem tatsächlichen Verbrauch beider Ordner vergleichen.
+5. Ist AK-13 bestätigt, ist der Befund **hoch bis kritisch** — er betrifft dauerhaft
+   abgelegte Bildschirminhalte ohne Kenntnis des Nutzers, und die Erfassung pausiert nach
+   der Regel aus `~/.claude/sdd/artefakte.md`, bis die Reparatur ausgeliefert ist.

--- a/features/B08-screenshots-anheften/spec.md
+++ b/features/B08-screenshots-anheften/spec.md
@@ -1,0 +1,162 @@
+# B08 · Screenshots anheften — Spezifikation
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+
+> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+>
+> **Hier sitzt der schwerste Einzelbefund der Kartierung** (FB-01): Angeheftete Bilder
+> werden auf die Festplatte geschrieben und niemals gelöscht.
+
+## Zweck
+
+Der Nutzer lässt eine Aufnahme als schwebendes Fenster über allen anderen liegen — um
+etwas abzuschreiben, zu vergleichen oder im Blick zu behalten, während er in einem anderen
+Programm arbeitet.
+
+## Abhängigkeiten
+
+| Braucht | Status | Warum |
+|---|---|---|
+| B03 Annotationseditor | `bestand` | Einstiegspunkt *Pin* in Werkzeugleiste und Fußzeile |
+| B09 Verlauf | `bestand` | zweiter Einstiegspunkt über das Kontextmenü |
+| B15 Menüleisten-Hub | `bestand` | Untermenü *Pinned Screenshots* |
+
+## User Stories
+
+- **US-01** · Als Nutzer möchte ich einen Screenshot über allen Fenstern schweben lassen,
+  damit ich beim Abtippen nicht ständig umschalten muss.
+- **US-02** · Als Nutzer möchte ich Größe und Durchsichtigkeit anpassen, damit er nicht
+  stört.
+- **US-03** · Als Nutzer möchte ich, dass angeheftete Bilder einen Neustart überstehen.
+
+## Nicht im Scope
+
+- Anheften mehrerer Bilder in einem Fenster — jedes Bild bekommt ein eigenes
+- Anmerkungen am angehefteten Bild — dafür führt *Open in Editor* zurück in B03
+- Anordnung oder Gruppierung angehefteter Fenster — nicht vorhanden
+
+## Akzeptanzkriterien
+
+- **AK-01** · Angenommen, der Editor ist offen, wenn *Pin* gewählt wird, dann erscheint das
+  Bild als rahmenloses Fenster über allen anderen Fenstern und der Editor schließt sich.
+- **AK-02** · Angenommen, ein Bild ist breiter als 400 Punkte, wenn es angeheftet wird, dann
+  wird es auf 400 Punkte Breite verkleinert, unter Beibehaltung des Seitenverhältnisses.
+- **AK-03** · Angenommen, ein Bild ist angeheftet, wenn es mit der Maus gezogen wird, dann
+  bewegt sich das Fenster mit.
+- **AK-04** · Angenommen, ein Bild ist angeheftet, wenn mit gedrückter Umschalttaste gezogen
+  wird, dann ändert sich die Größe unter Beibehaltung des Seitenverhältnisses, mindestens
+  jedoch 100 Punkte Breite.
+- **AK-05** · Angenommen, ein Bild ist angeheftet, wenn über ihm gescrollt wird, dann ändert
+  sich die Durchsichtigkeit zwischen 20 % und 100 %.
+- **AK-06** · Angenommen, der Zeiger liegt über einem angehefteten Bild, wenn er dort
+  verweilt, dann erscheint links oben eine Schaltfläche zum Schließen.
+- **AK-07** · Angenommen, ein Bild ist angeheftet, wenn es mit der rechten Maustaste
+  angeklickt wird, dann stehen *Copy Image*, *Save to Desktop*, *Open in Editor*,
+  *Opacity* (Untermenü) und *Close* zur Wahl.
+- **AK-08** · Angenommen, ein Bild ist angeheftet, wenn doppelt darauf geklickt wird, dann
+  verschwindet es.
+- **AK-09** · Angenommen, Bilder sind angeheftet, wenn das Menüleistensymbol angeklickt
+  wird, dann sind sie im Untermenü *Pinned Screenshots* als „Pin 1", „Pin 2" … aufgeführt
+  und über *Close All* gemeinsam schließbar.
+- **AK-10** · Angenommen, Bilder waren beim Beenden angeheftet, wenn die Anwendung neu
+  startet, dann erscheinen sie wieder — in Standardgröße an Standardposition, **nicht** an
+  ihrem vorherigen Platz und nicht mit ihrer vorherigen Durchsichtigkeit.
+- **AK-11** ⚠ · Angenommen, bereits 20 Bilder sind angeheftet, wenn ein weiteres angeheftet
+  werden soll, dann **geschieht nichts** — ohne jede Rückmeldung.
+  *(`PinnedScreenshotManager.swift:21` schreibt in ein `print()` und gibt `nil` zurück. Der
+  Nutzer wählt *Pin*, der Editor schließt sich womöglich, und kein Fenster erscheint. Zur
+  Klärung vorgelegt.)*
+
+### Datenschutz und Missbrauchsschutz
+
+Stufe A, Abschnitt 1 des Katalogs ausdrücklich in Kraft. **Dieses Feature schreibt
+Bildschirminhalte dauerhaft an einen Ort, den der Nutzer nicht kennt.**
+
+- **AK-12** ⚠ · Angenommen, ein Bild wird angeheftet, wenn die Aktion ausgeführt ist, dann
+  wird es als PNG nach `~/Library/Application Support/MikaScreenSnap/PinnedScreenshots/`
+  geschrieben — **auch dann, wenn das automatische Sichern in den Einstellungen abgeschaltet
+  ist**.
+  *(`PinnedScreenshotManager.swift:30` ruft `savePinnedImage` ohne Prüfung von
+  `autoSaveEnabled`. Wer das automatische Sichern bewusst abgeschaltet hat, legt hier
+  trotzdem Dateien an. Zur Klärung vorgelegt.)*
+- **AK-13** ⚠ · Angenommen, ein angeheftetes Bild wird geschlossen — über die Schaltfläche,
+  das Kontextmenü, den Doppelklick oder *Close All* —, wenn die Aktion ausgeführt ist, dann
+  **bleibt die Datei auf der Festplatte**.
+  *(Im gesamten Feature existiert kein einziger Löschaufruf. `unpinPanel`, `unpinAll` und
+  `closePanel` entfernen nur das Fenster. Zur Klärung vorgelegt.)*
+- **AK-14** ⚠ · Angenommen, mehr Dateien liegen im Ablageordner als 20, wenn die Anwendung
+  startet, dann werden die **alphabetisch ersten zwanzig** wiederhergestellt — bei
+  Zeitstempel-Dateinamen also die **ältesten**. Ein bewusst geschlossenes Bild kann dabei
+  zurückkehren, während ein neueres ausbleibt.
+  *(`PinnedScreenshotManager.swift:62-64` sortiert nach Dateinamen aufsteigend und nimmt
+  die ersten `maxPins`. Zur Klärung vorgelegt.)*
+- **AK-15** ⚠ · Angenommen, der Nutzer öffnet die Speicherverwaltung in den Einstellungen,
+  wenn die Größe angezeigt wird, dann sind die angehefteten Bilder **nicht enthalten**; und
+  *Clear History* löscht sie nicht.
+  *(`AdvancedTabView.swift:85` und `:157` arbeiten ausschließlich über den Verlaufsverwalter,
+  der nur den Bilderordner kennt. Zur Klärung vorgelegt.)*
+- **AK-16** · Angenommen, ein Bild wird angeheftet, wenn es gespeichert wird, dann enthält
+  kein Protokoll seinen Inhalt.
+- **AK-17** · Angenommen, ein Bild ist angeheftet, wenn es sichtbar ist, dann verlässt es
+  den Rechner nicht.
+
+*Abschnitt 4 (Rate Limits): trifft nicht zu. Abschnitt 6 (Geheimnisse): trifft nicht zu.*
+
+## Edge Cases
+
+- **EC-01** · Sehr kleines Bild wird angeheftet → keine Vergrößerung, es bleibt klein.
+- **EC-02** · Angeheftetes Bild wird auf 100 Punkte verkleinert → Untergrenze greift.
+- **EC-03** · Ablageordner wird von Hand geleert → beim nächsten Start erscheinen keine
+  Bilder; laufende Fenster bleiben unberührt.
+- **EC-04** · Datei im Ablageordner ist beschädigt → wird beim Wiederherstellen
+  übersprungen, ohne Meldung.
+- **EC-05** · Anwendung wird beendet, während Bilder angeheftet sind → die Fenster
+  verschwinden, die Dateien bleiben und kehren beim Start zurück.
+- **EC-06** · Bild wird angeheftet, geschlossen, erneut angeheftet → **zwei** Dateien im
+  Ablageordner.
+
+## Fehlbestand
+
+- **FB-01 · Angeheftete Bilder werden nie gelöscht.** Fundstellen:
+  `PinnedScreenshotManager.swift:37-46` (`unpinPanel`, `unpinAll` — nur `orderOut`),
+  `PinnedScreenshotPanel.swift:125` (`closePanel` — nur `orderOut`), sowie das Fehlen jedes
+  `removeItem` im Feature. Folge, in vier Stufen:
+  1. Bildschirminhalte sammeln sich **unbegrenzt** in `Application Support` an.
+  2. Die Obergrenze von 20 gilt für gleichzeitig offene Fenster, nicht für Dateien.
+  3. Geschlossene Bilder kehren beim Neustart zurück (AK-14).
+  4. Der Nutzer sieht diesen Speicher nirgends und kann ihn in der Anwendung nicht leeren
+     (AK-15) — nur über den Finder, wenn er den Ort kennt.
+  Gemessen an der Datenschutzregel des PRD („lokale Ablagen sind eine bewusste
+  Entscheidung") ist das der schwerste Befund der Erfassung.
+- **FB-02 · Das Anheften ignoriert die Einstellung zum automatischen Sichern.** Fundstelle:
+  `PinnedScreenshotManager.swift:30`. Folge: Eine ausdrückliche Entscheidung des Nutzers,
+  nichts auf die Festplatte zu schreiben, wird an dieser Stelle übergangen.
+- **FB-03 · Nur das Bild wird gesichert, nicht seine Anordnung.** Fundstelle:
+  `savePinnedImage` speichert ein PNG, sonst nichts. Folge: Das im README beschriebene
+  „persistent across app restarts" gilt für den Inhalt, nicht für die Anordnung — Position,
+  Größe und Durchsichtigkeit gehen verloren.
+- **FB-04 · Das Erreichen der Obergrenze ist unsichtbar.** Fundstelle:
+  `PinnedScreenshotManager.swift:21`. Folge: *Pin* tut scheinbar nichts.
+- **FB-05 · Die Wiederherstellung sortiert nach Dateinamen, nicht nach Aktualität.**
+  Fundstelle: `PinnedScreenshotManager.swift:62`. Folge: siehe AK-14.
+- **FB-06 · Keine Tests.**
+
+## Offene Fragen
+
+- **OF-01** · Soll das Schließen eines angehefteten Bildes seine Datei löschen? —
+  entscheidet der Autor. Dies ist die Kernfrage des Features.
+- **OF-02** · Soll die Anordnung mitgesichert werden? — entscheidet der Autor.
+- **OF-03** · Soll die Speicherverwaltung in den Einstellungen diesen Ordner einbeziehen? —
+  entscheidet der Autor. Betrifft B11.
+
+## Decision Log
+
+| # | Frage | Entscheidung | Begründung |
+|---|---|---|---|
+| 1 | Wie schwebt das Fenster? | rahmenloses, nicht aktivierendes Panel auf `.floating` | bleibt oben, ohne die Anwendung in den Vordergrund zu holen |
+| 2 | Wie wird gesichert? | PNG je Bild in *Application Support* | dort gehören Programmdaten hin, die der Nutzer nicht selbst verwaltet |
+| 3 | Dateiname mit Millisekunden | wie beim Verlauf auf die Sekunde | verhindert Kollisionen bei schnellem Anheften — im Verlauf fehlt genau das (B09/FB-02) |
+| 4 | Obergrenze 20 | unbegrenzt | Schutz gegen zugestellten Bildschirm |
+| 5 | Anzeigegröße höchstens 400 Punkte breit | Originalgröße | ein Vollbild-Screenshot als schwebendes Fenster wäre unbrauchbar |
+| 6 | Durchsichtigkeit über das Scrollrad | nur über das Kontextmenü | schnell erreichbar, ohne Menü |
+| 7 | Kein Löschen beim Schließen | Datei mit entfernen | **Grund nicht erkennbar.** Erkennbar ist nur, dass Wiederherstellung gewollt war — dass sie auch geschlossene Bilder erfasst, wirkt unbeabsichtigt (FB-01) |

--- a/features/B09-screenshot-verlauf/design.md
+++ b/features/B09-screenshot-verlauf/design.md
@@ -1,0 +1,135 @@
+# B09 · Screenshot-Verlauf — Systemdesign
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · Stack-Profil: `swiftui-macos`
+
+**Kein Code in diesem Dokument.**
+
+## Überblick
+
+Der Verlauf hat keinen Index und keine Datenbank: **Das Verzeichnis ist das Datenmodell.**
+Beim Start liest die Anwendung den eingestellten Ordner aus, filtert auf Bilddateien und
+baut daraus die Liste — bei jedem Start neu. Eine Datei, die von Hand hineingelegt wird,
+erscheint; eine gelöschte verschwindet.
+
+Das Sichern selbst hängt am Ende der Aufnahme: Bevor der Editor öffnet, ist die Datei
+bereits geschrieben. Zusätzlich entsteht ein verkleinertes Vorschaubild in einem
+versteckten Unterordner, damit der Browser nicht bei jedem Öffnen alle Vollbilder laden
+muss.
+
+## Komponentenstruktur
+
+```
+ScreenshotHistoryManager               Zustand und Dateizugriff
+├── autoSave(_:)                       schreibt Datei + Vorschaubild, stellt Eintrag voran
+├── loadHistory()                      liest das Verzeichnis, baut die Liste (im Initialisierer)
+├── deleteItem(_:) / clearAll()        entfernt Dateien endgültig
+├── storageUsage()                     summiert die Größe der Originale
+└── generateThumbnail(for:originalURL:) verkleinert auf max. 200 Punkte, JPEG 0,7
+
+AppPreferences.saveImage(_:)           Namensbildung, Formatwahl, Schreiben
+
+HistoryBrowserWindowController         reguläres Fenster
+└── HistoryBrowserView
+    ├── Suchfeld                       filtert über Datum und Dateiname
+    ├── LazyVGrid                      anpassend, mindestens 180 Punkte je Spalte
+    │   └── Kachel                     Vorschaubild, Datum, Pixelgröße
+    │       └── Kontextmenü            Editor · Kopieren · Anheften · Finder · Löschen
+    └── Leerzustand                    „No Screenshots"
+```
+
+## Datenmodell
+
+### Dateien
+
+| Was | Wo | Benennung |
+|---|---|---|
+| Aufnahme | `<saveLocation>/` | `MikaSnap_JJJJ-MM-TT_HH-mm-ss.png` bzw. `.jpg` |
+| Vorschaubild | `<saveLocation>/.thumbnails/` | **derselbe Dateiname wie das Original**, Inhalt immer JPEG |
+
+### `HistoryItem` — flüchtig, bei jedem Start neu gebildet
+
+| Feld | Typ | Herkunft | Anmerkung |
+|---|---|---|---|
+| `id` | `UUID` | beim Einlesen erzeugt | **nicht stabil über Programmstarts** |
+| `url` | `URL` | Verzeichniseintrag | |
+| `thumbnailURL` | `URL` | abgeleitet, sonst das Original | |
+| `date` | `Date` | **Änderungsdatum der Datei** | nicht der Aufnahmezeitpunkt |
+| `pixelWidth` / `pixelHeight` | `Int` | aus dem Dateikopf gelesen | je Datei ein Lesezugriff |
+
+Beim automatischen Sichern wird der Eintrag mit `Date()` und den Maßen des Bildes im
+Speicher gebildet — beim Neuladen dagegen aus der Datei. Die beiden Wege liefern also
+nicht zwingend dieselben Werte.
+
+## Zugriffsregeln
+
+| Wer | Darf lesen | Darf schreiben | Erzwungen durch |
+|---|---|---|---|
+| Der Nutzer | den eingestellten Ordner | Aufnahmen anlegen und löschen | Dateirechte des Systems |
+| Die Anwendung | denselben Ordner | dito | keine Sandbox, also voller Zugriff im Rahmen der Nutzerrechte |
+
+Es gibt **keine** anwendungsseitige Zugriffsregel: keine Verschlüsselung, keine Abfrage,
+keine Rechteprüfung. Wer Zugriff auf das Benutzerkonto hat, hat Zugriff auf alle
+Aufnahmen. Für Stufe A ist das vertretbar und für macOS üblich — aber es ist eine
+Entscheidung und keine Selbstverständlichkeit, weil der Inhalt hochsensibel sein kann.
+
+## Missbrauchsschutz
+
+| Vorgang | Limit | Anmerkung |
+|---|---|---|
+| automatisches Sichern | **keins** | jede Aufnahme schreibt; keine Obergrenze für Anzahl, Alter oder Gesamtgröße (FB-05) |
+| Löschen | Bestätigungsdialog vor *Clear History* | einzelne Einträge werden ohne Rückfrage gelöscht |
+
+## Externe Dienste
+
+Keine.
+
+## Erkennbare Entscheidungen
+
+| # | Entscheidung | Alternative | Warum so |
+|---|---|---|---|
+| 1 | Verzeichnis statt Index | Datenbank oder Indexdatei | keine Datenhaltung, die mit der Wirklichkeit auseinanderlaufen kann; der Preis ist FB-04 |
+| 2 | Sichern vor dem Öffnen des Editors | beim Schließen des Editors | **Grund nicht dokumentiert.** Erkennbar: nichts soll verloren gehen — Folge ist FB-01 |
+| 3 | Vorschaubilder in `.thumbnails` neben den Originalen | in *Application Support* | bleiben beim Bestand, auch wenn der Ordner verschoben wird |
+| 4 | Vorschaubilder als JPEG bei Qualität 0,7 | verlustfrei | Größe; Vorschau braucht keine Genauigkeit |
+| 5 | Vorschaubild trägt den Namen des Originals | eigene Endung `.jpg` | **Grund nicht erkennbar** — vermutlich Bequemlichkeit beim Zuordnen (FB-06) |
+| 6 | Endgültiges Löschen statt Papierkorb | `NSWorkspace.recycle` | **Grund nicht erkennbar** (FB-08, AK-18) |
+| 7 | Zeitstempel auf die Sekunde | mit Millisekunden | **Grund nicht erkennbar**; an anderer Stelle im Projekt wird feiner aufgelöst (FB-02) |
+| 8 | Suche über Datum und Dateiname | Volltextsuche über die Texterkennung | einfach; die vorhandene Texterkennung wird nicht genutzt |
+
+## Abdeckung der Akzeptanzkriterien
+
+| AK | Erfüllt durch | Anmerkung |
+|---|---|---|
+| AK-01 | `postCapture` → `autoSave` → `saveImage` | |
+| AK-02 | Prüfung von `autoSaveEnabled` in `autoSave` | |
+| AK-03 | Namensbildung in `saveImage` | |
+| AK-04 | Formatzweig mit Qualitätsfaktor | |
+| AK-05 | Verzeichnis wird vor dem Schreiben angelegt | |
+| AK-06 | `generateThumbnail` | Obergrenze 200 Punkte |
+| AK-07 ⚠ | **keine Komponente** — es gibt keine Kollisionsprüfung | |
+| AK-08 ⚠ | `print()` in `saveImage` | erreicht niemanden |
+| AK-09 | `HistoryBrowserWindowController` + `LazyVGrid` | neueste zuerst durch Voranstellen |
+| AK-10 | `filteredItems` | Datum **oder** Dateiname |
+| AK-11 | `ContentUnavailableView` | |
+| AK-12 | Kontextmenü der Kachel | fünf Einträge |
+| AK-13 | `deleteItem` | löscht beide Dateien |
+| AK-14 | Kachelbeschriftung | |
+| AK-15 | `storageUsage` + `formatBytes`, Reiter *Advanced* | |
+| AK-16 | `clearAll` | löscht auch den Vorschauordner |
+| AK-17 ⚠ | `storageUsage` summiert nur Originale | |
+| AK-18 ⚠ | `removeItem` statt Papierkorb | |
+| AK-19 ⚠ | Aufrufreihenfolge in `postCapture` | Gegenstück zu B04/AK-12 |
+| AK-20 | kein Protokollaufruf mit Dateibezug | |
+| AK-21 | keine Verschlüsselung im Feature | bewusst, siehe *Zugriffsregeln* |
+| AK-22 | kein Netzwerkaufruf im Feature | |
+
+## Übergabe an die QA
+
+1. **AK-19 zusammen mit B04 prüfen.** Das ist derselbe Befund von zwei Seiten und der
+   Grund, warum beide Features in der Erfassungsreihenfolge nebeneinanderstehen.
+2. **AK-07 ist reproduzierbar**: zweimal in derselben Sekunde aufnehmen — am ehesten über
+   `⌃⇧⌘5`, das ohne Interaktion auskommt. Danach zählen, wie viele Dateien entstanden sind.
+3. **AK-08** durch einen schreibgeschützten Zielordner erzwingen und beobachten, ob der
+   Nutzer irgendetwas davon mitbekommt.
+4. **FB-04** mit einem gefüllten Ordner messen (etwa 2.000 Dateien) und die Startzeit
+   vergleichen.

--- a/features/B09-screenshot-verlauf/spec.md
+++ b/features/B09-screenshot-verlauf/spec.md
@@ -1,0 +1,188 @@
+# B09 · Screenshot-Verlauf — Spezifikation
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+
+> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+
+## Zweck
+
+Jede Aufnahme wird ohne Zutun als Datei gesichert und bleibt über einen Browser mit
+Vorschaubildern auffindbar. Der Nutzer muss nicht daran denken zu speichern — und findet
+den Screenshot von vorgestern wieder.
+
+## Abhängigkeiten
+
+| Braucht | Status | Warum |
+|---|---|---|
+| B01 Bildschirmaufnahme | `bestand` | ruft das automatische Sichern auf |
+| B11 Einstellungen | `bestand` | liefert Ordner, Format, Qualität und die Speicherverwaltung |
+| B03 Annotationseditor | `bestand` | Ziel von *Open in Editor* |
+| B08 Anheften | `bestand` | Ziel von *Pin to Screen* |
+
+## User Stories
+
+- **US-01** · Als Nutzer möchte ich, dass jede Aufnahme automatisch gesichert wird, damit
+  ich nichts verliere, wenn ich den Editor versehentlich schließe.
+- **US-02** · Als Nutzer möchte ich alte Aufnahmen als Vorschaubilder durchsehen, damit
+  ich die richtige finde, ohne Dateien einzeln zu öffnen.
+- **US-03** · Als Nutzer möchte ich sehen, wie viel Platz die Aufnahmen belegen, und sie
+  auf einen Schlag löschen können.
+
+## Nicht im Scope
+
+- Aufnahmen aus dem Verlauf umbenennen, verschlagworten oder ordnen — nicht vorhanden
+- Automatisches Aufräumen nach Alter oder Größe — nicht vorhanden, siehe FB-05
+- Synchronisation zwischen Rechnern — ausdrücklich nicht (Stufe A, `docs/prd.md`)
+
+## Akzeptanzkriterien
+
+### Automatisches Sichern
+
+- **AK-01** · Angenommen, das automatische Sichern ist aktiviert (Standard), wenn eine
+  Aufnahme entsteht, dann liegt sie danach als Datei im eingestellten Ordner (Standard
+  `~/Pictures/MikaScreenSnap/`).
+- **AK-02** · Angenommen, das automatische Sichern ist deaktiviert, wenn eine Aufnahme
+  entsteht, dann wird **keine** Datei geschrieben und der Verlauf bleibt unverändert.
+- **AK-03** · Angenommen, das Format steht auf PNG (Standard), wenn gesichert wird, dann
+  entsteht eine `.png`-Datei mit dem Namensmuster
+  `MikaSnap_JJJJ-MM-TT_HH-mm-ss.png`.
+- **AK-04** · Angenommen, das Format steht auf JPEG, wenn gesichert wird, dann entsteht
+  eine `.jpg`-Datei mit der eingestellten Qualität (Standard 0,85).
+- **AK-05** · Angenommen, der eingestellte Ordner existiert nicht, wenn gesichert wird,
+  dann wird er angelegt.
+- **AK-06** · Angenommen, eine Aufnahme wird gesichert, wenn sie fertig ist, dann entsteht
+  zusätzlich ein Vorschaubild von höchstens 200 Punkten Kantenlänge im Unterordner
+  `.thumbnails`.
+- **AK-07** ⚠ · Angenommen, zwei Aufnahmen entstehen **innerhalb derselben Sekunde**, wenn
+  beide gesichert werden, dann trägt die zweite denselben Dateinamen und **überschreibt die
+  erste ersatzlos**.
+  *(`AppPreferences.swift:172` bildet den Namen aus einem Zeitstempel mit
+  Sekundengenauigkeit; `:194` schreibt ohne Prüfung auf Vorhandensein. Das Anheften
+  verwendet an vergleichbarer Stelle Millisekunden, das Sichern nicht. Zur Klärung
+  vorgelegt.)*
+- **AK-08** ⚠ · Angenommen, das Sichern schlägt fehl — etwa weil der Ordner nicht
+  beschreibbar ist —, wenn der Fehler auftritt, dann **erfährt der Nutzer nichts davon**:
+  Es erscheint keine Meldung, und die Aufnahme ist nach dem Schließen des Editors verloren.
+  *(`AppPreferences.swift:196` schreibt in ein `print()`, das in einem Programm ohne
+  Dock-Symbol niemanden erreicht. Zur Klärung vorgelegt.)*
+
+### Verlauf-Browser
+
+- **AK-09** · Angenommen, Aufnahmen existieren, wenn `⇧⌘H` gedrückt oder *Screenshot
+  History* gewählt wird, dann öffnet sich ein Fenster mit einem Raster aus Vorschaubildern,
+  neueste zuerst.
+- **AK-10** · Angenommen, der Verlauf ist offen, wenn in das Suchfeld getippt wird, dann
+  bleiben nur Einträge übrig, deren **Datum oder Dateiname** den Text enthalten.
+- **AK-11** · Angenommen, der Verlauf ist leer, wenn er geöffnet wird, dann erscheint der
+  Hinweis „No Screenshots — Take a screenshot to see it here."
+- **AK-12** · Angenommen, ein Eintrag ist sichtbar, wenn er mit der rechten Maustaste
+  angeklickt wird, dann stehen *Open in Editor*, *Copy*, *Pin to Screen*, *Show in Finder*
+  und *Delete* zur Wahl.
+- **AK-13** · Angenommen, ein Eintrag wird gelöscht, wenn die Aktion ausgeführt ist, dann
+  sind Originaldatei **und** Vorschaubild entfernt und der Eintrag verschwindet aus dem
+  Raster.
+- **AK-14** · Angenommen, ein Eintrag ist sichtbar, wenn er angezeigt wird, dann stehen
+  darunter Datum und Pixelgröße.
+
+### Speicherverwaltung
+
+- **AK-15** · Angenommen, die Einstellungen sind offen, wenn der Reiter *Advanced* gewählt
+  wird, dann stehen dort Anzahl und Gesamtgröße der Aufnahmen.
+- **AK-16** · Angenommen, *Clear History* wird bestätigt, wenn die Aktion läuft, dann sind
+  alle Aufnahmen und der gesamte `.thumbnails`-Ordner gelöscht.
+- **AK-17** ⚠ · Angenommen, die Speichergröße wird angezeigt, wenn sie berechnet wird, dann
+  zählt sie **nur die Originaldateien** — die Vorschaubilder fehlen in der Summe.
+  *(`ScreenshotHistoryManager.swift:110` summiert über `items`, also über Originale. Zur
+  Klärung vorgelegt.)*
+- **AK-18** ⚠ · Angenommen, Aufnahmen werden gelöscht, wenn die Aktion läuft, dann werden
+  sie **endgültig entfernt**, nicht in den Papierkorb gelegt.
+  *(`ScreenshotHistoryManager.swift:92` und `:101` benutzen `removeItem`. Zur Klärung
+  vorgelegt.)*
+
+### Datenschutz und Missbrauchsschutz
+
+Stufe A, Abschnitt 1 des Katalogs ausdrücklich in Kraft. Dieses Feature legt
+Bildschirminhalte **dauerhaft und unverschlüsselt** auf der Festplatte ab — es ist die
+Stelle, an der aus einem flüchtigen Bild eine Datei wird.
+
+- **AK-19** ⚠ · Angenommen, eine Aufnahme entsteht, wenn sie gesichert wird, dann geschieht
+  das **vor** dem Öffnen des Editors — also mit dem **unbearbeiteten Original**. Zensiert
+  der Nutzer anschließend einen Bereich, bleibt die unzensierte Datei bestehen.
+  *(`CaptureEngine.swift:427`. Gegenstück zu B04/AK-12. Zur Klärung vorgelegt — dies ist
+  der schwerwiegendste Einzelbefund der Erfassung.)*
+- **AK-20** · Angenommen, eine Aufnahme wird gesichert, wenn die Datei entsteht, dann
+  enthält kein Protokoll ihren Inhalt oder ihren Dateinamen.
+- **AK-21** · Angenommen, Aufnahmen liegen im Verlaufsordner, wenn darauf zugegriffen wird,
+  dann gelten ausschließlich die Dateirechte des Systems — die Anwendung verschlüsselt
+  nichts und fragt nichts ab.
+- **AK-22** · Angenommen, Aufnahmen existieren, wenn die Anwendung sie sichert, dann
+  verlässt keine davon den Rechner.
+
+*Abschnitt 4 (Rate Limits): trifft nicht zu. Abschnitt 6 (Geheimnisse): trifft nicht zu.*
+
+## Edge Cases
+
+- **EC-01** · Verlaufsordner wird während des Betriebs gelöscht → beim nächsten Sichern neu
+  angelegt; der angezeigte Verlauf zeigt bis zum Neustart Einträge ohne Datei.
+- **EC-02** · Datei wird im Finder gelöscht, während der Verlauf offen ist → der Eintrag
+  bleibt sichtbar, die Aktionen schlagen still fehl.
+- **EC-03** · Fremde Bilddatei wird in den Ordner gelegt → erscheint beim nächsten Start im
+  Verlauf, ohne Vorschaubild.
+- **EC-04** · Sehr viele Aufnahmen im Ordner → siehe FB-04, der Start verzögert sich.
+- **EC-05** · Ordner auf einem nicht eingebundenen Netzlaufwerk → Sichern schlägt fehl,
+  siehe AK-08.
+- **EC-06** · Vorschaubild fehlt → der Eintrag verweist ersatzweise auf das Original.
+
+## Fehlbestand
+
+- **FB-01 · Das automatisch Gesicherte ist immer das Original, nie das Bearbeitete.**
+  Fundstelle: `CaptureEngine.swift:427`. Folge: siehe B04/FB-01 — die Zensur schützt nur
+  das Weitergegebene. Zusätzlich: Annotationen gehen verloren, wenn der Nutzer den Editor
+  schließt, ohne zu exportieren; im Verlauf liegt dann nur die rohe Aufnahme.
+- **FB-02 · Namenskollision innerhalb einer Sekunde führt zu Datenverlust.** Fundstelle:
+  `AppPreferences.swift:172` (Format ohne Millisekunden), `:194` (Schreiben ohne Prüfung).
+  Folge: Zwei schnell aufeinanderfolgende Aufnahmen hinterlassen nur eine Datei — ohne
+  Meldung. Dass `PinnedScreenshotManager.swift:79` an gleicher Stelle Millisekunden
+  verwendet, zeigt, dass das Problem an anderer Stelle erkannt wurde.
+- **FB-03 · Fehlgeschlagenes Sichern bleibt unbemerkt.** Fundstelle:
+  `AppPreferences.swift:196`. Folge: Datenverlust ohne Hinweis — die schwerste Ausprägung
+  des projektweiten Befunds FB-AS-03.
+- **FB-04 · Der Verlauf wird beim Start vollständig und synchron eingelesen.** Fundstelle:
+  `ScreenshotHistoryManager.swift:26` (`loadHistory()` im Initialisierer), `:75`
+  (`imageSize(at:)` öffnet **jede** Datei einzeln). Folge: Der Programmstart wird mit
+  wachsendem Verlauf spürbar langsamer, weil für jede Datei die Bildgröße aus dem Dateikopf
+  gelesen wird — auf dem Hauptthread.
+- **FB-05 · Kein Aufräumen, keine Obergrenze.** Es gibt weder Höchstzahl noch Höchstalter
+  noch Höchstgröße. Folge: Der Ordner wächst unbegrenzt; die einzige Bereinigung ist
+  „alles löschen".
+- **FB-06 · Vorschaubilder tragen die Endung des Originals.** Fundstelle:
+  `ScreenshotHistoryManager.swift:134` — der Name wird vom Original übernommen, der Inhalt
+  ist immer JPEG. Folge: Ein Vorschaubild heißt `….png` und enthält JPEG-Daten. Funktioniert
+  unter macOS, ist aber irreführend.
+- **FB-07 · `HistoryItem.id` und `date` bedeuten nicht, wonach sie aussehen.** Die Kennung
+  wird bei jedem Start neu vergeben, das Datum ist das Änderungsdatum der Datei. Folge:
+  Kennungen dürfen nie über einen Programmstart hinweg verwendet werden; ein Kopiervorgang
+  ändert das angezeigte Datum.
+- **FB-08 · `clearAll()` löscht nur, was geladen wurde.** Fundstelle:
+  `ScreenshotHistoryManager.swift:99`. Folge: Dateien im Ordner, die beim Start nicht
+  eingelesen wurden, bleiben liegen, obwohl der Nutzer „alles löschen" gewählt hat.
+- **FB-09 · Keine Tests.**
+
+## Offene Fragen
+
+- **OF-01** · Soll das automatische Sichern erst beim Schließen des Editors geschehen — mit
+  dem bearbeiteten Bild? — entscheidet der Autor. Betrifft B04 unmittelbar.
+- **OF-02** · Sollen gelöschte Aufnahmen in den Papierkorb wandern? — entscheidet der Autor.
+- **OF-03** · Soll es eine Obergrenze oder automatisches Aufräumen geben? — entscheidet der
+  Autor.
+
+## Decision Log
+
+| # | Frage | Entscheidung | Begründung |
+|---|---|---|---|
+| 1 | Wo liegt der Verlauf? | im Dateisystem, kein Index | das Verzeichnis **ist** das Datenmodell — robust gegenüber fremden Änderungen |
+| 2 | Wann wird gesichert? | sofort nach der Aufnahme | **Grund nicht dokumentiert.** Erkennbar: nichts soll verloren gehen, auch wenn der Editor abstürzt — der Preis ist FB-01 |
+| 3 | Vorschaubilder als JPEG mit Qualität 0,7 | PNG wie das Original | kleiner; Vorschaubilder brauchen keine Verlustfreiheit |
+| 4 | Vorschaubilder in einem versteckten Unterordner | eigener Ort in *Application Support* | sie bleiben beim Original, ohne im Finder aufzufallen |
+| 5 | Suche über Datum und Dateiname | Inhaltssuche über die Texterkennung | einfach zu bauen; die Texterkennung ist zwar vorhanden (B05), wird hier aber nicht genutzt |
+| 6 | Zeitstempel ohne Millisekunden | mit Millisekunden wie beim Anheften | **Grund nicht erkennbar** — siehe FB-02 |

--- a/features/B10-tastenkombinationen/design.md
+++ b/features/B10-tastenkombinationen/design.md
@@ -1,0 +1,115 @@
+# B10 · Tastenkombinationen — Systemdesign
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · Stack-Profil: `swiftui-macos`
+
+**Kein Code in diesem Dokument.**
+
+## Überblick
+
+Systemweite Tastenkombinationen laufen über die Carbon-Schnittstelle `RegisterEventHotKey`
+— die einzige, die ohne Bedienungshilfen-Berechtigung auskommt. Das ist eine
+Datenschutzentscheidung: Ein Ereignisabgriff sähe **jede** Taste, die der Nutzer drückt;
+diese Schnittstelle meldet ausschließlich die angemeldeten Kombinationen.
+
+Der Preis ist eine C-Schnittstelle ohne Zustandsbezug. Der Rückruf ist ein einfacher
+Funktionszeiger, weshalb die Anwendung sich selbst über einen statischen Verweis
+wiederfindet und die Kennung der ausgelösten Kombination auf eine von sieben Rückrufaktionen
+abbildet.
+
+## Komponentenstruktur
+
+```
+HotkeyManager                          @MainActor
+├── currentBindings                    Aktion → Belegung
+├── sieben Rückrufe                    je Aktion einer
+├── statischer Verweis auf sich selbst nonisolated(unsafe) — Brücke zum C-Rückruf
+├── registerHotkeys()                  installiert den Behandler **und** meldet die 7 an
+├── unregisterAll()                    meldet die 7 ab — **nicht** den Behandler
+├── reRegisterAll(bindings:)           abmelden · sichern · erneut anmelden
+└── saveBindings()                     JSON in die Benutzereinstellungen
+
+HotkeyAction                           7 Fälle, je mit Voreinstellung, Beschriftung, Kennung
+HotkeyBinding                          Tastencode + Zusatztasten-Maske
+
+ShortcutsTabView                       Reiter *Shortcuts*
+├── Aufzeichner je Zeile               nimmt die nächste Kombination auf
+├── Konflikthinweis                    nur gegen die eigenen sieben
+├── „Apply"                            → reRegisterAll
+└── „Restore Defaults"                 → reRegisterAll mit den Voreinstellungen
+```
+
+**Der Aufbau von `registerHotkeys()` ist die Ursache von FB-01:** Die Methode leistet
+zweierlei — den Ereignisbehandler installieren und die Kombinationen anmelden —, wird aber
+mehrfach aufgerufen, während nur der zweite Teil ein Gegenstück in `unregisterAll()` hat.
+
+## Datenmodell
+
+| Schlüssel | Typ | Inhalt |
+|---|---|---|
+| `hotkeyBindings` | Data (JSON) | Zuordnung vom Aktionsnamen auf Tastencode und Maske |
+
+```
+HotkeyBinding
+├── keyCode   UInt32    Carbon-Tastencode, z. B. 0x14 = „3"
+└── modifiers UInt32    Maske aus cmdKey · shiftKey · controlKey · optionKey
+```
+
+Für die Anzeige gibt es zwei Umwandlungen: Tastencode → Zeichen (feste Tabelle mit rund
+70 Einträgen) und Maske → Symbole (⌃⌥⇧⌘). Unbekannte Tastencodes erscheinen als
+`Key<Zahl>`.
+
+## Zugriffsregeln
+
+| Wer | Darf | Erzwungen durch |
+|---|---|---|
+| Die Anwendung | von sieben Kombinationen erfahren | Carbon meldet nur Angemeldetes |
+| Die Anwendung | **keine** allgemeinen Tastatureingaben lesen | keine Bedienungshilfen-Berechtigung angefordert |
+
+Das ist die datenschutzrelevante Eigenschaft dieses Features und sollte bei jeder Änderung
+erhalten bleiben: Sobald ein Ereignisabgriff hinzukäme, sähe die Anwendung alles.
+
+## Missbrauchsschutz
+
+Nicht anwendbar.
+
+## Externe Dienste
+
+Keine.
+
+## Erkennbare Entscheidungen
+
+| # | Entscheidung | Alternative | Warum so |
+|---|---|---|---|
+| 1 | Carbon statt Ereignisabgriff | `CGEventTap` oder `NSEvent`-Beobachter | braucht keine Bedienungshilfen-Berechtigung und sieht keine fremden Eingaben |
+| 2 | Statischer Verweis als Brücke | Nutzerdaten am Rückruf | die C-Schnittstelle führt keinen Zustand mit; in `CLAUDE.md` festgehalten |
+| 3 | Kennungen 1–7 statt Aufzählungswerten | Zeichenketten | die Kennung der Kombination ist eine Ganzzahl |
+| 4 | Rückruf auf den Hauptthread verlagert | im Rückruf arbeiten | Carbon ruft nicht zwingend auf dem Hauptthread |
+| 5 | Belegungen als JSON | einzelne Schlüssel je Aktion | ein Schlüssel für alles; ohne Schemaversion |
+| 6 | Behandler und Anmeldung in einer Methode | getrennt | **Grund nicht erkennbar** — Ursache von FB-01 |
+
+## Abdeckung der Akzeptanzkriterien
+
+| AK | Erfüllt durch | Anmerkung |
+|---|---|---|
+| AK-01 | `RegisterEventHotKey` + Ereignisbehandler | |
+| AK-02 | `defaultBinding` je Aktion | |
+| AK-03 | Aufzeichner im Reiter *Shortcuts* | |
+| AK-04 | Vergleich in `ShortcutsTabView` | nur intern |
+| AK-05 | `saveBindings` + Laden im Initialisierer | |
+| AK-06 | *Restore Defaults* → `reRegisterAll` | |
+| AK-07 ⚠ | Fehlerprotokoll ohne Oberfläche | |
+| AK-08 ⚠ | wiederholtes `InstallEventHandler` | **ohne Gegenstück** |
+| AK-09 | Wahl der Schnittstelle | die tragende Datenschutzeigenschaft |
+| AK-10 | `HotkeyBinding` enthält nur Zahlen | |
+| AK-11 | nur Fehlschläge werden protokolliert | |
+
+## Übergabe an die QA
+
+1. **AK-08 ist zählbar und sollte zuerst geprüft werden.** Anwendung starten, im Reiter
+   *Shortcuts* zweimal eine Belegung ändern, dann `⌃⇧⌘3` **einmal** drücken und zählen, wie
+   viele Editorfenster und Dateien entstehen. Erwartung nach Aktenlage: drei.
+   Gegenprobe über *Reset All Preferences*, das denselben Weg nimmt.
+2. **AK-07**: eine vom System belegte Kombination zuweisen und prüfen, ob die Oberfläche
+   irgendetwas meldet.
+3. **AK-09** ist eine Zusicherung, die erhalten bleiben muss: prüfen, dass die Anwendung
+   nicht in der Liste der Bedienungshilfen-Berechtigungen auftaucht.

--- a/features/B10-tastenkombinationen/spec.md
+++ b/features/B10-tastenkombinationen/spec.md
@@ -1,0 +1,131 @@
+# B10 · Tastenkombinationen — Spezifikation
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+
+> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+
+## Zweck
+
+Sieben Funktionen sind systemweit über Tastenkombinationen erreichbar, ohne dass die
+Anwendung im Vordergrund sein muss. Alle sieben lassen sich umbelegen.
+
+## Abhängigkeiten
+
+| Braucht | Status | Warum |
+|---|---|---|
+| B01, B05, B06, B07, B09 | `bestand` | die ausgelösten Funktionen |
+| B11 Einstellungen | `bestand` | beherbergt den Reiter *Shortcuts* |
+
+## User Stories
+
+- **US-01** · Als Nutzer möchte ich aus jedem Programm heraus aufnehmen können, ohne zur
+  Menüleiste zu greifen.
+- **US-02** · Als Nutzer möchte ich Kombinationen ändern können, wenn sie mit anderen
+  Programmen kollidieren.
+- **US-03** · Als Nutzer möchte ich zu den Voreinstellungen zurückkehren können.
+
+## Nicht im Scope
+
+- Kombinationen für Werkzeuge im Editor — die sind fest und Teil von B03
+- Mehrere Kombinationen für dieselbe Funktion — nicht vorhanden
+- Kombinationen ohne Zusatztaste — von der verwendeten Systemschnittstelle nicht sinnvoll
+  unterstützt
+
+## Akzeptanzkriterien
+
+- **AK-01** · Angenommen, die Anwendung läuft, wenn eine der sieben Kombinationen gedrückt
+  wird, dann wird die zugehörige Funktion ausgelöst — unabhängig davon, welches Programm
+  gerade im Vordergrund ist.
+- **AK-02** · Angenommen, die Anwendung startet zum ersten Mal, wenn die Kombinationen
+  angemeldet werden, dann gelten: `⌃⇧⌘3` Vollbild, `⌃⇧⌘4` Bereich, `⌃⇧⌘5` vorderstes
+  Fenster, `⇧⌘6` Text erfassen, `⇧⌘7` Farbpipette, `⇧⌘8` Messen, `⇧⌘H` Verlauf.
+- **AK-03** · Angenommen, der Reiter *Shortcuts* ist offen, wenn eine Zeile zum Aufzeichnen
+  angeklickt wird, dann wird die nächste gedrückte Kombination übernommen und in
+  Symbolschreibweise angezeigt.
+- **AK-04** · Angenommen, eine Kombination ist bereits einer **anderen Funktion dieser
+  Anwendung** zugewiesen, wenn sie aufgezeichnet wird, dann erscheint der Hinweis „Conflict
+  with <Funktion>".
+- **AK-05** · Angenommen, Kombinationen wurden geändert, wenn die Anwendung neu startet,
+  dann gelten die geänderten.
+- **AK-06** · Angenommen, der Reiter *Shortcuts* ist offen, wenn *Restore Defaults* gewählt
+  wird, dann gelten wieder die sieben Voreinstellungen.
+- **AK-07** ⚠ · Angenommen, eine Kombination ist bereits vom System oder einem anderen
+  Programm belegt, wenn sie zugewiesen wird, dann **schlägt die Anmeldung still fehl**: Die
+  Einstellung zeigt die neue Kombination, sie löst aber nichts aus.
+  *(`HotkeyManager.swift:245` protokolliert den Fehler und fährt fort; die Oberfläche erfährt
+  nichts davon. Die Konflikterkennung in `ShortcutsTabView.swift:82` vergleicht
+  ausschließlich mit den eigenen sieben Aktionen. Zur Klärung vorgelegt.)*
+- **AK-08** ⚠ · Angenommen, die Belegung wurde seit dem Start **n**-mal geändert, wenn danach
+  eine Kombination gedrückt wird, dann wird die zugehörige Funktion **(n+1)-mal** ausgelöst.
+  *(`HotkeyManager.swift:234` ruft `InstallEventHandler` innerhalb von `registerHotkeys()`.
+  Diese Methode läuft im Initialisierer **und** bei jedem `reRegisterAll`. Ein Aufruf von
+  `RemoveEventHandler` existiert im gesamten Quelltext nicht, und die Kennung des
+  installierten Handlers wird nicht einmal aufbewahrt. `unregisterAll` entfernt nur die
+  Kombinationen selbst, nicht den Ereignisbehandler. Folge: Wer im Reiter *Shortcuts*
+  zweimal etwas ändert, löst mit `⌃⇧⌘3` danach drei Aufnahmen aus. Zur Klärung vorgelegt —
+  dies ist der schwerste Befund dieses Features.)*
+
+### Datenschutz und Missbrauchsschutz
+
+Stufe A, Abschnitt 1 in Kraft.
+
+- **AK-09** · Angenommen, Kombinationen sind angemeldet, wenn Tasten gedrückt werden, dann
+  erfährt die Anwendung **ausschließlich** von den sieben angemeldeten Kombinationen — die
+  verwendete Systemschnittstelle liefert keine allgemeinen Tastatureingaben und die
+  Anwendung fordert keine Bedienungshilfen-Berechtigung an.
+- **AK-10** · Angenommen, Kombinationen werden gespeichert, wenn sie abgelegt werden, dann
+  enthalten die Daten nur Tastencodes und Zusatztasten-Masken.
+- **AK-11** · Angenommen, eine Kombination wird ausgelöst, wenn das geschieht, dann steht
+  nichts davon in einem Protokoll; protokolliert wird nur eine **fehlgeschlagene Anmeldung**.
+
+*Abschnitt 4 (Rate Limits) und Abschnitt 6 (Geheimnisse): treffen nicht zu.*
+
+## Edge Cases
+
+- **EC-01** · Kombination bereits vom System belegt (etwa `⌘Leertaste`) → siehe AK-07.
+- **EC-02** · Aufzeichnung mit `Escape` → Verhalten ungeprüft.
+- **EC-03** · Kombination ohne Zusatztaste → wird angenommen, fängt danach aber
+  gewöhnliche Tasteneingaben systemweit ab.
+- **EC-04** · Gespeicherte Belegung ist beschädigt → Rückfall auf die Voreinstellungen, weil
+  die Dekodierung fehlschlägt.
+- **EC-05** · Zwei Funktionen auf derselben Kombination trotz Warnung → die zuletzt
+  angemeldete gewinnt; die andere schlägt still fehl.
+- **EC-06** · Kombination wird gedrückt, während bereits eine Auswahl läuft → die alte wird
+  verworfen (B01/EC-07).
+
+## Fehlbestand
+
+- **FB-01 · Ereignisbehandler werden bei jeder Neuanmeldung erneut installiert.**
+  Fundstelle: `HotkeyManager.swift:234`, ohne Gegenstück. Folge: mehrfaches Auslösen nach
+  jeder Änderung der Belegung — mehrere Aufnahmen, mehrere Editorfenster, mehrere Dateien
+  aus einem Tastendruck. Über `AdvancedTabView.swift:170` (*Reset All Preferences*) tritt
+  derselbe Effekt auf, ohne dass der Nutzer die Kombinationen überhaupt angefasst hat.
+- **FB-02 · Fehlgeschlagene Anmeldungen bleiben unsichtbar.** Fundstelle:
+  `HotkeyManager.swift:245`. Folge: Eine Kombination steht in den Einstellungen und tut
+  nichts; der Grund ist nur in der Konsole zu finden.
+- **FB-03 · Die Konflikterkennung kennt nur die eigene Anwendung.** Fundstelle:
+  `ShortcutsTabView.swift:82`. Folge: Der häufigste Konfliktfall — mit dem System oder
+  einem anderen Programm — wird nicht erkannt. Zusammen mit FB-02 gibt es dafür keinerlei
+  Rückmeldung.
+- **FB-04 · Keine Prüfung auf sinnlose Belegungen.** Eine Kombination ohne Zusatztaste wird
+  angenommen und fängt danach systemweit eine gewöhnliche Taste ab.
+- **FB-05 · Keine Tests.** Kodierung und Dekodierung der Belegung sowie die
+  Symbolschreibweise sind reine Umwandlung und ideal prüfbar.
+
+## Offene Fragen
+
+- **OF-01** · Soll die Anmeldung eines Ereignisbehandlers einmalig erfolgen? — entscheidet
+  der Autor. Bis dahin gilt AK-08 als beschriebenes Verhalten.
+- **OF-02** · Soll eine fehlgeschlagene Anmeldung in der Oberfläche erscheinen? —
+  entscheidet der Autor.
+
+## Decision Log
+
+| # | Frage | Entscheidung | Begründung |
+|---|---|---|---|
+| 1 | Welche Schnittstelle für systemweite Kombinationen? | Carbon `RegisterEventHotKey` | die einzige, die ohne Bedienungshilfen-Berechtigung auskommt — ein Ereignisabgriff bräuchte weitreichende Rechte |
+| 2 | Wie findet der Rückruf zur Instanz? | statischer Verweis, `nonisolated(unsafe)` | Carbon-Rückrufe sind C-Funktionszeiger ohne Zustand; in `CLAUDE.md` als Muster festgehalten |
+| 3 | Signatur `0x4D534E53` | beliebiger Wert | „MSNS" als Kennzeichnung der Anwendung |
+| 4 | Wie werden Belegungen gespeichert? | JSON in den Benutzereinstellungen | Tastencode und Maske sind Zahlen; es gibt keine Schemaversion (siehe `docs/datenmodell.md`, FB-DM-06) |
+| 5 | Rückfall bei fehlerhaften Daten | Voreinstellungen | besser als keine Kombinationen |
+| 6 | Konflikterkennung nur intern | auch gegen das System prüfen | **Grund erkennbar**: macOS bietet dafür keine brauchbare Abfrage — dass der Fehlschlag dann aber unsichtbar bleibt, ist die eigentliche Lücke (FB-02) |

--- a/features/B11-einstellungen/design.md
+++ b/features/B11-einstellungen/design.md
@@ -1,0 +1,117 @@
+# B11 · Einstellungen — Systemdesign
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · Stack-Profil: `swiftui-macos`
+
+**Kein Code in diesem Dokument.**
+
+## Überblick
+
+Ein Fenster, das einen SwiftUI-Baum in AppKit einbettet und vier Reiter zeigt. Der Zustand
+liegt vollständig in `AppPreferences` — einer beobachtbaren Klasse, deren Eigenschaften
+beim Setzen unmittelbar in die Benutzereinstellungen schreiben. Es gibt kein „Übernehmen"
+und keinen Zwischenstand.
+
+Die Reiter greifen auf sechs andere Features durch: Verlauf, Tastenkombinationen,
+Ausschlussliste, Anmeldestart, Aktualisierung und Ersteinrichtung. Die Einstellungen selbst
+enthalten kaum eigene Logik — sie sind die Oberfläche zu Zuständen, die anderswo wirken.
+
+**Genau daraus erklären sich die Befunde:** Ein Schalter, dessen Gegenstück im anderen
+Feature fehlt, sieht hier vollständig aus und tut nichts.
+
+## Komponentenstruktur
+
+```
+PreferencesWindowController            .titled .closable
+└── PreferencesContainerView           Reiterauswahl
+    ├── GeneralTabView
+    │   ├── File Output                Ordner · Format · Qualität (nur bei JPEG)
+    │   ├── Capture Behavior           Ton · Schwebevorschau (wirkungslos) · Auto-Sichern
+    │   └── ExcludedAppsSection        → B02
+    ├── ShortcutsTabView               sieben Aufzeichner + Konflikthinweis → B10
+    ├── AnnotationTabView
+    │   ├── Defaults                   Werkzeug · Farbe · Strichstärke (2/4/6)
+    │   └── Behavior                   letztes Werkzeug merken · Beschriftungen (wirkungslos)
+    └── AdvancedTabView
+        ├── System                     Anmeldestart → B13 · automatische Updates → B14
+        ├── Storage                    Anzahl · Größe · Ordner öffnen · Verlauf löschen → B09
+        └── About                      Ersteinrichtung → B12 · Zurücksetzen · Fassung
+
+PreferencesStyles                      Reiterdefinition mit Symbolen und Beschriftungen
+AppPreferences                         der gemeinsame Zustand
+```
+
+## Datenmodell
+
+Vollständig in `docs/datenmodell.md`, Abschnitt 1. Sechzehn Schlüssel in den
+Benutzereinstellungen, davon **vier ohne Leser** (drei hier, einer in B12).
+
+Zwei Eigenheiten:
+
+- `defaultStrokeColorData` wird als archiviertes Farbobjekt abgelegt, nicht als Zahlenwert.
+- `excludedBundleIdentifiers` ist im Speicher eine Menge, in den Einstellungen ein Feld.
+
+## Zugriffsregeln
+
+Keine. Alle Einstellungen gehören dem Nutzer des Rechners.
+
+## Missbrauchsschutz
+
+| Vorgang | Schutz |
+|---|---|
+| *Clear History* | Rückfrage, die die Endgültigkeit benennt |
+| *Reset All Preferences* | Rückfrage |
+| einzelne Einstellungen | keiner nötig |
+
+## Externe Dienste
+
+Keine unmittelbar; der Reiter *Advanced* steuert die Aktualisierungsprüfung aus B14.
+
+## Erkennbare Entscheidungen
+
+| # | Entscheidung | Alternative | Warum so |
+|---|---|---|---|
+| 1 | Sofortiges Speichern beim Setzen | „Übernehmen"-Schaltfläche | entspricht dem Verhalten der Systemeinstellungen |
+| 2 | Ein gemeinsamer Einstellungszustand | je Feature ein eigener | eine Stelle für alle Voreinstellungen; der Preis ist eine Klasse, die fast jedes Feature berührt |
+| 3 | Bindungen mit ausdrücklichem Lesen und Schreiben | `@Bindable` | die Klasse wird als unveränderlicher Verweis übergeben |
+| 4 | Vier Reiter mit Systemsymbolen | eine lange Liste | folgt den Systemeinstellungen |
+| 5 | Systemeigenes Erscheinungsbild | dunkles Markenbild wie im Editor | seit `a43683a`; die Dokumentation nennt weiterhin den alten Zustand (FB-02) |
+| 6 | Qualitätsregler nur bei JPEG | immer sichtbar | er wirkt bei PNG nicht |
+| 7 | Rücksetzen über eine feste Schlüsselliste | gesamte Sammlung entfernen | **Grund nicht erkennbar** (FB-04) |
+
+## Abdeckung der Akzeptanzkriterien
+
+| AK | Erfüllt durch | Anmerkung |
+|---|---|---|
+| AK-01 | `PreferencesWindowController` + Container | `⌘,` im Menü |
+| AK-02 ⚠ | systemeigene Darstellung | Dokumentation abweichend |
+| AK-03 | `NSOpenPanel` im Reiter *General* | |
+| AK-04 | Regler, sichtbar bei JPEG | |
+| AK-05 | dieselbe Bedingung | |
+| AK-06 | `captureSoundEnabled` | gelesen in B01 |
+| AK-07 | `autoSaveEnabled` | gelesen in B09 |
+| AK-08 ⚠ | **kein Leser** | |
+| AK-09 | `ExcludedAppsSection` | → B02 |
+| AK-10 | Übernahme beim Öffnen des Editors | → B03 |
+| AK-11 ⚠ | Standard 3 gegen Auswahl 2/4/6 | |
+| AK-12 | `rememberLastTool` | gelesen in B03 |
+| AK-13 ⚠ | **kein Leser** | |
+| AK-14 | `storageUsage` + Schaltflächen | → B09 |
+| AK-15 | `clearAll` nach Rückfrage | → B09 |
+| AK-16 | Abschnitte *System* und *About* | → B13, B14, B12 |
+| AK-17 | `resetAllPreferences` + Neuanmeldung | |
+| AK-18 ⚠ | feste Schlüsselliste | Farbverlauf und Sparkle bleiben |
+| AK-19 ⚠ | `reRegisterAll` ohne Entfernen des Behandlers | → B10 |
+| AK-20 | nur Pfade, Zahlen, Wahrheitswerte | |
+| AK-21 | nur der Pfad wird abgelegt | |
+| AK-22 | Rückfrage mit Hinweis auf Endgültigkeit | |
+| AK-23 ⚠ | **keine Komponente** | → B08 |
+
+## Übergabe an die QA
+
+1. **AK-08, AK-13 und AK-11** sind in Minuten zu prüfen und betreffen Zusagen, die die
+   Oberfläche macht, ohne sie einzulösen.
+2. **AK-19** hat Außenwirkung: nach *Reset All Preferences* eine Tastenkombination drücken
+   und zählen, wie viele Editorfenster entstehen.
+3. **AK-18** durch Farben abgreifen, zurücksetzen, Menü prüfen.
+4. **AK-02** ist eine Entscheidungsfrage, keine Prüffrage — die QA sollte sie als offenen
+   Punkt weiterreichen, nicht als Fehler bewerten.

--- a/features/B11-einstellungen/spec.md
+++ b/features/B11-einstellungen/spec.md
@@ -1,0 +1,179 @@
+# B11 · Einstellungen — Spezifikation
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+
+> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+
+## Zweck
+
+Ein Fenster mit vier Reitern, in dem sich Speicherort, Format, Verhalten,
+Zeichen-Standards, Tastenkombinationen und die Ausschlussliste einstellen lassen — dazu
+Speicherverwaltung und Zurücksetzen.
+
+## Abhängigkeiten
+
+| Braucht | Status | Warum |
+|---|---|---|
+| B09 Verlauf | `bestand` | Speicherverwaltung und Ordnerwahl |
+| B10 Tastenkombinationen | `bestand` | Reiter *Shortcuts* |
+| B02 App-Ausschluss | `bestand` | Abschnitt *Privacy* |
+| B13 Start bei Login | `bestand` | Schalter im Reiter *Advanced* |
+| B14 Updates | `bestand` | Schalter und Schaltfläche im Reiter *Advanced* |
+| B12 Ersteinrichtung | `bestand` | Schaltfläche *Show Again* |
+
+## User Stories
+
+- **US-01** · Als Nutzer möchte ich festlegen, wohin und in welchem Format Aufnahmen
+  gesichert werden.
+- **US-02** · Als Nutzer möchte ich sehen, wie viel Platz meine Aufnahmen belegen, und sie
+  löschen können.
+- **US-03** · Als Nutzer möchte ich alles auf Anfang zurücksetzen können.
+
+## Nicht im Scope
+
+- Ein- und Ausfuhr der Einstellungen — nicht vorhanden
+- Profile oder mehrere Konfigurationen — nicht vorhanden
+
+## Akzeptanzkriterien
+
+### Rahmen
+
+- **AK-01** · Angenommen, die Anwendung läuft, wenn `⌘,` gedrückt oder *Preferences…*
+  gewählt wird, dann öffnet sich ein Fenster mit den vier Reitern *General*, *Shortcuts*,
+  *Annotation* und *Advanced*.
+- **AK-02** ⚠ · Angenommen, das Fenster ist offen, wenn es angezeigt wird, dann erscheint es
+  im **systemeigenen Erscheinungsbild** und folgt der Hell-/Dunkel-Einstellung des Systems.
+  *(`README.md` und `CHANGELOG.md` (3.4.0) beschreiben es als „dark-themed" im „Mika+ brand
+  aesthetic"; `Sources/Preferences/` enthält **keinen einzigen** Verweis auf die
+  Markenpalette, und der Dateikopf von `PreferencesStyles.swift` lautet „native macOS
+  style". Commit `a43683a` hat das Erscheinungsbild geändert, ohne die Dokumentation
+  nachzuziehen. Zur Klärung vorgelegt: Welche Seite ist falsch?)*
+
+### Reiter *General*
+
+- **AK-03** · Angenommen, der Reiter ist offen, wenn *Change…* gewählt wird, dann lässt sich
+  ein Ordner wählen, in den künftig gesichert wird.
+- **AK-04** · Angenommen, das Format steht auf JPEG, wenn der Reiter angezeigt wird, dann
+  erscheint zusätzlich ein Schieberegler für die Qualität mit Prozentanzeige.
+- **AK-05** · Angenommen, das Format steht auf PNG, wenn der Reiter angezeigt wird, dann ist
+  der Qualitätsregler **nicht** sichtbar.
+- **AK-06** · Angenommen, der Schalter *Capture sound* wird umgelegt, wenn danach aufgenommen
+  wird, dann erklingt der Ton entsprechend.
+- **AK-07** · Angenommen, der Schalter *Auto-save screenshots* wird ausgeschaltet, wenn danach
+  aufgenommen wird, dann entsteht keine Datei im Verlaufsordner.
+- **AK-08** ⚠ · Angenommen, der Schalter *Floating preview* wird eingeschaltet und eine
+  Dauer gewählt, wenn danach aufgenommen wird, dann **geschieht nichts anderes als vorher**.
+  *(`floatingPreviewEnabled` und `previewDismissDuration` werden gespeichert, geladen,
+  zurückgesetzt und angeboten — aber von keinem Feature gelesen. Zur Klärung vorgelegt.)*
+- **AK-09** · Angenommen, der Abschnitt *Privacy* ist sichtbar, wenn er angezeigt wird, dann
+  steht dort die Zahl der ausgeschlossenen Programme und eine Schaltfläche zur Auswahl
+  (Umsetzung in B02).
+
+### Reiter *Annotation*
+
+- **AK-10** · Angenommen, ein Standardwerkzeug, eine Standardfarbe und eine Strichstärke sind
+  gewählt, wenn der Editor öffnet, dann sind sie voreingestellt.
+- **AK-11** ⚠ · Angenommen, die Anwendung wurde nie eingestellt, wenn der Reiter zum ersten
+  Mal geöffnet wird, dann zeigt die Auswahl der Strichstärke **keinen** ausgewählten Wert:
+  Der Standard ist 3, zur Wahl stehen 2 („Thin"), 4 („Medium") und 6 („Thick").
+  *(`AppPreferences.swift:114` und `:162` setzen 3,0; `AnnotationTabView.swift:64-66` bietet
+  2, 4 und 6 an. Zur Klärung vorgelegt.)*
+- **AK-12** · Angenommen, *Remember last used tool* ist eingeschaltet (Standard), wenn der
+  Editor geschlossen wird, dann wird das zuletzt benutzte Werkzeug zum Standard.
+- **AK-13** ⚠ · Angenommen, der Schalter *Show toolbar labels* wird eingeschaltet, wenn der
+  Editor geöffnet wird, dann **erscheinen keine Beschriftungen**.
+  *(`showToolbarLabels` wird von der Werkzeugleiste nicht gelesen. Zur Klärung vorgelegt.)*
+
+### Reiter *Advanced*
+
+- **AK-14** · Angenommen, der Reiter ist offen, wenn er angezeigt wird, dann stehen dort
+  Anzahl und Gesamtgröße der Aufnahmen sowie Schaltflächen zum Öffnen des Ordners und zum
+  Löschen des Verlaufs.
+- **AK-15** · Angenommen, *Clear History* wird gewählt, wenn die Rückfrage bestätigt wird,
+  dann werden alle Aufnahmen und Vorschaubilder endgültig gelöscht.
+- **AK-16** · Angenommen, der Reiter ist offen, wenn er angezeigt wird, dann stehen dort
+  Schalter für den Anmeldestart und die automatische Aktualisierung, eine Schaltfläche zum
+  Prüfen mit dem Zeitpunkt der letzten Prüfung, sowie Fassungsnummer und Erstellungsnummer.
+- **AK-17** · Angenommen, *Reset All Preferences* wird bestätigt, wenn die Aktion läuft, dann
+  stehen alle Einstellungen wieder auf ihren Voreinstellungen und die Tastenkombinationen
+  werden neu angemeldet.
+- **AK-18** ⚠ · Angenommen, *Reset All Preferences* wird ausgeführt, wenn danach nachgesehen
+  wird, dann bleiben **Farbverlauf und Palette erhalten** und die von Sparkle geführten
+  Einstellungen ebenso.
+  *(`AppPreferences.swift:135` führt eine von Hand gepflegte Schlüsselliste ohne
+  `colorHistory`, `colorPalette` und ohne Sparkles eigene Schlüssel. Zur Klärung vorgelegt.)*
+- **AK-19** ⚠ · Angenommen, *Reset All Preferences* wird ausgeführt, wenn danach eine
+  Tastenkombination gedrückt wird, dann wird die zugehörige Funktion **doppelt** ausgelöst.
+  *(`AdvancedTabView.swift:170` ruft `reRegisterAll`, das einen zusätzlichen
+  Ereignisbehandler installiert — siehe B10/AK-08. Zur Klärung vorgelegt.)*
+
+### Datenschutz und Missbrauchsschutz
+
+Stufe A, Abschnitt 1 in Kraft.
+
+- **AK-20** · Angenommen, Einstellungen werden geändert, wenn sie gespeichert werden, dann
+  enthalten sie keine Nutzerinhalte — nur Pfade, Formate, Zahlen und Wahrheitswerte.
+- **AK-21** · Angenommen, ein Ordner wird über *Change…* gewählt, wenn das geschieht, dann
+  wird nur der Pfad gespeichert.
+- **AK-22** · Angenommen, *Clear History* wird ausgeführt, wenn gelöscht wird, dann erscheint
+  vorher eine Rückfrage, die die Endgültigkeit benennt.
+- **AK-23** ⚠ · Angenommen, *Clear History* wird ausgeführt, wenn gelöscht wird, dann bleiben
+  die **angehefteten Bilder** in *Application Support* unberührt und ungenannt.
+  *(Siehe B08/AK-15. Zur Klärung vorgelegt.)*
+
+*Abschnitte 4 und 6 des Katalogs: treffen nicht zu.*
+
+## Edge Cases
+
+- **EC-01** · Gewählter Ordner nicht beschreibbar → fällt erst beim Sichern auf, dort
+  unsichtbar (B09/AK-08).
+- **EC-02** · Gewählter Ordner wird gelöscht → wird beim nächsten Sichern neu angelegt.
+- **EC-03** · Einstellungen offen, während der Verlauf sich ändert → Speicheranzeige wird
+  nicht laufend aktualisiert.
+- **EC-04** · *Reset* bei geöffnetem Editor → der Editor arbeitet mit den bereits
+  übernommenen Werten weiter.
+
+## Fehlbestand
+
+- **FB-01 · Drei Einstellungen ohne jede Wirkung.** `floatingPreviewEnabled`,
+  `previewDismissDuration` (`GeneralTabView.swift:95-121`) und `showToolbarLabels`
+  (`AnnotationTabView.swift:97`). Gegenprobe: `captureSoundEnabled`, `rememberLastTool` und
+  `defaultAnnotationTool` werden sehr wohl gelesen. Folge: Der Nutzer stellt etwas ein, das
+  nichts tut — und hat keinen Anhaltspunkt dafür.
+  *(Zusammen mit `permissionSkipped` aus B12 sind es vier tote Schlüssel im Projekt.)*
+- **FB-02 · Die Dokumentation beschreibt das Fenster falsch.** `README.md`, `CHANGELOG.md`
+  (3.4.0) gegen `Sources/Preferences/`. Folge: siehe AK-02.
+- **FB-03 · Standard-Strichstärke steht nicht zur Auswahl.** Fundstellen:
+  `AppPreferences.swift:114`, `:162` gegen `AnnotationTabView.swift:64-66`. Folge: leere
+  Auswahl beim ersten Öffnen.
+- **FB-04 · Die Rücksetzliste ist von Hand gepflegt.** Fundstelle:
+  `AppPreferences.swift:135`. Folge: Wer einen Schlüssel hinzufügt, muss daran denken, ihn
+  einzutragen — bei `colorHistory` und `colorPalette` ist genau das unterblieben. Eine
+  vollständige Rücknahme über die Sammlung der Anwendungseinstellungen wäre unabhängig
+  davon.
+- **FB-05 · Die Speicherverwaltung kennt nur einen von zwei Ablageorten.** Fundstelle:
+  `AdvancedTabView.swift:85`, `:157`. Folge: siehe AK-23 und B08/FB-01.
+- **FB-06 · Zurücksetzen verdoppelt die Tastenkombinationen.** Fundstelle:
+  `AdvancedTabView.swift:170`. Folge: siehe AK-19.
+- **FB-07 · Keine Rückmeldung nach dem Zurücksetzen.** Es gibt keinen Hinweis, dass die
+  Aktion ausgeführt wurde; sichtbar wird es nur an den geänderten Feldern.
+- **FB-08 · Keine Tests.**
+
+## Offene Fragen
+
+- **OF-01** · Sollen die drei wirkungslosen Einstellungen umgesetzt oder entfernt werden? —
+  entscheidet der Autor.
+- **OF-02** · Ist das Fenster falsch oder die Dokumentation? — entscheidet der Autor.
+- **OF-03** · Soll die Speicherverwaltung beide Ablageorte umfassen? — entscheidet der
+  Autor. Betrifft B08.
+
+## Decision Log
+
+| # | Frage | Entscheidung | Begründung |
+|---|---|---|---|
+| 1 | Wie sind die Einstellungen aufgeteilt? | vier Reiter | folgt dem Aufbau der macOS-Systemeinstellungen |
+| 2 | Wann wird gespeichert? | sofort bei jeder Änderung | kein „Übernehmen"; jede Eigenschaft schreibt beim Setzen |
+| 3 | Wo liegen die Werte? | Benutzereinstellungen, gebündelt in einer Klasse | eine Stelle für alle Voreinstellungen |
+| 4 | Erscheinungsbild | systemeigen, seit `a43683a` | zuvor dunkel im Markenbild; die Dokumentation nennt weiterhin den alten Zustand (FB-02) |
+| 5 | Zurücksetzen über eine feste Schlüsselliste | die gesamte Sammlung entfernen | **Grund nicht erkennbar** — die Folge ist FB-04 |
+| 6 | Endgültiges Löschen mit Rückfrage | Papierkorb ohne Rückfrage | die Rückfrage ist da, der Papierkorb nicht (B09/AK-18) |

--- a/features/B12-ersteinrichtung/design.md
+++ b/features/B12-ersteinrichtung/design.md
@@ -1,0 +1,104 @@
+# B12 · Ersteinrichtung — Systemdesign
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · Stack-Profil: `swiftui-macos`
+
+**Kein Code in diesem Dokument.**
+
+## Überblick
+
+Der Ablauf ist ein SwiftUI-`TabView` in einem gewöhnlichen Fenster, das dem Muster des
+„Über"-Fensters folgt. Seine Besonderheit ist die **Berechtigungserkennung im
+Sekundentakt**: Weil macOS die Anwendung nicht benachrichtigt, wenn der Nutzer in den
+Systemeinstellungen eine Berechtigung erteilt, fragt die Berechtigungsseite jede Sekunde
+selbst nach.
+
+Der Ablauf hat drei oder zwei Seiten, je nachdem, ob die Berechtigung beim Aufbau bereits
+vorliegt. Diese Entscheidung fällt einmal, beim Aufbau der Ansicht.
+
+## Komponentenstruktur
+
+```
+OnboardingWindowController             gewöhnliches Fenster, .titled .closable
+└── OnboardingView                     480 × 560, dunkler Verlauf
+    ├── TabView                        seitenweise, ohne Reiterleiste
+    │   ├── WelcomeScreen              Begrüßung → weiter
+    │   ├── PermissionScreen           nur wenn die Berechtigung fehlt
+    │   │   ├── Zeitgeber, 1 s         fragt die Berechtigung ab
+    │   │   ├── „Open System Settings" öffnet die Systemeinstellung
+    │   │   └── „Skip for now"         setzt permissionSkipped (ohne Wirkung)
+    │   └── ShortcutsScreen            sieben Tastenkombinationen
+    │       ├── Schalter Anmeldestart  voreingestellt ein
+    │       └── „Done"                 setzt den Anmeldestart, schließt
+    ├── Punktanzeige                   Anzahl und Position, nicht bedienbar
+    └── Escape                         schließt sofort
+```
+
+## Datenmodell
+
+| Schlüssel | Typ | Gesetzt von | Gelesen von |
+|---|---|---|---|
+| `hasCompletedOnboarding` | Bool | beim Schließen des Fensters, immer | Programmstart |
+| `permissionSkipped` | Bool | *Skip for now* | **niemandem** |
+
+## Zugriffsregeln
+
+Keine. Der Ablauf liest den Berechtigungszustand des Systems und schreibt zwei
+Wahrheitswerte.
+
+Die Berechtigung selbst wird **nicht** über diesen Ablauf erteilt — er verweist nur
+dorthin. Erteilt wird sie durch den Nutzer in den Systemeinstellungen; wirksam wird sie
+für die Anwendung beim nächsten Aufnahmeversuch.
+
+## Missbrauchsschutz
+
+Nicht anwendbar.
+
+## Externe Dienste
+
+Keine. Der Deeplink `x-apple.systempreferences:` öffnet eine Systemoberfläche, überträgt
+aber nichts.
+
+## Erkennbare Entscheidungen
+
+| # | Entscheidung | Alternative | Warum so |
+|---|---|---|---|
+| 1 | `TabView` seitenweise statt eigener Navigation | eigener Zustandsautomat | mit Bordmitteln, wenige Zeilen |
+| 2 | Abfrage im Sekundentakt | Systembenachrichtigung abwarten | es gibt keine Benachrichtigung für diese Berechtigung |
+| 3 | Sekunde Verzögerung vor dem Weiterblättern | sofort | das grüne Häkchen soll gesehen werden |
+| 4 | Seitenzahl beim Aufbau festgelegt | fortlaufend anpassen | verhindert, dass sich die Seitenstruktur unter dem Nutzer verändert — mit der Folge von EC-01 |
+| 5 | Fenster folgt dem Muster des „Über"-Fensters | eigenes Muster | in `CLAUDE.md` als Konvention festgehalten |
+| 6 | Aufgabe zum Weiterblättern wird beim Verschwinden abgebrochen | laufen lassen | verhindert Weiterblättern nach dem Schließen |
+
+## Abdeckung der Akzeptanzkriterien
+
+| AK | Erfüllt durch | Anmerkung |
+|---|---|---|
+| AK-01 | `AppDelegate` prüft `hasCompletedOnboarding` beim Start | |
+| AK-02 | `needsPermission` bestimmt den Aufbau | einmalig beim Aufbau |
+| AK-03 | Punktanzeige | |
+| AK-04 | `withAnimation` beim Seitenwechsel | |
+| AK-05 | Deeplink in die Systemeinstellungen | |
+| AK-06 | Zeitgeber + Aufgabe mit einer Sekunde Verzögerung | |
+| AK-07 | *Skip for now* | Vermerk ohne Wirkung |
+| AK-08 | `ShortcutsScreen` | |
+| AK-09 | *Done* → `setEnabled` → schließen | |
+| AK-10 | `windowWillClose` | greift bei **jedem** Schließweg |
+| AK-11 | Rückruf aus den Einstellungen | Umsetzung in B11 |
+| AK-12 ⚠ | `Escape` + `windowWillClose` | |
+| AK-13 ⚠ | Anfangswert `true` | |
+| AK-14 ⚠ | `setEnabled` nur in *Done* | |
+| AK-15 ⚠ | **keine Komponente** — es wird nie angefordert | |
+| AK-16 | Text der Berechtigungsseite | |
+| AK-17 | zwei Wahrheitswerte | |
+| AK-18 ⚠ | `permissionSkipped` ohne Leser | |
+
+## Übergabe an die QA
+
+1. **AK-15 mit einem frischen Benutzerkonto prüfen** — das ist der einzige aussagekräftige
+   Weg. Anwendung installieren, starten, dem Ablauf folgen und feststellen, ob die
+   Anwendung in der Liste der Systemeinstellungen überhaupt erscheint, bevor sie zum ersten
+   Mal aufzunehmen versucht hat. Das ist die praktisch wichtigste Prüfung dieses Features.
+2. **AK-13 und AK-14 zusammen**: Ablauf bis zur letzten Seite, Schalter unangetastet
+   lassen, `Escape` drücken — dann in den Systemeinstellungen nachsehen, ob ein
+   Anmeldeobjekt existiert. Danach dasselbe mit *Done*.
+3. **AK-12**: `Escape` auf der Begrüßungsseite, Anwendung neu starten.

--- a/features/B12-ersteinrichtung/spec.md
+++ b/features/B12-ersteinrichtung/spec.md
@@ -1,0 +1,157 @@
+# B12 · Ersteinrichtung — Spezifikation
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+
+> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+
+## Zweck
+
+Beim ersten Start führt die Anwendung durch drei Bildschirme: Begrüßung, die
+Bildschirmaufnahme-Berechtigung, eine Übersicht der Tastenkombinationen. Danach ist sie
+einsatzbereit — oder der Nutzer weiß zumindest, was ihm fehlt.
+
+## Abhängigkeiten
+
+| Braucht | Status | Warum |
+|---|---|---|
+| B01 Bildschirmaufnahme | `bestand` | die Berechtigung, um die es geht |
+| B13 Start bei Login | `bestand` | Schalter auf dem letzten Bildschirm |
+| B11 Einstellungen | `bestand` | einziger Weg, den Ablauf erneut zu öffnen |
+
+## User Stories
+
+- **US-01** · Als neuer Nutzer möchte ich erfahren, welche Berechtigung gebraucht wird und
+  warum, bevor mich das System danach fragt.
+- **US-02** · Als neuer Nutzer möchte ich die Tastenkombinationen einmal gesehen haben.
+- **US-03** · Als neuer Nutzer möchte ich den Ablauf überspringen können.
+
+## Nicht im Scope
+
+- Einrichtung von Speicherort oder Format — bleibt den Einstellungen überlassen
+- Erklärung einzelner Werkzeuge — nicht vorhanden
+- Erneutes Anzeigen nach einem Update — der Ablauf erscheint nur einmal
+
+## Akzeptanzkriterien
+
+- **AK-01** · Angenommen, die Anwendung wurde noch nie abgeschlossen eingerichtet, wenn sie
+  startet, dann öffnet sich das Einrichtungsfenster (480 × 560) mit dunklem Farbverlauf.
+- **AK-02** · Angenommen, die Berechtigung fehlt, wenn der Ablauf aufgebaut wird, dann hat
+  er **drei** Seiten; ist sie erteilt, hat er **zwei** — der Berechtigungsschritt entfällt.
+- **AK-03** · Angenommen, der Ablauf läuft, wenn er angezeigt wird, dann zeigen Punkte am
+  unteren Rand die Zahl der Seiten und die aktuelle Position.
+- **AK-04** · Angenommen, die Begrüßungsseite ist sichtbar, wenn *Weiter* gewählt wird, dann
+  erscheint die nächste Seite mit einer Übergangsbewegung.
+- **AK-05** · Angenommen, die Berechtigungsseite ist sichtbar und die Berechtigung fehlt,
+  wenn *Open System Settings* gewählt wird, dann öffnet sich die Systemeinstellung für die
+  Bildschirmaufnahme.
+- **AK-06** · Angenommen, die Berechtigungsseite ist sichtbar, wenn die Berechtigung
+  **während** der Anzeige erteilt wird, dann wechselt die Darstellung binnen einer Sekunde
+  auf ein grünes Häkchen und blättert nach einer weiteren Sekunde selbsttätig weiter.
+- **AK-07** · Angenommen, die Berechtigungsseite ist sichtbar, wenn *Skip for now* gewählt
+  wird, dann geht es ohne Berechtigung weiter.
+- **AK-08** · Angenommen, die letzte Seite ist sichtbar, wenn sie angezeigt wird, dann stehen
+  dort alle sieben Tastenkombinationen und ein Schalter *Launch Mika+ScreenSnap at login*.
+- **AK-09** · Angenommen, die letzte Seite ist sichtbar, wenn *Done* gewählt wird, dann wird
+  der Anmeldestart entsprechend dem Schalter gesetzt und das Fenster schließt sich.
+- **AK-10** · Angenommen, das Einrichtungsfenster schließt sich — gleich auf welchem Weg —,
+  wenn es geschlossen ist, dann gilt die Einrichtung als abgeschlossen und erscheint beim
+  nächsten Start nicht mehr.
+- **AK-11** · Angenommen, die Einrichtung ist abgeschlossen, wenn in den Einstellungen
+  *Show Onboarding Again* gewählt wird, dann erscheint sie erneut.
+- **AK-12** ⚠ · Angenommen, der Ablauf ist auf der ersten Seite, wenn `Escape` gedrückt
+  wird, dann schließt er sich und gilt als **abgeschlossen** — der Nutzer sieht ihn nicht
+  wieder, ohne die Einstellungen zu öffnen.
+  *(`OnboardingView.swift:74` behandelt `Escape` als Abschluss;
+  `OnboardingWindow.swift:58` setzt beim Schließen `hasCompletedOnboarding = true`,
+  unabhängig davon, wie weit der Nutzer gekommen ist. Zur Klärung vorgelegt.)*
+- **AK-13** ⚠ · Angenommen, die letzte Seite wird zum ersten Mal angezeigt, wenn der Nutzer
+  nichts ändert, dann ist der Schalter für den Anmeldestart **bereits eingeschaltet** — ein
+  Klick auf *Done* richtet ein Anmeldeobjekt ein, ohne dass der Nutzer es ausdrücklich
+  gewählt hat.
+  *(`ShortcutsScreen.swift:14` setzt den Anfangswert auf `true`. Zur Klärung vorgelegt.)*
+- **AK-14** ⚠ · Angenommen, der Ablauf wird vor der letzten Seite abgebrochen, wenn er
+  schließt, dann wird der Anmeldestart **nicht** gesetzt — obwohl der Schalter „ein" zeigte.
+  *(`ShortcutsScreen.swift:63` ruft `setEnabled` ausschließlich in der *Done*-Aktion.
+  Zusammen mit AK-13 heißt das: Der angezeigte Zustand und der tatsächliche gehen
+  auseinander. Zur Klärung vorgelegt.)*
+
+### Berechtigung
+
+- **AK-15** ⚠ · Angenommen, die Berechtigung fehlt, wenn der Ablauf sie behandelt, dann wird
+  sie **nie beim System angefordert** — es wird nur abgefragt und in die Systemeinstellungen
+  verwiesen.
+  *(Im gesamten Quelltext gibt es fünf Aufrufe von `CGPreflightScreenCaptureAccess()` und
+  **keinen einzigen** von `CGRequestScreenCaptureAccess()`. Folge: Der Systemdialog
+  erscheint nicht; die Anwendung wird erst dann in die Liste der Systemeinstellungen
+  eingetragen, wenn sie zum ersten Mal tatsächlich eine Aufnahme versucht. Ein Nutzer, der
+  im Einrichtungsablauf auf *Open System Settings* klickt, kann dort also vor einer Liste
+  stehen, in der die Anwendung noch gar nicht auftaucht. Zur Klärung vorgelegt.)*
+
+### Datenschutz und Missbrauchsschutz
+
+Stufe A.
+
+- **AK-16** · Angenommen, die Berechtigungsseite wird angezeigt, wenn der Nutzer sie liest,
+  dann nennt sie den Zweck und stellt fest, dass die Daten auf dem Rechner bleiben.
+- **AK-17** · Angenommen, der Ablauf läuft, wenn er abgeschlossen wird, dann werden
+  ausschließlich zwei Wahrheitswerte gespeichert (`hasCompletedOnboarding`,
+  `permissionSkipped`) — keine Nutzerdaten.
+- **AK-18** ⚠ · Angenommen, der Nutzer wählt *Skip for now*, wenn das vermerkt wird, dann
+  bleibt dieser Vermerk **wirkungslos**: `permissionSkipped` wird gespeichert und von
+  **niemandem** gelesen.
+  *(Einzige Fundstelle außerhalb der Einstellungsklasse: `PermissionScreen.swift:63`. Zur
+  Klärung vorgelegt.)*
+
+*Abschnitt 4 (Rate Limits) und Abschnitt 6 (Geheimnisse): treffen nicht zu.*
+
+## Edge Cases
+
+- **EC-01** · Berechtigung wird erteilt, während die Begrüßungsseite sichtbar ist → der
+  Seitenaufbau bleibt dreiseitig, weil er beim Aufbau festgelegt wurde.
+- **EC-02** · Berechtigung wird während der Berechtigungsseite entzogen → die Anzeige
+  wechselt nicht zurück; `granted` kennt nur den Weg vom Fehlen zum Vorhandensein.
+- **EC-03** · Systemeinstellungen lassen sich nicht öffnen → keine Rückmeldung.
+- **EC-04** · Fenster wird über die rote Schaltfläche geschlossen → gilt als abgeschlossen
+  (AK-12).
+- **EC-05** · *Show Onboarding Again* bei erteilter Berechtigung → zweiseitiger Ablauf.
+
+## Fehlbestand
+
+- **FB-01 · Die Berechtigung wird nie angefordert.** Fundstelle: kein Aufruf von
+  `CGRequestScreenCaptureAccess()` im gesamten Quelltext. Folge: Der Erstkontakt führt über
+  eine manuelle Suche in den Systemeinstellungen statt über den vorgesehenen Systemdialog —
+  in einer Liste, in der die Anwendung möglicherweise noch nicht steht. Das ist die
+  wahrscheinlichste Ursache für einen misslungenen ersten Start.
+- **FB-02 · `permissionSkipped` ist wirkungslos.** Fundstelle: `PermissionScreen.swift:63`,
+  ohne Leser. Folge: Der vierte Einstellungsschlüssel ohne Wirkung — die Anwendung könnte
+  darauf aufbauend später erinnern, tut es aber nicht.
+- **FB-03 · Der Abschluss wird durch jedes Schließen ausgelöst.** Fundstelle:
+  `OnboardingWindow.swift:58`. Folge: Ein versehentliches `Escape` auf der ersten Seite
+  beendet die Einrichtung dauerhaft.
+- **FB-04 · Anzeigezustand und Wirkung des Anmeldestarts gehen auseinander.** Fundstellen:
+  `ShortcutsScreen.swift:14` (voreingestellt ein), `:63` (nur bei *Done* gesetzt). Folge:
+  Wer abbricht, hat einen Schalter gesehen, der „ein" zeigte, ohne dass etwas geschah — wer
+  *Done* drückt, richtet ein Anmeldeobjekt ein, ohne es gewählt zu haben.
+- **FB-05 · Kein Weg zurück im Ablauf.** Es gibt nur Vorwärtsnavigation; die Punkte am
+  unteren Rand sind Anzeige, nicht bedienbar.
+- **FB-06 · Keine Tests.**
+
+## Offene Fragen
+
+- **OF-01** · Soll `CGRequestScreenCaptureAccess()` aufgerufen werden, damit der
+  Systemdialog erscheint? — entscheidet der Autor. Betrifft B01.
+- **OF-02** · Soll ein Abbruch vor der letzten Seite als „abgeschlossen" gelten? —
+  entscheidet der Autor.
+- **OF-03** · Soll der Anmeldestart voreingestellt eingeschaltet sein? — entscheidet der
+  Autor.
+
+## Decision Log
+
+| # | Frage | Entscheidung | Begründung |
+|---|---|---|---|
+| 1 | Wie viele Seiten? | drei, oder zwei bei erteilter Berechtigung | keine Seite ohne Zweck zeigen |
+| 2 | Wie wird die Berechtigung erkannt? | Abfrage im Sekundentakt | ohne Delegate merkt die Anwendung sonst nicht, dass der Nutzer sie in den Systemeinstellungen erteilt hat |
+| 3 | Selbsttätiges Weiterblättern nach Erteilung | auf einen Klick warten | der Nutzer kommt gerade aus den Systemeinstellungen zurück und soll nicht suchen |
+| 4 | Anmeldestart im Ablauf statt in den Einstellungen | nur in den Einstellungen | die naheliegende Stelle für eine Entscheidung, die man einmal trifft |
+| 5 | Abschluss beim Schließen des Fensters | erst nach der letzten Seite | **Grund nicht erkennbar** (FB-03) |
+| 6 | Nur abfragen, nie anfordern | `CGRequestScreenCaptureAccess()` aufrufen | **Grund nicht erkennbar** (FB-01) |

--- a/features/B12-ersteinrichtung/spec.md
+++ b/features/B12-ersteinrichtung/spec.md
@@ -81,11 +81,13 @@ einsatzbereit — oder der Nutzer weiß zumindest, was ihm fehlt.
   sie **nie beim System angefordert** — es wird nur abgefragt und in die Systemeinstellungen
   verwiesen.
   *(Im gesamten Quelltext gibt es fünf Aufrufe von `CGPreflightScreenCaptureAccess()` und
-  **keinen einzigen** von `CGRequestScreenCaptureAccess()`. Folge: Der Systemdialog
-  erscheint nicht; die Anwendung wird erst dann in die Liste der Systemeinstellungen
-  eingetragen, wenn sie zum ersten Mal tatsächlich eine Aufnahme versucht. Ein Nutzer, der
-  im Einrichtungsablauf auf *Open System Settings* klickt, kann dort also vor einer Liste
-  stehen, in der die Anwendung noch gar nicht auftaucht. Zur Klärung vorgelegt.)*
+  **keinen einzigen** von `CGRequestScreenCaptureAccess()`. Der einzige Aufruf, der die
+  Anwendung in die Systemliste einträgt — `SCShareableContent.current` in
+  `MikaScreenSnapApp.swift:112` — steht in einem Zweig, der beim Erststart **nicht** läuft
+  (`:44-48`). Folge: Der Systemdialog erscheint nicht, und die Anwendung wird erst beim
+  zweiten Start oder beim ersten Aufnahmeversuch eingetragen. Ein Nutzer, der im
+  Einrichtungsablauf auf *Open System Settings* klickt, steht dort vor einer Liste, in der
+  die Anwendung noch gar nicht auftaucht. Zur Klärung vorgelegt.)*
 
 ### Datenschutz und Missbrauchsschutz
 
@@ -117,11 +119,16 @@ Stufe A.
 
 ## Fehlbestand
 
-- **FB-01 · Die Berechtigung wird nie angefordert.** Fundstelle: kein Aufruf von
-  `CGRequestScreenCaptureAccess()` im gesamten Quelltext. Folge: Der Erstkontakt führt über
-  eine manuelle Suche in den Systemeinstellungen statt über den vorgesehenen Systemdialog —
-  in einer Liste, in der die Anwendung möglicherweise noch nicht steht. Das ist die
-  wahrscheinlichste Ursache für einen misslungenen ersten Start.
+- **FB-01 · Die Berechtigung wird nie angefordert — und beim Erststart nicht einmal
+  angestoßen.** Fundstellen: kein Aufruf von `CGRequestScreenCaptureAccess()` im gesamten
+  Quelltext; zusätzlich `MikaScreenSnapApp.swift:44-48`. Dort steht die Prüfung, die über
+  `SCShareableContent.current` die Anwendung überhaupt erst in die Systemliste einträgt und
+  den Systemdialog auslösen kann — sie läuft aber **nur im `else`-Zweig**, also erst wenn
+  die Ersteinrichtung bereits abgeschlossen ist. Genau beim ersten Start übernimmt die
+  Ersteinrichtung, die ausschließlich abfragt. Folge: Der Nutzer klickt im Onboarding auf
+  *Open System Settings* und steht dort vor einer Liste, in der die Anwendung noch nicht
+  auftaucht — sie wird erst beim zweiten Start oder beim ersten Aufnahmeversuch eingetragen.
+  Das ist die wahrscheinlichste Ursache für einen misslungenen ersten Start.
 - **FB-02 · `permissionSkipped` ist wirkungslos.** Fundstelle: `PermissionScreen.swift:63`,
   ohne Leser. Folge: Der vierte Einstellungsschlüssel ohne Wirkung — die Anwendung könnte
   darauf aufbauend später erinnern, tut es aber nicht.

--- a/features/B13-start-bei-login/design.md
+++ b/features/B13-start-bei-login/design.md
@@ -1,0 +1,73 @@
+# B13 · Automatischer Start bei Login — Systemdesign
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · Stack-Profil: `swiftui-macos`
+
+**Kein Code in diesem Dokument.**
+
+## Überblick
+
+Das kleinste Feature der Anwendung: eine Klasse mit einer abgeleiteten Eigenschaft und
+einer Methode. Sie kapselt den Systemdienst für Anmeldeobjekte und führt **bewusst keinen
+eigenen Zustand** — der Schalter fragt bei jedem Lesen das System.
+
+Das ist die richtige Entscheidung und im Dateikopf begründet: Eine eigene Ablage könnte von
+dem abweichen, was in den Systemeinstellungen steht, und der Nutzer kann dort jederzeit
+eingreifen.
+
+## Komponentenstruktur
+
+```
+LaunchAtLoginManager                   @MainActor, kein eigener Zustand
+├── isEnabled                          fragt den Systemdienst
+└── setEnabled(_:)                     eintragen oder entfernen, Fehler → print()
+
+Einstiegspunkte
+├── Einstellungen → Advanced → Schalter
+└── Ersteinrichtung → letzte Seite → Schalter (voreingestellt ein, B12/AK-13)
+```
+
+## Datenmodell
+
+**Keines.** Der Zustand liegt ausschließlich im System.
+
+## Zugriffsregeln
+
+| Wer | Darf | Erzwungen durch |
+|---|---|---|
+| Die Anwendung | sich selbst als Anmeldeobjekt eintragen und entfernen | Systemdienst; der Nutzer kann in den Systemeinstellungen widersprechen |
+
+## Missbrauchsschutz
+
+Nicht anwendbar.
+
+## Externe Dienste
+
+Keine.
+
+## Erkennbare Entscheidungen
+
+| # | Entscheidung | Alternative | Warum so |
+|---|---|---|---|
+| 1 | Systemdienst für Anmeldeobjekte | Hilfsanwendung mit eigenem Bündel | ab macOS 13 der vorgesehene Weg, ohne eingebettete Hilfsanwendung |
+| 2 | Kein eigener Zustand | Zustand in den Benutzereinstellungen spiegeln | ausdrücklich begründet: das System ist die Wahrheit |
+| 3 | Klasse nicht beobachtbar | `@Observable` | **Grund nicht erkennbar** — trägt zu FB-01 bei |
+
+## Abdeckung der Akzeptanzkriterien
+
+| AK | Erfüllt durch | Anmerkung |
+|---|---|---|
+| AK-01 | `setEnabled(true)` | |
+| AK-02 | `setEnabled(false)` | |
+| AK-03 | `isEnabled` fragt den Systemdienst | |
+| AK-04 | Aufruf in der Ersteinrichtung | Umsetzung in B12 |
+| AK-05 | ausschließlich der Systemdienst | belegbar: keine weitere Schnittstelle im Feature |
+| AK-06 | kein Schlüssel in den Einstellungen | |
+| AK-07 ⚠ | `print()` + fehlende Beobachtbarkeit | |
+
+## Übergabe an die QA
+
+1. **AK-07** erzwingen, indem die Anwendung außerhalb von `/Applications` betrieben wird —
+   etwa direkt aus dem Erstellungsverzeichnis. Beobachten, ob der Schalter danach den
+   tatsächlichen Zustand zeigt.
+2. **AK-03** prüfen: Anmeldeobjekt in den Systemeinstellungen entfernen, dann die
+   Einstellungen der Anwendung öffnen.

--- a/features/B13-start-bei-login/spec.md
+++ b/features/B13-start-bei-login/spec.md
@@ -1,0 +1,93 @@
+# B13 · Automatischer Start bei Login — Spezifikation
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+
+> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+
+## Zweck
+
+Die Anwendung startet auf Wunsch bei der Anmeldung am Mac mit. Bei einem Werkzeug, das in
+der Menüleiste wohnt und über Tastenkombinationen bedient wird, ist das die Voraussetzung
+dafür, dass es überhaupt bereitsteht.
+
+## Abhängigkeiten
+
+| Braucht | Status | Warum |
+|---|---|---|
+| B11 Einstellungen | `bestand` | Schalter im Reiter *Advanced* |
+| B12 Ersteinrichtung | `bestand` | Schalter auf der letzten Seite |
+
+## User Stories
+
+- **US-01** · Als Nutzer möchte ich, dass das Werkzeug nach dem Anmelden bereitsteht, ohne
+  es zu starten.
+- **US-02** · Als Nutzer möchte ich das jederzeit abschalten können.
+
+## Nicht im Scope
+
+- Verzögerter Start — nicht vorhanden
+- Start ohne sichtbares Menüleistensymbol — die Anwendung ist immer sichtbar
+
+## Akzeptanzkriterien
+
+- **AK-01** · Angenommen, der Reiter *Advanced* ist offen, wenn der Schalter *Launch at
+  Login* eingeschaltet wird, dann ist die Anwendung als Anmeldeobjekt eingetragen und
+  startet bei der nächsten Anmeldung mit.
+- **AK-02** · Angenommen, das Anmeldeobjekt besteht, wenn der Schalter ausgeschaltet wird,
+  dann ist es entfernt.
+- **AK-03** · Angenommen, der Nutzer entfernt das Anmeldeobjekt in den Systemeinstellungen,
+  wenn die Einstellungen der Anwendung danach geöffnet werden, dann zeigt der Schalter
+  „aus" — das System ist die Wahrheitsquelle, nicht eine eigene Ablage.
+- **AK-04** · Angenommen, die Einrichtung läuft, wenn auf der letzten Seite *Done* gewählt
+  wird, dann wird der Anmeldestart entsprechend dem dortigen Schalter gesetzt (siehe
+  B12/AK-13 zur Voreinstellung).
+
+### Datenschutz und Missbrauchsschutz
+
+Stufe A.
+
+- **AK-05** · Angenommen, der Anmeldestart wird gesetzt, wenn das geschieht, dann wird
+  ausschließlich der Systemdienst für Anmeldeobjekte benutzt — es wird nichts in einen
+  Startordner geschrieben und kein Hintergrunddienst eingerichtet.
+- **AK-06** · Angenommen, der Anmeldestart wird gesetzt, wenn das geschieht, dann speichert
+  die Anwendung selbst nichts darüber.
+- **AK-07** ⚠ · Angenommen, das Eintragen oder Entfernen schlägt fehl, wenn der Fehler
+  auftritt, dann erfährt der Nutzer nichts davon, und **der Schalter zeigt weiterhin den
+  gewünschten statt den tatsächlichen Zustand** — bis die Ansicht neu aufgebaut wird.
+  *(`LaunchAtLoginManager.swift:24` schreibt in ein `print()`. Die Klasse ist **nicht**
+  `@Observable`, weshalb eine fehlgeschlagene Änderung kein Neuzeichnen auslöst. Zur
+  Klärung vorgelegt.)*
+
+*Abschnitte 4 und 6 des Katalogs: treffen nicht zu.*
+
+## Edge Cases
+
+- **EC-01** · Anwendung liegt nicht in `/Applications` → das Eintragen kann fehlschlagen;
+  siehe AK-07.
+- **EC-02** · Nutzer verweigert die Systemabfrage zum Anmeldeobjekt → dito.
+- **EC-03** · Anwendung wird verschoben, nachdem das Anmeldeobjekt eingetragen wurde →
+  Verhalten liegt beim System.
+- **EC-04** · Zwei Kopien der Anwendung auf dem Rechner → Verhalten ungeprüft.
+
+## Fehlbestand
+
+- **FB-01 · Fehlschläge sind unsichtbar und der Schalter lügt.** Fundstelle:
+  `LaunchAtLoginManager.swift:24`. Folge: Der Nutzer glaubt, der Anmeldestart sei
+  eingerichtet, und wundert sich beim nächsten Anmelden. Zwei Ursachen wirken zusammen: das
+  wirkungslose `print()` und die fehlende Beobachtbarkeit der Klasse.
+- **FB-02 · Kein Abgleich beim Start.** Die Anwendung fragt den Zustand nur ab, wenn eine
+  Ansicht ihn anzeigt. Folge: keine unmittelbare — vermerkt, weil die Klasse damit als
+  einzige im Projekt ohne eigenen Zustand auskommt, was ausdrücklich so gewollt ist.
+- **FB-03 · Keine Tests.**
+
+## Offene Fragen
+
+- **OF-01** · Soll ein Fehlschlag gemeldet werden? — entscheidet der Autor.
+
+## Decision Log
+
+| # | Frage | Entscheidung | Begründung |
+|---|---|---|---|
+| 1 | Wie wird der Anmeldestart eingerichtet? | `SMAppService.mainApp` | ab macOS 13 der vorgesehene Weg; keine Hilfsanwendung, kein Startordner |
+| 2 | Wo liegt die Wahrheit? | beim System | ausdrücklich im Dateikopf vermerkt: keine eigene Ablage, die auseinanderlaufen kann |
+| 3 | Fehlerbehandlung | `print()` | **Grund nicht erkennbar** (FB-01) |

--- a/features/B14-automatische-updates/design.md
+++ b/features/B14-automatische-updates/design.md
@@ -1,0 +1,125 @@
+# B14 · Automatische Updates — Systemdesign
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · Stack-Profil: `swiftui-macos`
+
+**Kein Code in diesem Dokument.**
+
+## Überblick
+
+Die Anwendung enthält kein eigenes Aktualisierungswerk. Sie bettet Sparkle als Rahmenwerk
+ein und stellt eine dünne Hülle darum, die drei Dinge nach außen gibt: prüfen, den Schalter
+für die automatische Prüfung, den Zeitpunkt der letzten Prüfung. Alles Weitere — Oberfläche,
+Download, Signaturprüfung, Installation, Neustart — leistet Sparkle.
+
+Der Ablauf: Sparkle lädt eine XML-Datei von GitHub, vergleicht die dort genannte Fassung
+mit der eigenen, prüft bei Bedarf die EdDSA-Signatur des Programmpakets gegen den
+öffentlichen Schlüssel aus dem eigenen Paket und installiert.
+
+## Komponentenstruktur
+
+```
+SparkleUpdater                        dünne Hülle, @MainActor
+├── canCheckForUpdates                bereitgestellt — von niemandem gelesen (FB-01)
+├── automaticallyChecksForUpdates     lesen und schreiben
+├── lastUpdateCheckDate               nur lesen
+└── checkForUpdates()                 stößt Sparkles Ablauf an
+
+SPUStandardUpdaterController          Sparkle, mit dem Start des Werks beim Erzeugen
+├── updaterDelegate: nil
+└── userDriverDelegate: nil
+
+Einstiegspunkte
+├── Menüleiste → „Check for Updates…"
+└── Einstellungen → Advanced → Schalter + Schaltfläche + Zeitpunkt
+```
+
+## Datenmodell
+
+Kein eigenes. Sparkle führt seinen Zustand in eigenen Schlüsseln der
+Benutzereinstellungen — Zeitpunkt der letzten Prüfung, automatische Prüfung, übersprungene
+Fassungen. Diese Schlüssel sind der Anwendung nicht bekannt und werden von
+*Reset All Preferences* **nicht** erfasst.
+
+### Konfiguration im Programmpaket
+
+| Schlüssel | Wert | Bedeutung |
+|---|---|---|
+| `SUFeedURL` | `…/daumedia/MikaScreenSnap/main/appcast.xml` | Adresse des Appcasts, seit `db55d1f` auf `main` |
+| `SUPublicEDKey` | `eauiHgP4…` | öffentlicher Schlüssel zur Signaturprüfung |
+| `SUSendProfileInfo` | **nicht gesetzt** | Voreinstellung „nein" — kein Systemprofil |
+| `SUScheduledCheckInterval` | **nicht gesetzt** | Sparkles Voreinstellung greift |
+
+### Appcast
+
+Ein RSS-Kanal mit einem `<item>` je Fassung; derzeit drei. Jeder Eintrag trägt Fassung,
+Beschreibung, Datum und ein `<enclosure>` mit Adresse, Länge und EdDSA-Signatur des DMG.
+
+## Zugriffsregeln
+
+| Wer | Darf | Erzwungen durch |
+|---|---|---|
+| Sparkle | den Appcast und Programmpakete über HTTPS laden | Systemvertrauensspeicher |
+| Sparkle | ein Update installieren | **nur** bei gültiger EdDSA-Signatur |
+| Die Anwendung | prüfen anstoßen, Schalter setzen | die Hülle |
+
+Die Signaturprüfung ist die einzige echte Sicherheitsschranke der ganzen Anwendung: Ohne
+sie könnte jeder, der den Feed unterschiebt, beliebigen Code auf dem Rechner ausführen.
+
+## Missbrauchsschutz
+
+| Vorgang | Limit | Anmerkung |
+|---|---|---|
+| Aktualisierungsprüfung | **keins** in der Anwendung | ruft eine statische Datei ab; GitHub begrenzt seinerseits |
+
+## Externe Dienste
+
+| Dienst | Wofür | Was geht hin | Was wird vorher entfernt |
+|---|---|---|---|
+| GitHub (`raw.githubusercontent.com`) | Appcast abrufen | HTTP-Anfrage — unvermeidlich IP-Adresse, Zeitpunkt, Programmkennzeichnung | nichts zu entfernen: es werden **keine** Anwendungsdaten gesendet |
+| GitHub Releases | Programmpaket laden | dito | dito |
+
+Kein Auftragsverarbeitungsvertrag erforderlich, weil keine personenbezogenen Daten
+übermittelt werden. Die Verbindung selbst ist auf der Datenschutzseite unter „The one
+network connection" ausgewiesen — Zusage und Code stimmen hier überein.
+
+## Erkennbare Entscheidungen
+
+| # | Entscheidung | Alternative | Warum so |
+|---|---|---|---|
+| 1 | Sparkle statt eigener Lösung | selbst gebauter Prüf- und Installationsweg | Signaturprüfung und Installation sind sicherheitskritisch und ungeeignet zum Selberbauen |
+| 2 | Standardcontroller ohne Delegates | eigene Delegates | einfachste Einbindung; Preis siehe FB-02 und FB-03 |
+| 3 | Appcast auf GitHub statt eigenem Server | eigene Infrastruktur | keine Betriebskosten, keine Serverpflege |
+| 4 | `@preconcurrency import` | auf Sparkles Nebenläufigkeitsangaben warten | Sparkle ist nicht auf Swift-6-Nebenläufigkeit vorbereitet; ohne die Kennzeichnung baut das Projekt nicht |
+| 5 | Hülle als eigene Klasse | Sparkle direkt in der Oberfläche verwenden | hält den `@preconcurrency`-Bereich klein und die Oberfläche testbar |
+| 6 | Kein Systemprofil senden | Sparkles Profilübermittlung einschalten | Voreinstellung beibehalten — passt zur Zusage „keine Analyse" |
+
+## Abdeckung der Akzeptanzkriterien
+
+| AK | Erfüllt durch | Anmerkung |
+|---|---|---|
+| AK-01 | `checkForUpdates()` → Sparkle | Oberfläche von Sparkle |
+| AK-02 | Sparkle, Beschreibung aus dem Appcast | |
+| AK-03 | `automaticallyChecksForUpdates` | Abstand nach Sparkles Voreinstellung |
+| AK-04 | Reiter *Advanced* | Umsetzung in B11 |
+| AK-05 | Sparkles Signaturprüfung gegen `SUPublicEDKey` | |
+| AK-06 | Sparkles Fehlerbehandlung | die Anwendung erfährt nichts davon (FB-02) |
+| AK-07 ⚠ | **keine Komponente** — `canCheckForUpdates` wird nicht gelesen | |
+| AK-08 ⚠ | ins Paket kompilierte Feed-Adresse älterer Fassungen | organisatorisch gelöst, nicht technisch |
+| AK-09 | Sparkle sendet keine Anwendungsdaten | belegbar: die Hülle übergibt nichts |
+| AK-10 | unvermeidliche Eigenschaft jeder HTTP-Verbindung | im PRD ausgewiesen |
+| AK-11 | `SUSendProfileInfo` nicht gesetzt | Voreinstellung |
+| AK-12 | `SUPublicEDKey` im Programmpaket | |
+| AK-13 | HTTPS in Feed und Enclosure-Adressen | im Appcast nachprüfbar |
+
+## Übergabe an die QA
+
+1. **AK-12 und AK-05 sind die wichtigsten Kriterien der gesamten Erfassung.** Zu prüfen mit
+   einem manipulierten lokalen Appcast: Signatur verfälschen und sicherstellen, dass die
+   Installation verweigert wird. Gelingt eine Installation trotz falscher Signatur, ist das
+   ein kritischer Befund, der alles andere überlagert.
+2. **AK-13**: Appcast und alle Enclosure-Adressen auf HTTPS prüfen — ein einzelner
+   HTTP-Eintrag genügt für einen Angriff auf dem Übertragungsweg.
+3. **FB-03** in der Praxis: Editor mit Anmerkungen offen halten und ein Update einspielen.
+   Zu beobachten, ob gewarnt wird.
+4. **AK-08** ist organisatorisch, nicht technisch — die QA sollte prüfen, ob `master` den
+   aktuellen Appcast trägt.

--- a/features/B14-automatische-updates/spec.md
+++ b/features/B14-automatische-updates/spec.md
@@ -1,0 +1,152 @@
+# B14 · Automatische Updates — Spezifikation
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+
+> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+>
+> **Dies ist das einzige Feature mit Netzwerkverkehr** — und das einzige, das
+> ausführbaren Code auf den Rechner bringt. Beides hebt es in der Prüfreihenfolge
+> nach vorn, unabhängig von seiner geringen Größe.
+
+## Zweck
+
+Die Anwendung findet selbst heraus, dass eine neue Fassung vorliegt, und installiert sie
+auf Wunsch. Ohne diesen Weg erreicht keine Fehlerbehebung einen bestehenden Nutzer — der
+Vertrieb läuft nicht über den App Store.
+
+## Abhängigkeiten
+
+| Braucht | Status | Warum |
+|---|---|---|
+| B11 Einstellungen | `bestand` | beherbergt Schalter und Schaltfläche im Reiter *Advanced* |
+| B15 Menüleisten-Hub | `bestand` | zweiter Einstiegspunkt |
+
+Extern: das Sparkle-Rahmenwerk (2.6 oder neuer), eingebettet ins Programmpaket, und der
+Appcast auf `raw.githubusercontent.com`.
+
+## User Stories
+
+- **US-01** · Als Nutzer möchte ich von neuen Fassungen erfahren, ohne die Projektseite zu
+  besuchen.
+- **US-02** · Als Nutzer möchte ich selbst nachsehen können, wann zuletzt geprüft wurde.
+- **US-03** · Als Nutzer möchte ich die automatische Prüfung abschalten können.
+
+## Nicht im Scope
+
+- Zurückrollen auf eine ältere Fassung — nicht vorhanden
+- Auswahl zwischen Vorab- und stabilen Fassungen — der Appcast kennt nur einen Kanal
+- Änderungsprotokoll in der Anwendung — die Beschreibung kommt aus dem Appcast und wird
+  von Sparkle angezeigt
+
+## Akzeptanzkriterien
+
+- **AK-01** · Angenommen, die Anwendung läuft, wenn *Check for Updates…* im Menü oder im
+  Reiter *Advanced* gewählt wird, dann prüft Sparkle den Appcast und meldet das Ergebnis —
+  auch dann, wenn keine neue Fassung vorliegt.
+- **AK-02** · Angenommen, eine neue Fassung liegt vor, wenn die Prüfung sie findet, dann
+  zeigt Sparkle deren Beschreibung an und bietet die Installation an.
+- **AK-03** · Angenommen, die automatische Prüfung ist eingeschaltet, wenn die Anwendung
+  läuft, dann prüft Sparkle in seinem voreingestellten Abstand selbsttätig.
+- **AK-04** · Angenommen, der Reiter *Advanced* ist offen, wenn er angezeigt wird, dann
+  steht dort ein Schalter *Automatic updates* und darunter der Zeitpunkt der letzten
+  Prüfung.
+- **AK-05** · Angenommen, ein Update wird geladen, wenn die Signatur nicht zum hinterlegten
+  öffentlichen Schlüssel passt, dann verweigert Sparkle die Installation.
+- **AK-06** · Angenommen, ein Update wird geladen, wenn die Verbindung fehlschlägt, dann
+  meldet Sparkle den Fehler und die Anwendung läuft unverändert weiter.
+- **AK-07** ⚠ · Angenommen, das Aktualisierungswerk ist noch nicht bereit, wenn der
+  Menüeintrag *Check for Updates…* angezeigt wird, dann ist er **trotzdem anklickbar**.
+  *(`SparkleUpdater.swift:13` stellt `canCheckForUpdates` bereit; die Eigenschaft wird von
+  **keiner** Oberfläche gelesen. Der Eintrag in `CHANGELOG.md` zu 3.3.1 — „Update menu
+  button — now visually disabled when Sparkle updater is not ready" — beschreibt einen
+  Zustand, den der Code heute nicht mehr herstellt. Zur Klärung vorgelegt.)*
+- **AK-08** ⚠ · Angenommen, eine Fassung bis einschließlich 3.4.1 ist installiert, wenn sie
+  nach Updates sucht, dann fragt sie den Appcast auf dem Zweig **`master`** ab, nicht auf
+  `main`.
+  *(Die Feed-Adresse ist ins Programmpaket kompiliert; erst `db55d1f` hat sie auf `main`
+  umgestellt. Solange solche Installationen bestehen, muss `main:master` mitgepusht werden,
+  sonst erreichen sie keine Aktualisierung mehr. Vermerkt in `README.md`. Zur Klärung
+  vorgelegt: bis wann?)*
+
+### Datenschutz und Missbrauchsschutz
+
+Stufe A. **Dies ist die einzige Stelle, an der die Anwendung eine Netzwerkverbindung
+aufbaut** — die Zusage im PRD („kein Byte verlässt den Rechner") gilt für Nutzerdaten, hier
+ist die Ausnahme.
+
+- **AK-09** · Angenommen, eine Aktualisierungsprüfung läuft, wenn die Verbindung besteht,
+  dann werden **keine Nutzerdaten** übertragen: kein Bildinhalt, keine Einstellungen, keine
+  Kennung. Es wird eine Datei abgerufen.
+- **AK-10** · Angenommen, eine Aktualisierungsprüfung läuft, wenn sie stattfindet, dann
+  erfährt GitHub als Gegenstelle unvermeidlich IP-Adresse, Zeitpunkt und
+  Programmkennzeichnung des Aufrufs.
+- **AK-11** · Angenommen, Sparkle prüft, wenn die Voreinstellung zur Übermittlung eines
+  anonymen Systemprofils unverändert ist, dann wird **kein** Systemprofil gesendet
+  (`SUSendProfileInfo` ist in `Resources/Info.plist` nicht gesetzt, Sparkles Voreinstellung
+  ist „nein").
+- **AK-12** · Angenommen, ein Update wird installiert, wenn es angewandt wird, dann ist es
+  über EdDSA gegen den in `Resources/Info.plist` hinterlegten öffentlichen Schlüssel geprüft.
+- **AK-13** · Angenommen, Feed und Programmpaket werden geladen, wenn die Verbindung
+  aufgebaut wird, dann geschieht das ausschließlich über HTTPS.
+
+*Abschnitt 4 (Rate Limits): trifft nicht zu — die Prüfung ruft eine statische Datei ab und
+kostet nichts. Abschnitt 6 (Geheimnisse): Der **öffentliche** Signaturschlüssel steht
+bestimmungsgemäß im Programmpaket; der private liegt im Schlüsselbund des Autors und darf
+das Repository nie berühren.*
+
+## Edge Cases
+
+- **EC-01** · Kein Netz → Sparkle meldet einen Fehler, die Anwendung läuft weiter.
+- **EC-02** · Appcast fehlerhaft → Sparkle meldet „error parsing the update feed" (in 3.3.2
+  bereits einmal aufgetreten).
+- **EC-03** · Signatur passt nicht → Installation wird verweigert.
+- **EC-04** · Update während laufender Aufnahme → Verhalten ungeprüft; ein Neustart der
+  Anwendung während geöffneter Panels ist nicht abgesichert.
+- **EC-05** · Herabstufung im Appcast (kleinere Fassungsnummer) → Sparkle bietet sie nicht an.
+- **EC-06** · Nicht beglaubigtes Programmpaket → Gatekeeper verweigert den Start nach der
+  Installation; der Nutzer sitzt dann vor einer beschädigten Installation.
+
+## Fehlbestand
+
+- **FB-01 · `canCheckForUpdates` ist toter Code, und die Dokumentation behauptet das
+  Gegenteil.** Fundstelle: `SparkleUpdater.swift:13`, ohne Leser; `CHANGELOG.md`, Eintrag
+  3.3.1. Folge: Ein Zustand, den die Dokumentation zusichert, wird nicht hergestellt —
+  vermutlich bei der Neugestaltung der Einstellungen in 3.4.0 verloren gegangen.
+- **FB-02 · Keine Delegates am Aktualisierungswerk.** Fundstelle:
+  `SparkleUpdater.swift:23` übergibt `nil` für beide Delegates. Folge: Die Anwendung erfährt
+  nichts über Verlauf und Ausgang einer Prüfung, kann Fehler nicht protokollieren und den
+  Ablauf nicht beeinflussen — etwa um eine Installation zu verschieben, während der Editor
+  ungesicherte Anmerkungen hält.
+- **FB-03 · Ein Update kann ungesicherte Arbeit vernichten.** Es gibt keine Prüfung, ob der
+  Editor offen ist oder `hasUnsavedChanges` gesetzt ist, bevor Sparkle die Anwendung für die
+  Installation beendet. Folge: Anmerkungen gehen ohne Rückfrage verloren. Ohne Delegate
+  (FB-02) ist dieser Punkt auch nicht nachrüstbar.
+- **FB-04 · Der Zweigwechsel des Feeds hat kein Ende.** Fundstelle: `README.md`,
+  Abschnitt *Auto-Update*. Folge: `main:master` muss auf unbestimmte Zeit mitgepusht
+  werden; vergisst der Autor es einmal, bemerkt es niemand, weil die betroffenen
+  Installationen still auf altem Stand bleiben.
+- **FB-05 · Kein Prüfweg für den Appcast.** Es gibt keinen Test und keinen
+  Auslieferungsschritt, der die XML-Datei gegen Sparkles Erwartung prüft. Folge: Der Fehler
+  aus 3.3.2 (falscher Namensraum) konnte ausgeliefert werden und war erst am Gerät des
+  Nutzers sichtbar.
+- **FB-06 · Keine Tests.**
+
+## Offene Fragen
+
+- **OF-01** · Bis wann muss `master` mitgepflegt werden? — entscheidet der Autor.
+- **OF-02** · Soll ein Update verschoben werden, wenn der Editor ungesicherte Anmerkungen
+  hält? — entscheidet der Autor.
+- **OF-03** · Soll `canCheckForUpdates` wieder benutzt oder entfernt werden? — entscheidet
+  der Autor. Der CHANGELOG-Eintrag zu 3.3.1 ist bis dahin unzutreffend.
+
+## Decision Log
+
+| # | Frage | Entscheidung | Begründung |
+|---|---|---|---|
+| 1 | Wie werden Updates verteilt? | Sparkle mit Appcast auf GitHub | ohne App Store gibt es keinen anderen Weg zum bestehenden Nutzer; die Sandbox ist aus (siehe PRD) |
+| 2 | Wie wird die Echtheit gesichert? | EdDSA-Signatur, öffentlicher Schlüssel im Paket | Sparkles empfohlener Weg; der private Schlüssel liegt im Schlüsselbund |
+| 3 | Wo liegt der Appcast? | `raw.githubusercontent.com`, Zweig `main` | keine eigene Serverinfrastruktur nötig |
+| 4 | Wie wird Sparkle eingebunden? | dünne Hülle um den Standardcontroller | die Oberfläche kommt vollständig von Sparkle |
+| 5 | Delegates? | keine | **Grund nicht erkennbar** — vermutlich nicht gebraucht (FB-02) |
+| 6 | Wo steht der Schalter für die automatische Prüfung? | Reiter *Advanced* | wird selten geändert |
+| 7 | Zweigwechsel `master` → `main` | `db55d1f` | `master` war seit März unberührt, wodurch die Auslieferung von 3.4.1 zunächst unsichtbar blieb |

--- a/features/B15-menueleisten-hub/design.md
+++ b/features/B15-menueleisten-hub/design.md
@@ -1,0 +1,107 @@
+# B15 · Menüleisten-Hub & Programminfo — Systemdesign
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · Stack-Profil: `swiftui-macos`
+
+**Kein Code in diesem Dokument.**
+
+## Überblick
+
+Die Anwendung ist eine SwiftUI-App, deren gesamte Oberfläche aus einem `MenuBarExtra`
+besteht. Daneben steht ein Programmdelegat, der beim Start drei Dinge tut: die
+Ersteinrichtung oder die Berechtigungsprüfung anstoßen, angeheftete Bilder wiederherstellen
+und die sieben Tastenkombinationen anmelden.
+
+Der gemeinsame Zustand liegt in einem Halter, der alle Verwalter und Fenstercontroller
+führt. Fenstercontroller werden beim ersten Bedarf erzeugt und danach wiederverwendet.
+
+Der vollständige Menüaufbau steht in `docs/app-shell.md`.
+
+## Komponentenstruktur
+
+```
+MikaScreenSnapApp                      @main
+├── AppDelegate
+│   ├── applicationDidFinishLaunching
+│   │   ├── Ersteinrichtung **oder** Berechtigungsprüfung   ← siehe FB-02
+│   │   ├── restorePins(appState:)     → B08
+│   │   └── HotkeyManager(…)           sieben Rückrufe → B10
+│   ├── applicationShouldTerminateAfterLastWindowClosed → false
+│   ├── showOnboarding()               → B12
+│   └── checkScreenCapturePermission() ruft SCShareableContent — nur im else-Zweig
+├── AppState                           gemeinsamer Halter
+│   ├── Verwalter                      Aufnahme · Verlauf · Farben · Aktualisierung · Anmeldestart
+│   ├── Fenstercontroller              Editor · Verlauf · Einstellungen · Über · Einrichtung
+│   ├── pinnedPanels                   Grundlage des Untermenüs
+│   └── lastCapture
+└── MenuBarExtra                       Schablonensymbol
+    ├── Programm                       Über · Updates · Berechtigungswarnung
+    ├── Aufnahme                       vier Einträge
+    ├── Zusatzfunktionen               Text · Farbe · Messen
+    ├── Verwaltung                     Pins ▸ · Farben ▸ · Verlauf
+    └── Abschluss                      Einstellungen ⌘, · Beenden ⌘Q
+
+AboutWindowController                  Symbol · Name · Fassung aus dem Paket
+```
+
+## Datenmodell
+
+Kein eigenes. `AppState` hält Verweise, keine Daten.
+
+Bemerkenswert ist die Reihenfolge beim Start: Angeheftete Bilder werden **vor** der
+Anmeldung der Tastenkombinationen wiederhergestellt und **unabhängig davon**, ob die
+Ersteinrichtung läuft. Beim allerersten Start können also bereits Fenster erscheinen,
+während die Einrichtung noch offen ist — sofern der Ablageordner Dateien enthält.
+
+## Zugriffsregeln
+
+Keine. Das Menü zeigt Zustände, die andere Features führen.
+
+## Missbrauchsschutz
+
+Nicht anwendbar.
+
+## Externe Dienste
+
+Keine. Der Deeplink in die Systemeinstellungen überträgt nichts.
+
+## Erkennbare Entscheidungen
+
+| # | Entscheidung | Alternative | Warum so |
+|---|---|---|---|
+| 1 | `MenuBarExtra` statt eines eigenen Statuselements | `NSStatusItem` von Hand | SwiftUI-Bordmittel; das Menü ist eine Ansicht |
+| 2 | Schablonenbild als Symbol | farbiges Symbol | folgt hell und dunkel automatisch |
+| 3 | Fenstercontroller träge erzeugt und behalten | jedes Mal neu | Zustand und Position bleiben innerhalb einer Sitzung erhalten |
+| 4 | Dauerhaft ohne Dock-Symbol, Fenster über ausdrückliche Aktivierung | Betriebsart wechseln | in 3.4.0 behoben; in `CLAUDE.md` als Konvention festgehalten |
+| 5 | Berechtigungsprüfung im `else`-Zweig der Ersteinrichtung | in beiden Zweigen | **Grund nicht erkennbar** — Ursache von FB-02 |
+| 6 | Angeheftete Bilder vor den Kombinationen wiederherstellen | danach oder verzögert | **Grund nicht erkennbar**; ohne Wirkung, solange nichts fehlschlägt |
+
+## Abdeckung der Akzeptanzkriterien
+
+| AK | Erfüllt durch | Anmerkung |
+|---|---|---|
+| AK-01 | `LSUIElement` im Programmpaket + `MenuBarExtra` | |
+| AK-02 | Schablonenbild | |
+| AK-03 | Trennlinien im Menü | |
+| AK-04 | Kombination im Titel | siehe Entscheidung 4 |
+| AK-05 | Abfrage beim Aufbau des Menüs | |
+| AK-06 | dieselbe Abfrage | |
+| AK-07 | Untermenü über `pinnedPanels` | → B08 |
+| AK-08 | Untermenü über den Farbverlauf | → B06 |
+| AK-09 | `AboutWindowController`, Fassung aus dem Paket | |
+| AK-10 | `NSApplication.terminate` | |
+| AK-11 | `applicationShouldTerminateAfterLastWindowClosed` → false | |
+| AK-12 | ausdrückliche Aktivierung in den Controllern | |
+| AK-13 ⚠ | **keine Komponente** — nichts wird deaktiviert | |
+| AK-14 ⚠ | **keine Komponente** | → B14 |
+| AK-15 | nur Speicherzugriffe beim Aufbau | |
+| AK-16 | Schreiben des Hex-Werts im Untermenü | |
+
+## Übergabe an die QA
+
+1. **FB-02 ist die wichtigste Feststellung dieses Features** und erklärt B12/FB-01: Die
+   Berechtigungsprüfung, die die Anwendung in die Systemliste einträgt, läuft beim
+   Erststart nicht. Mit einem frischen Benutzerkonto zu prüfen.
+2. **AK-01 und AK-11** sind die Grundzusagen der Anwendungsform — nach dem Schließen aller
+   Fenster muss das Menüleistensymbol bleiben (der Fehler aus 3.4.0 darf nicht
+   zurückkehren).
+3. **AK-13** gemeinsam mit B01 prüfen.

--- a/features/B15-menueleisten-hub/spec.md
+++ b/features/B15-menueleisten-hub/spec.md
@@ -1,0 +1,130 @@
+# B15 · Menüleisten-Hub & Programminfo — Spezifikation
+
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+
+> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+
+## Zweck
+
+Die Anwendung hat kein Hauptfenster und kein Dock-Symbol. Das Menüleistensymbol ist ihr
+**einziger sichtbarer Anker**: Von dort ist jede Funktion erreichbar, dort erscheint der
+Hinweis auf eine fehlende Berechtigung, und dort wird die Anwendung beendet.
+
+## Abhängigkeiten
+
+| Braucht | Status | Warum |
+|---|---|---|
+| alle übrigen Features | `bestand` | das Menü ist ihre gemeinsame Oberfläche |
+
+## User Stories
+
+- **US-01** · Als Nutzer möchte ich jede Funktion erreichen, ohne Tastenkombinationen zu
+  kennen.
+- **US-02** · Als Nutzer möchte ich sehen, welche Kombination zu welcher Funktion gehört.
+- **US-03** · Als Nutzer möchte ich erkennen, wenn eine Berechtigung fehlt.
+- **US-04** · Als Nutzer möchte ich die Fassungsnummer nachschlagen können.
+
+## Nicht im Scope
+
+- Ein Hauptfenster — die Anwendung bleibt dauerhaft ohne Dock-Symbol
+- Anpassbare Menüeinträge — nicht vorhanden
+
+## Akzeptanzkriterien
+
+- **AK-01** · Angenommen, die Anwendung läuft, wenn sie gestartet ist, dann erscheint ein
+  Symbol in der Menüleiste, **kein** Dock-Symbol und kein Eintrag im Programmumschalter.
+- **AK-02** · Angenommen, die Menüleiste ist hell oder dunkel, wenn das Symbol angezeigt
+  wird, dann passt es sich an (Schablonenbild).
+- **AK-03** · Angenommen, das Symbol wird angeklickt, wenn das Menü erscheint, dann sind
+  vier Gruppen durch Trennlinien geschieden: Programm, Aufnahme, Zusatzfunktionen,
+  Verwaltung.
+- **AK-04** · Angenommen, ein Menüeintrag hat eine Tastenkombination, wenn er angezeigt
+  wird, dann steht sie **im Titel** — nicht als eigene Spalte.
+- **AK-05** · Angenommen, die Bildschirmaufnahme-Berechtigung fehlt, wenn das Menü geöffnet
+  wird, dann erscheint zusätzlich der Eintrag „⚠ Screen Recording not granted", der in die
+  Systemeinstellungen führt.
+- **AK-06** · Angenommen, die Berechtigung ist erteilt, wenn das Menü geöffnet wird, dann
+  fehlt dieser Eintrag.
+- **AK-07** · Angenommen, angeheftete Bilder bestehen, wenn das Untermenü *Pinned
+  Screenshots* geöffnet wird, dann sind sie einzeln aufgeführt und über *Close All*
+  gemeinsam schließbar; sonst steht dort „No pinned screenshots".
+- **AK-08** · Angenommen, Farben wurden abgegriffen, wenn *Color History* geöffnet wird,
+  dann stehen sie mit farbigem Punkt und Hex-Wert da; sonst „No colors picked yet".
+- **AK-09** · Angenommen, *About Mika+ScreenSnap* wird gewählt, wenn das Fenster erscheint,
+  dann zeigt es Symbol, Namen und die Fassungsnummer **aus dem Programmpaket** — nicht fest
+  verdrahtet.
+- **AK-10** · Angenommen, *Quit* wird gewählt, wenn die Aktion ausgeführt ist, dann beendet
+  sich die Anwendung.
+- **AK-11** · Angenommen, alle Fenster werden geschlossen, wenn das geschehen ist, dann
+  **läuft die Anwendung weiter**.
+- **AK-12** · Angenommen, ein Fenster wird aus dem Menü geöffnet, wenn es erscheint, dann
+  kommt es nach vorn und nimmt den Tastaturfokus — obwohl die Anwendung kein Dock-Symbol
+  hat.
+- **AK-13** ⚠ · Angenommen, die Berechtigung fehlt, wenn ein Aufnahmeeintrag angeklickt
+  wird, dann ist er **trotzdem anklickbar** und führt zu einem fehlgeschlagenen Versuch mit
+  Kurzmeldung.
+  *(`MikaScreenSnapApp.swift:159` zeigt den Warneintrag, deaktiviert aber keinen der
+  Aufnahmeeinträge. Zur Klärung vorgelegt.)*
+- **AK-14** ⚠ · Angenommen, das Aktualisierungswerk ist nicht bereit, wenn *Check for
+  Updates…* angezeigt wird, dann ist der Eintrag trotzdem anklickbar (siehe B14/AK-07).
+
+### Datenschutz und Missbrauchsschutz
+
+Stufe A.
+
+- **AK-15** · Angenommen, das Menü wird geöffnet, wenn es aufgebaut wird, dann werden nur
+  Zustände gelesen, die bereits im Speicher liegen — es entsteht kein Zugriff auf den
+  Bildschirm und keine Datei.
+- **AK-16** · Angenommen, ein Farbeintrag wird angeklickt, wenn das geschieht, dann wird
+  nur der Hex-Wert in die Zwischenablage gelegt.
+
+*Abschnitte 4 und 6 des Katalogs: treffen nicht zu.*
+
+## Edge Cases
+
+- **EC-01** · Menüleiste voll → das Symbol kann unsichtbar sein; die Anwendung ist dann nur
+  über Tastenkombinationen erreichbar.
+- **EC-02** · Menü geöffnet, während eine Auswahl läuft → die Auswahl liegt auf einer
+  höheren Ebene.
+- **EC-03** · Sehr viele angeheftete Bilder → das Untermenü wird lang; es gibt keine
+  Begrenzung der Anzeige über die zwanzig Panels hinaus.
+- **EC-04** · Berechtigung wird bei geöffnetem Menü erteilt → der Warneintrag verschwindet
+  erst beim nächsten Öffnen.
+
+## Fehlbestand
+
+- **FB-01 · Der Warnhinweis warnt, hindert aber nicht.** Fundstelle:
+  `MikaScreenSnapApp.swift:159`. Folge: siehe AK-13 und B01/FB-03.
+- **FB-02 · Beim Erststart wird die Berechtigung nicht angestoßen.** Fundstelle:
+  `MikaScreenSnapApp.swift:44-48` — `checkScreenCapturePermission()`, das über
+  `SCShareableContent.current` die Anwendung überhaupt erst in die Systemliste einträgt,
+  läuft **nur im `else`-Zweig**, also wenn die Ersteinrichtung bereits abgeschlossen ist.
+  Beim ersten Start übernimmt die Ersteinrichtung, die ausschließlich abfragt. Folge: Der
+  Nutzer wird im Onboarding in die Systemeinstellungen geschickt, bevor die Anwendung dort
+  gelistet sein kann. Siehe B12/FB-01 — hier ist die Fundstelle für das *Warum*.
+- **FB-03 · Angeheftete Bilder heißen nur „Pin 1", „Pin 2".** Fundstelle:
+  `MikaScreenSnapApp.swift:206`. Folge: Bei mehreren angehefteten Bildern ist nicht
+  erkennbar, welches gemeint ist; ein Vorschaubild oder ein Zeitstempel fehlt.
+- **FB-04 · Kein Weg zur Projektseite oder Hilfe.** Weder Menü noch „Über"-Fenster
+  verlinken auf das Projekt. Folge: Wer einen Fehler melden will, findet den Weg nicht aus
+  der Anwendung heraus — bei „keine Fehlerberichte" als Erfolgskriterium (`docs/prd.md`)
+  ist das bemerkenswert.
+- **FB-05 · Keine Tests.**
+
+## Offene Fragen
+
+- **OF-01** · Sollen Aufnahmeeinträge bei fehlender Berechtigung deaktiviert sein? —
+  entscheidet der Autor. Betrifft B01 und B12.
+- **OF-02** · Soll das „Über"-Fenster auf das Projekt verweisen? — entscheidet der Autor.
+
+## Decision Log
+
+| # | Frage | Entscheidung | Begründung |
+|---|---|---|---|
+| 1 | Menüleiste statt Dock | gewöhnliche Anwendung mit Fenster | ein Aufnahmewerkzeug soll nicht im Weg stehen; `LSUIElement` gesetzt |
+| 2 | Dauerhaft ohne Dock-Symbol | zwischen den Betriebsarten wechseln | 3.4.0 behoben: der Wechsel machte die Anwendung nach dem Schließen aus dem Dock unerreichbar |
+| 3 | Weiterlaufen ohne Fenster | mit dem letzten Fenster beenden | eine Menüleistenanwendung, die sich beendet, wäre nicht mehr erreichbar |
+| 4 | Kombinationen im Titel statt als Tastenzuordnung | echte Tastenzuordnungen | sie sind systemweit über Carbon angemeldet, nicht an das Menü gebunden |
+| 5 | Leerzustände als Text statt ausgeblendeter Untermenüs | Untermenü ausblenden | ein verschwundener Eintrag sieht aus wie ein Fehler |
+| 6 | Fassungsnummer aus dem Programmpaket | fest verdrahtet | seit 3.1.0; verhindert Abweichungen zwischen Anzeige und Paket |
+| 7 | `Capture Window…` ohne Kombination | eigene Kombination vergeben | die interaktive Auswahl braucht ohnehin die Maus; `⌃⇧⌘5` deckt den schnellen Fall ab |

--- a/features/index.md
+++ b/features/index.md
@@ -8,76 +8,121 @@ einem Fehler in `B04` ist die Spec eine Rekonstruktion und kann selbst falsch se
 
 | ID | Feature | Prio | Status | Abhängig von | Zuletzt |
 |---|---|---|---|---|---|
-| B01 | Bildschirmaufnahme | P0 | bestand | — | — |
-| B02 | App-Ausschluss von Aufnahmen | P0 | bestand | B01 | — |
-| B03 | Anmerkungs-Editor | P0 | bestand | B01 | — |
-| B04 | Bereiche zensieren | P0 | bestand | B03 | — |
-| B05 | Bildschirmtext erfassen (OCR) | P1 | bestand | B01, B02 | — |
-| B06 | Farbpipette | P1 | bestand | B01, B02 | — |
-| B07 | Lineal / Bildschirm vermessen | P1 | bestand | B03 | — |
-| B08 | Screenshots anheften | P1 | bestand | B01, B03 | — |
-| B09 | Screenshot-Verlauf | P0 | bestand | B01 | — |
-| B10 | Tastenkombinationen | P0 | bestand | B01 | — |
-| B11 | Einstellungen | P0 | bestand | B01, B09, B10 | — |
-| B12 | Ersteinrichtung | P1 | bestand | B01, B13 | — |
-| B13 | Automatischer Start bei Login | P2 | bestand | — | — |
-| B14 | Automatische Updates | P1 | bestand | — | — |
-| B15 | Menüleisten-Hub & Programminfo | P0 | bestand | alle | — |
+| B01 | Bildschirmaufnahme | P0 | rekonstruiert | B02, B03, B09, B10, B12 | 2026-08-25 |
+| B02 | App-Ausschluss von Aufnahmen | P0 | rekonstruiert | B01, B11 | 2026-08-25 |
+| B03 | Anmerkungs-Editor | P0 | rekonstruiert | B01, B04, B05, B07, B08, B09, B11 | 2026-08-25 |
+| B04 | Bereiche zensieren | P0 | rekonstruiert | B01, B03, B09 | 2026-08-25 |
+| B05 | Bildschirmtext erfassen (OCR) | P1 | rekonstruiert | B01, B02, B03, B10 | 2026-08-25 |
+| B06 | Farbpipette | P1 | rekonstruiert | B01, B02, B10, B15 | 2026-08-25 |
+| B07 | Lineal / Bildschirm vermessen | P1 | rekonstruiert | B03, B10 | 2026-08-25 |
+| B08 | Screenshots anheften | P1 | rekonstruiert | B03, B09, B15 | 2026-08-25 |
+| B09 | Screenshot-Verlauf | P0 | rekonstruiert | B01, B03, B08, B11 | 2026-08-25 |
+| B10 | Tastenkombinationen | P0 | rekonstruiert | B01, B05, B06, B07, B09, B11 | 2026-08-25 |
+| B11 | Einstellungen | P0 | rekonstruiert | B02, B09, B10, B12, B13, B14 | 2026-08-25 |
+| B12 | Ersteinrichtung | P1 | rekonstruiert | B01, B11, B13 | 2026-08-25 |
+| B13 | Automatischer Start bei Login | P2 | rekonstruiert | B11, B12 | 2026-08-25 |
+| B14 | Automatische Updates | P1 | rekonstruiert | B11, B15 | 2026-08-25 |
+| B15 | Menüleisten-Hub & Programminfo | P0 | rekonstruiert | alle | 2026-08-25 |
 
-## Erfassungsreihenfolge
+**Alle fünfzehn Features sind rückerfasst.** Je Feature liegen `spec.md` und `design.md`
+vor. Nächster Schritt: `/sdd-qa B01` und so fort, in der Reihenfolge unten.
+
+## Was `rekonstruiert` hier bedeutet — und was noch fehlt
+
+Die Specs beschreiben, **was der Code tut**, nicht was er tun sollte. Wo das Verhalten
+fragwürdig aussieht, steht es trotzdem als Kriterium da, mit ⚠ markiert — damit `sdd-qa` es
+reproduziert statt es zu übersehen.
+
+**Der Bestätigungsschritt steht aus.** Nach dem Verfahren wird jedes ⚠-Kriterium einzeln
+vorgelegt mit der Frage: *„Das tut der Code heute — soll er das?"* Diese Frage kann kein
+Agent beantworten, weil die Absicht nirgends im Code steht. Bis sie beantwortet ist, gilt:
+
+| Antwort | Folge |
+|---|---|
+| „ja, so gewollt" | Marker entfällt, bleibt reguläres Kriterium |
+| „nein, das ist ein Fehler" | wandert aus den Kriterien in den *Fehlbestand* |
+| „unklar" | bleibt als offene Frage stehen |
+
+**51 Kriterien** tragen den Marker. Sie sind konservativ gesetzt: im Zweifel markiert statt
+stillschweigend durchgewunken.
+
+## Prüfreihenfolge
 
 **B01 → B02 → B04 → B09 → B05 → B06 → B08 → B14 → B12 → B03 → B10 → B11 → B13 → B07 → B15**
 
-Nach Risiko, nicht nach Nummer. Die Rückerfassung ist die Eintrittskarte für `sdd-qa`,
-und die QA ist an einem Bestandsprojekt ein Sicherheitsaudit — wer mit der Darstellung
-anfängt, prüft zuletzt, was zuerst brennen kann.
+Nach Risiko, nicht nach Nummer. Die QA ist an einem Bestandsprojekt ein Sicherheitsaudit —
+wer mit der Darstellung anfängt, prüft zuletzt, was zuerst brennen kann.
 
 | Rang | Features | Warum hier |
 |---|---|---|
-| 1 | B01, B02 | lesen über ScreenCaptureKit die Bildschirminhalte **jeder** laufenden App. B02 trägt die einzige Zugriffsregel der Anwendung: Was ausgeschlossen ist, darf nirgends auftauchen — auch nicht in B05 und B06 |
-| 2 | B04, B09 | zusammen, weil die entscheidende Frage nur über beide zu beantworten ist: **Liegt das unverpixelte Original im Verlauf, nachdem der Nutzer etwas zensiert hat?** Wer beide getrennt prüft, findet das nie |
-| 3 | B05, B06 | lesen ebenfalls den gesamten Bildschirm — OCR erkennt Text, den es nicht erkennen sollte; die Pipette snapshottet alle Displays für ein einziges Pixel |
-| 4 | B08 | legt Bildschirminhalte dauerhaft ab und stellt sie beim Start wieder her. Der schwerste Befund der Kartierung sitzt hier (FB-DM-01) |
-| 5 | B14 | einziger Netzwerkpfad der App — und Sparkle installiert ausführbaren Code. Ein Fehler in der Signaturprüfung wiegt schwerer als jeder Darstellungsfehler |
-| 6 | B12 | steuert den Berechtigungsfluss: Was hier schiefgeht, entscheidet, ob B01 überhaupt darf |
-| 7 | B03, B10, B11 | nehmen Eingaben entgegen und schreiben Dateien, lesen aber nichts von fremden Fenstern |
-| 8 | B13, B07, B15 | Systemdienst, Messung und Navigation — geringstes Risiko |
+| 1 | B01, B02 | lesen die Bildschirminhalte **jeder** laufenden App; B02 trägt die einzige Zugriffsregel der Anwendung |
+| 2 | B04, B09 | die Frage, die nur über beide zu beantworten ist: liegt das unzensierte Original im Verlauf? |
+| 3 | B05, B06 | lesen ebenfalls den gesamten Bildschirm |
+| 4 | B08 | legt Bildschirminhalte dauerhaft ab und stellt sie beim Start wieder her |
+| 5 | B14 | einziger Netzwerkpfad — und der einzige Weg, auf dem ausführbarer Code auf den Rechner kommt |
+| 6 | B12 | steuert den Berechtigungsfluss |
+| 7 | B03, B10, B11 | nehmen Eingaben entgegen und schreiben Dateien |
+| 8 | B13, B07, B15 | geringstes Risiko |
 
-B03 steht bewusst **hinter** B04, obwohl es dessen Vorstufe ist: Der Editor als Ganzes ist
-Werkzeug, das Zensieren ist eine Datenschutzzusage. Für die Rückerfassung von B04 reicht
-das Wissen über den Editor aus dem Code; umgekehrt gilt das nicht.
+## Befunde aus der Rückerfassung
 
-## Umfang
+**89 Einträge unter *Fehlbestand*** über alle Specs, jeder mit Fundstelle und Folge. Hier
+stehen nur die, die über ein einzelnes Feature hinausreichen oder Daten betreffen. Die
+Grade sind **vorläufig** — gesetzt beim Lesen, nicht beim Prüfen. `sdd-qa` bewertet neu und
+schreibt nach `features/befunde.md` fort.
 
-Fünfzehn Features, fünfzehn Sitzungen. Das ist kein Argument dagegen, aber es sollte
-niemand überrascht sein. Jede Sitzung wird einzeln aufgerufen:
+### Datenverlust und Datenverbleib
 
-```
-/sdd-erfassen B01
-```
-
-Danach `/sdd-qa B01`. Was die QA findet, entscheidet über den weiteren Weg — ein
-kritischer oder hoher Befund unterbricht die Erfassung, bis die Reparatur ausgeliefert
-ist, weil er Code betrifft, der in diesem Moment läuft.
-
-## Bereits bekannte Befunde
-
-Aus der Kartierung, jeweils verifiziert und dem Feature zugeordnet, in dessen Spec sie
-unter *Fehlbestand* gehören. Sie sind **keine** Akzeptanzkriterien.
-
-| Befund | Feature | Grad (vorläufig) | Kurz |
+| Befund | Feature | Grad (vorläufig) | Kern |
 |---|---|---|---|
-| FB-DM-01 | B08 | hoch | angeheftete Bilder werden nie gelöscht, sammeln sich unsichtbar an, geschlossene Pins kehren zurück |
-| FB-AS-03 | B03, B05, B08, B09, B13 | mittel | sechs `print()` in Fehlerpfaden — der Nutzer erfährt nicht, wenn das Sichern fehlschlägt |
-| FB-DM-03 | B06 | mittel | `resetAll()` löscht Farbverlauf und Palette nicht |
-| FB-DS-01 | B11 | mittel | README und CHANGELOG beschreiben die Einstellungen als dunkel; der Code ist systemnativ |
-| FB-DM-02 | B11 | mittel | drei Einstellungen ohne jede Wirkung |
-| FB-AS-02 | B01, B12 | mittel | fehlende Berechtigung wird angezeigt, blockiert aber nichts — der Weg führt durch einen Fehlversuch |
-| FB-DM-04 | B09 | niedrig | `HistoryItem.id` bei jedem Start neu, `date` ist das Änderungsdatum |
-| FB-DM-05 | B03 | niedrig | `AnnotationSnapshot.data` untypisiert, Fehler fallen erst zur Laufzeit auf |
-| FB-DM-06 | projektweit | niedrig | keine Schemaversion in `UserDefaults`, kein Migrationspfad |
-| FB-DS-02 bis -05 | B11, projektweit | niedrig | Markenpalette nur teilweise angewandt, keine Tokens, kein Hell-Modus, Kontrast ungeprüft |
-| FB-AS-01, FB-AS-04 | B12, projektweit | niedrig | Onboarding schwer wiederauffindbar, keine Fensterwiederherstellung |
+| Auto-Save schreibt **vor** dem Editor, also immer das unzensierte Original | B04, B09 | **hoch** | wer ein Passwort verpixelt und exportiert, hat das Original weiter in `~/Pictures/MikaScreenSnap/` |
+| Angeheftete Bilder werden nie gelöscht, geschlossene kehren zurück | B08 | **hoch** | unsichtbarer, unbegrenzt wachsender Ablageort, in der Anwendung nicht leerbar |
+| Dateiname mit Sekundengenauigkeit, Schreiben ohne Prüfung | B03, B09 | mittel | zwei Aufnahmen in derselben Sekunde → eine Datei |
+| Fehlgeschlagenes Sichern schließt den Editor trotzdem und meldet nichts | B03, B09 | mittel | stiller Datenverlust |
+| Anheften ignoriert die Einstellung zum automatischen Sichern | B08 | mittel | eine ausdrückliche Nutzerentscheidung wird übergangen |
 
-Die Grade sind **vorläufig** — gesetzt beim Lesen, nicht beim Prüfen. `sdd-qa` bewertet
-sie neu und schreibt sie nach `features/befunde.md` fort.
+### Zusagen, die nicht eingelöst werden
+
+| Befund | Feature | Grad | Kern |
+|---|---|---|---|
+| Zwischenablage ohne Vertraulichkeitskennzeichnung | B03, B05, B06 | mittel | bei geräteübergreifender Zwischenablage trägt **macOS** Bild und erkannten Text zu anderen Geräten — die einzige Einschränkung der Zusage „kein Byte verlässt den Rechner" |
+| Zensurstärke fest und nicht auflösungsbezogen; Weichzeichnen ohne Kantenfortsetzung | B04 | mittel | am Rand eines weichgezeichneten Bereichs bleibt mehr Originalinformation stehen |
+| Palette wird befüllt und nirgends angezeigt | B06 | mittel | im README beworben, aus Nutzersicht wirkungslos |
+| Ausschlussliste nicht nachprüfbar, nur laufende Programme wählbar | B02 | mittel | eine Zusage ohne Kontrollmöglichkeit; Passwortmanager nicht vorbeugend ausschließbar |
+| Vier Einstellungsschlüssel ohne jeden Leser | B11, B12 | mittel | `floatingPreviewEnabled`, `previewDismissDuration`, `showToolbarLabels`, `permissionSkipped` |
+| README und CHANGELOG beschreiben die Einstellungen als dunkel und markenfarben | B11 | mittel | der Code ist seit `a43683a` systemnativ |
+| CHANGELOG 3.3.1 sagt, die Update-Schaltfläche werde deaktiviert | B14 | niedrig | `canCheckForUpdates` ist toter Code |
+
+### Fehlverhalten mit Außenwirkung
+
+| Befund | Feature | Grad | Kern |
+|---|---|---|---|
+| Ereignisbehandler werden bei jeder Neuanmeldung erneut installiert | B10, B11 | **hoch** | nach *n* Änderungen der Belegung löst ein Tastendruck *n+1* Aufnahmen aus; *Reset All Preferences* nimmt denselben Weg |
+| Vollbild und Bereich rechnen immer gegen `displays.first` | B01 | mittel | auf Mehrschirm-Arbeitsplätzen falscher Bildschirm und falscher Ausschnitt — obwohl `ScreenGeometry` die Lösung enthält und der Fensterpfad sie benutzt |
+| Vollbild multipliziert die Pixelgröße fest mit 2 | B01 | mittel | falsche Auflösung bei Skalierung ≠ 2 |
+| Berechtigung wird nie angefordert, beim Erststart nicht einmal angestoßen | B12, B15, B01 | mittel | der Nutzer wird in eine Systemliste geschickt, in der die Anwendung noch nicht steht |
+| Leertaste doppelt belegt (Einheitenwechsel und Verschieben) | B07, B03 | niedrig | Messen und Verschieben lösen gleichzeitig aus |
+| Leeres OCR-Ergebnis bleibt stumm; die beiden OCR-Wege verhalten sich unterschiedlich | B05 | niedrig | Fehlschlag und Nichtstun sind nicht unterscheidbar |
+| Lupe zeigt einen eingefrorenen Bildschirm | B06 | niedrig | bewusste Entscheidung, aber nicht gekennzeichnet |
+
+### Projektweit
+
+| Befund | Grad | Kern |
+|---|---|---|
+| **Keine Tests** (`Tests/` fehlt) | mittel | betrifft alle 15 Features. Genau die Fehlerklasse, die 3.4.1 im Fensterpfad behoben hat, ist im Bereichs- und Vollbildpfad unbemerkt geblieben — sie wäre testbar gewesen |
+| Sechs `print()` in Fehlerpfaden | mittel | erreichen in einem Programm ohne Dock-Symbol niemanden |
+| Keine Schemaversion in den Benutzereinstellungen | niedrig | ein Formatwechsel verliert die Konfiguration unbemerkt |
+| Rücksetzliste von Hand gepflegt | niedrig | Farbverlauf, Palette und Sparkles Schlüssel überstehen *Reset All Preferences* |
+| Kein Weg zur Projektseite aus der Anwendung | niedrig | bei „keine Fehlerberichte" als Erfolgskriterium bemerkenswert |
+
+## Nächster Schritt
+
+```
+/sdd-qa B01
+```
+
+Findet die QA nichts, geht das Feature auf `deployed` mit Auditvermerk — ausgeliefert wird
+nichts, der Code läuft ja. Ein kritischer oder hoher Befund **unterbricht** die Reihe, bis
+die Reparatur draußen ist; mittlere und niedrige sammeln sich in `features/befunde.md`.
+
+Nach allen fünfzehn: `/sdd-erfassen abschluss` für den Auditbericht.


### PR DESCRIPTION
Phase 2 of `sdd-erfassen`. All fifteen inventoried features now carry a `spec.md` and a
`design.md` describing what version 3.4.1 actually does. **No source file is touched** —
this is documentation, plus two corrections to the project documents from #31 where the
reading contradicted them.

## What was produced

`features/BNN-slug/spec.md` + `design.md` for B01…B15, plus an updated `features/index.md`.

- **89 entries** under *Fehlbestand*, each with a source location and a consequence
- **51 acceptance criteria** carry a ⚠ marker: the code behaves this way and the intent is
  unconfirmed

**The confirmation step is still open, deliberately.** Each marked criterion needs the
question *"the code does this today — should it?"*, and no agent can answer that because
the intent is nowhere in the source. Markers were set conservatively — marked when in doubt
rather than waved through. A reconstruction that is tidier than reality is worse than none:
it produces a test report you would believe.

## Findings that reach past a single feature

### Data loss and data retention

| Finding | Feature | Provisional | Core |
|---|---|---|---|
| Auto-save writes **before** the editor opens, so always the unredacted original | B04, B09 | **high** | redact a password, export, and the original still sits in `~/Pictures/MikaScreenSnap/` |
| Pinned images are never deleted; closed ones come back | B08 | **high** | an invisible, unbounded store the app cannot clear |
| Filenames are second-precision and written without an existence check | B03, B09 | medium | two captures in one second leave one file |
| A failed write closes the editor anyway and tells nobody | B03, B09 | medium | silent data loss |
| Pinning ignores the auto-save setting | B08 | medium | an explicit user decision is bypassed |

### Promises not kept

| Finding | Feature | Provisional | Core |
|---|---|---|---|
| Pasteboard writes carry no concealed marker | B03, B05, B06 | medium | with Universal Clipboard on, **macOS** carries images and recognised text to the user's other devices — the one qualification to "no byte leaves the machine" |
| Redaction strength is fixed and resolution-blind; blur has no edge clamp | B04 | medium | more original information survives at the edge of a blurred region |
| The colour palette is filled and displayed nowhere | B06 | medium | README-advertised, indistinguishable from a plain click |
| The exclusion list cannot be verified, and only running apps are selectable | B02 | medium | a promise with no way to check it |
| Four settings keys with no reader at all | B11, B12 | medium | `floatingPreviewEnabled`, `previewDismissDuration`, `showToolbarLabels`, `permissionSkipped` |
| README and CHANGELOG call the preferences window dark and branded | B11 | medium | the code has been system-native since `a43683a` |

### Misbehaviour with visible effect

| Finding | Feature | Provisional | Core |
|---|---|---|---|
| Event handlers are installed again on every re-registration | B10, B11 | **high** | after *n* rebinds one keypress fires *n+1* captures; *Reset All Preferences* takes the same path |
| Full-screen and area always compute against `displays.first` | B01 | medium | wrong screen and wrong crop on multi-display setups — though `ScreenGeometry` holds the fix and the window path uses it |
| Full-screen multiplies pixel size by a hard-coded 2 | B01 | medium | wrong resolution at any scale but 2 |
| The permission is never requested, and on a first launch not even nudged | B12, B15, B01 | medium | onboarding sends the user to a System Settings list the app is not in yet |

### Project-wide

**No tests at all.** This is the finding behind several others: the very failure class 3.4.1
fixed in the window path is still live in the area and full-screen paths, and it is pure
arithmetic that would have been testable. Also: six `print()` calls in error paths that
reach nobody in an `LSUIElement` bundle, no schema version in user defaults, and a
hand-maintained reset list with blind spots.

## Corrections to the phase-1 documents

- `docs/prd.md` — the privacy promise now says precisely what holds: the app opens no
  connection beyond the Sparkle check, but the clipboard is a system service that can carry
  content off the machine. Two open points added (`OF-05`, `OF-06`).
- `docs/datenmodell.md` — `permissionSkipped` recorded as a fourth dead key; two further
  findings on the reset list and the stroke-width mismatch.

## Next

Review order stays risk-first: `B01 → B02 → B04 → B09 → B05 → B06 → B08 → B14 → B12 → B03 →
B10 → B11 → B13 → B07 → B15`. Then `/sdd-qa B01` and onwards. A critical or high finding
pauses the run until the fix ships, because it concerns code that is live right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)