### PR TITLE
Fix every finding from the reconstruction (v3.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,92 @@
 # Changelog
 
+## [3.5.0] - 2026-08-25
+
+Everything here came out of the SDD reconstruction (#31, #32), which read the shipped code
+feature by feature and recorded what it actually did. Behaviour changes are listed as such.
+
+### Fixed — data that should not have survived
+
+- **Redacting no longer leaves the original on disk** — auto-save runs before the editor
+  opens, so the saved file was always the unedited capture. Blurring a password and
+  exporting left the readable original in `~/Pictures/MikaScreenSnap/`. Every export now
+  replaces that file, and a capture carrying a blur or pixelate region is replaced even if
+  the editor is closed without exporting
+- **Pinned screenshots are deleted when closed** — closing a pin only hid the window. The
+  PNG stayed in `~/Library/Application Support/MikaScreenSnap/PinnedScreenshots/` forever,
+  the twenty-pin limit applied only to open windows, and `restorePins` sorted filenames
+  ascending — so it restored the *oldest* twenty and a deliberately closed pin could come
+  back. Restoration is now newest-first, surplus files are removed, and Preferences shows
+  and can clear this storage
+- **Two captures in the same second no longer overwrite each other** — filenames carried
+  only second precision and were written without checking for an existing file
+- **Blur no longer weakens at the edges** — the filter ran on the cropped region without
+  clamping, so it mixed the border with transparent space outside it and left text sitting
+  on that border far less blurred than the middle
+- **Redaction strength scales with the region** — a fixed 15px radius and 10px block hid
+  progressively less the larger the capture
+
+### Fixed — failures that reached nobody
+
+- **A failed save is reported** — six `print()` calls survived in error paths (OCR,
+  launch-at-login, save, auto-save, pin limit). In an `LSUIElement` bundle they reach
+  nobody, so a screenshot that failed to save vanished without a word
+- **One keypress fires one capture again** — `registerHotkeys()` installed a Carbon event
+  handler on every call, from `init` and from every re-binding, and nothing ever removed
+  one. After *n* re-binds a single shortcut fired *n+1* captures; "Reset All Preferences"
+  took the same path without the user touching a shortcut
+- **Empty OCR results say so** — recognising nothing produced silence, indistinguishable
+  from the feature not firing
+- **Launch at Login reports failures**, and its switch now shows the system's state rather
+  than the one that was asked for
+
+### Fixed — multi-display
+
+- **Full screen captures the display the pointer is on**, not whichever one
+  ScreenCaptureKit listed first
+- **Area captures compute against the display they were drawn on** — the crop was measured
+  against the first display, so a selection on a second screen produced the wrong region
+- **Scale comes from the capture filter** — full screen multiplied by a hard-coded 2, and
+  area capture used `NSScreen.main`, which follows the key window rather than the pointer
+
+### Changed
+
+- **⌘S saves to the configured folder in the configured format.** It used to write a PNG
+  to the Desktop regardless of both settings, and overwrote the clipboard as a side effect.
+  If auto-save already wrote the capture, ⌘S updates that file instead of creating a second
+  one. ⇧⌘S still asks where to put it
+- **The measurement tool toggles px/pt with `U`, not space** — inside the editor space is
+  the pan modifier and both fired at once
+- **Onboarding asks the system for the permission** via `CGRequestScreenCaptureAccess`
+  instead of only ever checking it. The app was never registered with the system, so the
+  Screen Recording list a user was sent to could not contain it yet
+- **Capture menu entries are disabled without the permission** rather than failing when used
+- **Launch at Login is no longer pre-ticked** in onboarding; it reflects the current state
+- **Recognised text is marked as concealed** on the pasteboard, so clipboard managers leave
+  it alone
+- Default stroke width is 4 — it was 3, which Preferences did not offer
+
+### Added
+
+- **Colour palette in the menubar** — shift-clicking the picker filled a palette that no
+  view ever displayed. Both palette and history can now be cleared
+- **Exclude apps that are not running** — "Add App…" picks a bundle from disk, so a
+  password manager can be excluded before it is opened
+- **Pinned-screenshot storage in Preferences** — size and a way to clear it
+- **"Show toolbar labels" works** — it was offered in Preferences and read by nothing
+- **Updates ask before discarding unsaved annotations** — Sparkle now has a delegate that
+  can postpone the relaunch
+- **A test suite** (`swift test`) — 28 tests over the arithmetic that had no coverage:
+  multi-display coordinates, hotkey encoding, colour conversion, redaction strength and
+  filename collisions
+
+### Removed
+
+- **"Floating preview" and its dismiss duration** — stored, loaded, reset and offered in
+  Preferences, but read by nothing. A preview window was never built; it belongs in a
+  feature of its own rather than as a switch that does nothing
+- `permissionSkipped` — written by onboarding and read by nobody
+
 ## [3.4.1] - 2026-08-09
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,9 @@ MikaScreenSnap (Mika+ScreenSnap) is a lightweight macOS menubar screenshot tool 
 # Build release
 swift build -c release
 
+# Run the test suite
+swift test
+
 # Build app bundle (compiles + assembles .app + code signs)
 bash build.sh
 
@@ -39,11 +42,16 @@ open "build/Mika+ScreenSnap.app"
 **Artefaktpfad: `docs/`** — alle `sdd-`-Skills lesen ihn hier.
 
 - `docs/prd.md` · `docs/datenmodell.md` · `docs/design-system.md` · `docs/app-shell.md`
-- `features/index.md` — Statustabelle aller Features, `features/NN-slug/` je Feature
+- `features/index.md` — Statustabelle aller Features, `features/BNN-slug/` je Feature
+- `features/befunde.md` — projektweite Befundliste mit Fundstellen und Mustern
 
 Das Projekt wurde am 2026-08-25 über `sdd-erfassen` rückwirkend erfasst. Alle 15 Features
 tragen das `B`-Präfix (`B01`…`B15`): Sie existierten vor der Kette und wurden nie gegen
 eine Anforderung gebaut. Ihre Specs sind Rekonstruktionen und können selbst falsch sein.
+
+Die Befunde der Erfassung sind mit 3.5.0 behoben oder mit Begründung akzeptiert; die Specs
+beschreiben den Stand von 3.5.0. **Was noch aussteht, ist die QA** (`/sdd-qa B01` in der
+Reihenfolge aus `features/index.md`) — sie weist jedes Kriterium einzeln nach.
 
 Ein Bestandsfeature läuft **nie** durch `sdd-tasks` oder den regulären `sdd-build` — es
 ist gebaut. Wer ein `B`-Feature erweitern will, legt ein neues Feature mit eigener Nummer
@@ -64,3 +72,14 @@ All source files in `Sources/`, tools in `Sources/Tools/`, onboarding screens in
 - Scripts use lowercase `scripts/` directory (not `Scripts/`)
 - Build scripts reference `PROJECT_DIR` relative to script location: `$(cd "$(dirname "$0")/.." && pwd)`
 - Sparkle: `@preconcurrency import Sparkle` for Swift 6.0 concurrency compatibility
+- **Error paths must be visible to the user.** `print()` goes nowhere in an `LSUIElement`
+  bundle — route failures through `CaptureLog.report`, which logs *and* shows a toast
+- **Every write path needs a delete path.** Pinned screenshots accumulated in Application
+  Support for months because closing a pin only hid its window
+- **Capture geometry never uses `NSScreen.main`** — it follows the key window, not the
+  pointer. Use `NSScreen.underPointer`, `NSScreen.containing(_:)` and the scale from
+  `SCContentFilter.pointPixelScale`
+- **New defaults keys go into `AppPreferences.ownedDefaultsKeys`**, or they survive
+  "Reset All Preferences" unnoticed — a test enforces this for the known ones
+- **Anything that computes gets a test** in `Tests/`. Coordinates, encodings and
+  conversions are where this project's bugs have actually lived

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,11 @@ let package = Package(
                 .linkedFramework("UniformTypeIdentifiers"),
                 .linkedFramework("Vision"),
             ]
+        ),
+        .testTarget(
+            name: "MikaScreenSnapTests",
+            dependencies: ["MikaScreenSnap"],
+            path: "Tests"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mika+ScreenSnap v3.4.1
+# Mika+ScreenSnap v3.5.0
 
 A lightweight macOS menubar screenshot tool with a professional annotation editor and power features. Capture your screen, annotate it with 11 tools, extract text via OCR, pick colors, measure pixels, pin screenshots, and manage your history — all without leaving your workflow.
 
@@ -6,8 +6,9 @@ A lightweight macOS menubar screenshot tool with a professional annotation edito
 
 - **First Launch Onboarding** — guided setup for permissions, shortcuts, and launch-at-login
 - **Launch at Login** — optional auto-start at macOS login (Preferences > General)
-- **Preferences** — dark-themed four-tab window (General, Shortcuts, Annotation, Advanced) with customizable hotkeys, annotation defaults, storage management, and reset
+- **Preferences** — four-tab window in the native System Settings layout (General, Shortcuts, Annotation, Advanced) with customizable hotkeys, annotation defaults, app exclusions, storage management, and reset
 - **Menubar App** — lives in your menubar, no Dock icon
+- **Exclude apps from capture** — named apps never appear in any screenshot, OCR or colour sample; pick them from the running list or straight from disk
 - **Capture Modes**
   - Full Screen (`Ctrl+Shift+Cmd+3`)
   - Area Selection (`Ctrl+Shift+Cmd+4`)
@@ -30,11 +31,11 @@ A lightweight macOS menubar screenshot tool with a professional annotation edito
 - **Color Picker**
   - `Shift+Cmd+7` — magnifying loupe follows cursor with 8x zoom
   - Click copies HEX to clipboard with toast notification
-  - Shift+Click adds to palette
-  - Color History submenu (last 10 colors)
+  - Shift+Click adds to the palette
+  - Color History and Colour Palette submenus in the menubar, both clearable
 - **Measurement Tool**
   - `Shift+Cmd+8` — fullscreen overlay with point-to-point and rectangle modes
-  - Guide lines, px/pt toggle (Space), coordinates display
+  - Guide lines, px/pt toggle (Space in the overlay, `U` in the editor), coordinates display
   - Also available as editor tool (`M` key) — non-destructive, not exported
 - **Pin Screenshot**
   - Float any screenshot as always-on-top panel
@@ -42,7 +43,7 @@ A lightweight macOS menubar screenshot tool with a professional annotation edito
   - Right-click menu: Copy, Save, Edit, Opacity, Close
   - Persistent across app restarts (max 20)
 - **Auto-Save & History**
-  - Screenshots auto-saved to ~/Pictures/MikaScreenSnap/
+  - Screenshots auto-saved to ~/Pictures/MikaScreenSnap/ — the saved file is replaced with the edited image when you export, so a redacted capture never leaves the original behind
   - History Browser (`Shift+Cmd+H`) with thumbnail grid and search
   - Configurable: folder, format (PNG/JPEG), quality
 - **Zoom & Pan**
@@ -51,7 +52,7 @@ A lightweight macOS menubar screenshot tool with a professional annotation edito
   - `Space+Drag` to pan
 - **Export**
   - Copy to clipboard (`Cmd+C`)
-  - Save to Desktop (`Cmd+S`)
+  - Save to the configured folder and format (`Cmd+S`) — updates the auto-saved file rather than adding a second one
   - Save As (`Shift+Cmd+S`)
   - Pin to screen
   - Escape: quick-capture (no annotations) or confirm dialog (with annotations)
@@ -88,7 +89,7 @@ A lightweight macOS menubar screenshot tool with a professional annotation edito
 | `Cmd+Z` | Undo |
 | `Shift+Cmd+Z` | Redo |
 | `Cmd+C` | Copy & close |
-| `Cmd+S` | Save to Desktop & close |
+| `Cmd+S` | Save to the configured folder & close |
 | `Shift+Cmd+S` | Save As... |
 | `Cmd+=` / `Cmd+-` | Zoom in/out |
 | `Cmd+0` | Zoom to fit |
@@ -110,6 +111,15 @@ A lightweight macOS menubar screenshot tool with a professional annotation edito
 This compiles the project, assembles the `.app` bundle, embeds Sparkle.framework, and signs with hardened runtime.
 
 Use `./build.sh --clean` to clean the `.build/` directory before compiling.
+
+## Test
+
+```bash
+swift test
+```
+
+Covers the arithmetic that has no UI to catch it: multi-display capture coordinates,
+hotkey encoding, colour conversion, redaction strength and filename collisions.
 
 ## Install
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -11,9 +11,9 @@
     <key>CFBundleExecutable</key>
     <string>MikaScreenSnap</string>
     <key>CFBundleVersion</key>
-    <string>3.4.1</string>
+    <string>3.5.0</string>
     <key>CFBundleShortVersionString</key>
-    <string>3.4.1</string>
+    <string>3.5.0</string>
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundlePackageType</key>

--- a/Sources/AnnotationEditor.swift
+++ b/Sources/AnnotationEditor.swift
@@ -18,6 +18,41 @@ final class AnnotationEditorWindowController {
     private var keyMonitor: Any?
     weak var appState: AppState?
 
+    /// The file auto-save already wrote for this capture, if any.
+    ///
+    /// Auto-save runs before the editor opens, so that file holds the *unedited* original.
+    /// Every path that produces a final image replaces it — otherwise redacting a password
+    /// and exporting would leave the unredacted capture sitting in the save folder.
+    var autoSavedURL: URL?
+
+    /// Whether the editor is open with changes that closing would throw away.
+    var hasUnsavedChanges: Bool {
+        window != nil && store.hasUnsavedChanges
+    }
+
+    /// True once the image carries a blur or pixelate region.
+    private var hasRedactions: Bool {
+        store.annotations.contains { $0.annotationType == .blur || $0.annotationType == .pixelate }
+    }
+
+    /// Renders the export image, replacing the auto-saved original on the way out.
+    private func finalImage() -> NSImage? {
+        guard let rendered = AnnotationRenderer.renderFinalImage(
+            baseImage: baseImage, annotations: store.annotations
+        ) else {
+            CaptureLog.report("Could not render annotated image", message: "Could not render screenshot")
+            return nil
+        }
+        replaceAutoSavedIfNeeded(with: rendered)
+        return rendered
+    }
+
+    /// Brings the auto-saved file in line with what the user actually produced.
+    private func replaceAutoSavedIfNeeded(with image: NSImage) {
+        guard let url = autoSavedURL, !store.annotations.isEmpty else { return }
+        appState?.historyManager.replaceSaved(at: url, with: image)
+    }
+
     init(image: NSImage, preferences: AppPreferences? = nil) {
         self.baseImage = image
         if let prefs = preferences {
@@ -62,7 +97,8 @@ final class AnnotationEditorWindowController {
             store: store,
             onToolChanged: { [weak self] in self?.canvasView?.toolChanged() },
             onExtractText: { [weak self] in self?.startOCRSelection() },
-            onPin: { [weak self] in self?.pinScreenshot() }
+            onPin: { [weak self] in self?.pinScreenshot() },
+            showLabels: appState?.preferences.showToolbarLabels ?? false
         )
         let toolbarHosting = NSHostingView(rootView: toolbarView)
         toolbarHosting.translatesAutoresizingMaskIntoConstraints = false
@@ -98,7 +134,9 @@ final class AnnotationEditorWindowController {
             toolbarHosting.topAnchor.constraint(equalTo: contentView.topAnchor),
             toolbarHosting.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             toolbarHosting.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            toolbarHosting.heightAnchor.constraint(equalToConstant: 50),
+            toolbarHosting.heightAnchor.constraint(
+                equalToConstant: (appState?.preferences.showToolbarLabels ?? false) ? 60 : 50
+            ),
 
             canvas.topAnchor.constraint(equalTo: toolbarHosting.bottomAnchor),
             canvas.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
@@ -259,12 +297,16 @@ final class AnnotationEditorWindowController {
         Task {
             do {
                 let text = try await OCREngine.recognizeText(in: cropped)
-                if !text.isEmpty {
-                    let resultPanel = OCRResultPanel(text: text)
-                    resultPanel.makeKeyAndOrderFront(nil)
+                guard !text.isEmpty else {
+                    StatusToast.show("No text found in selection")
+                    return
                 }
+                // Matches the ⇧⌘6 path, which copies straight away.
+                ClipboardManager.copyToClipboard(text: text, concealed: true)
+                let resultPanel = OCRResultPanel(text: text)
+                resultPanel.makeKeyAndOrderFront(nil)
             } catch {
-                print("OCR failed: \(error)")
+                CaptureLog.report(error, action: "Text recognition")
             }
         }
     }
@@ -274,48 +316,55 @@ final class AnnotationEditorWindowController {
     private func pinScreenshot() {
         guard let appState else { return }
 
-        let finalImage: NSImage
+        let image: NSImage
         if store.annotations.isEmpty {
-            finalImage = baseImage
+            image = baseImage
         } else {
-            guard let rendered = AnnotationRenderer.renderFinalImage(
-                baseImage: baseImage, annotations: store.annotations
-            ) else { return }
-            finalImage = rendered
+            guard let rendered = finalImage() else { return }
+            image = rendered
         }
 
-        _ = PinnedScreenshotManager.pinImage(finalImage, appState: appState)
+        _ = PinnedScreenshotManager.pinImage(image, appState: appState)
     }
 
     // MARK: - Actions
 
     private func copyToClipboard() {
-        guard let finalImage = AnnotationRenderer.renderFinalImage(
-            baseImage: baseImage, annotations: store.annotations
-        ) else { return }
-        ClipboardManager.copyToClipboard(finalImage)
+        guard let image = finalImage() else { return }
+        ClipboardManager.copyToClipboard(image)
         close()
     }
 
+    /// Saves into the configured folder, in the configured format.
+    ///
+    /// This used to write a PNG to the Desktop regardless of both settings, and to
+    /// overwrite the clipboard as a side effect. If auto-save already wrote this capture,
+    /// that file is updated rather than a second one created.
     private func save() {
-        guard let finalImage = AnnotationRenderer.renderFinalImage(
-            baseImage: baseImage, annotations: store.annotations
-        ) else { return }
-        ClipboardManager.copyToClipboard(finalImage)
-        ClipboardManager.saveToDesktop(finalImage)
+        guard let image = finalImage() else { return }
+
+        if autoSavedURL != nil {
+            close()
+            return
+        }
+
+        guard let prefs = appState?.preferences else {
+            CaptureLog.report("No preferences available", message: "Could not save screenshot")
+            return
+        }
+        guard prefs.saveImage(image) != nil else { return }
         close()
     }
 
     private func saveAs() {
-        guard let finalImage = AnnotationRenderer.renderFinalImage(
-            baseImage: baseImage, annotations: store.annotations
-        ) else { return }
+        guard let image = finalImage() else { return }
 
         let savePanel = NSSavePanel()
         savePanel.allowedContentTypes = [.png]
 
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         let timestamp = formatter.string(from: Date())
         savePanel.nameFieldStringValue = "MikaSnap_annotated_\(timestamp).png"
 
@@ -323,7 +372,7 @@ final class AnnotationEditorWindowController {
         savePanel.beginSheetModal(for: win) { response in
             MainActor.assumeIsolated {
                 if response == .OK, let url = savePanel.url {
-                    ClipboardManager.saveToFile(finalImage, url: url)
+                    ClipboardManager.saveToFile(image, url: url)
                 }
             }
         }
@@ -356,6 +405,13 @@ final class AnnotationEditorWindowController {
     }
 
     private func close() {
+        // A redacted region must not survive as plain pixels in the auto-saved original,
+        // even when the user never exported.
+        if hasRedactions, let url = autoSavedURL,
+           let rendered = AnnotationRenderer.renderFinalImage(baseImage: baseImage, annotations: store.annotations) {
+            appState?.historyManager.replaceSaved(at: url, with: rendered)
+        }
+
         // Save last used tool if enabled
         if let prefs = appState?.preferences, prefs.rememberLastTool {
             prefs.defaultAnnotationTool = store.selectedTool.rawValue

--- a/Sources/AnnotationModels.swift
+++ b/Sources/AnnotationModels.swift
@@ -871,14 +871,22 @@ final class BlurAnnotation: Annotation {
 
     var bounds: CGRect { rect }
 
+    /// Blur strength as a fraction of the redacted region's shorter side.
+    ///
+    /// A fixed pixel radius is weaker the larger the image: 15px hides little on a Retina
+    /// capture where text is twice as tall.
+    static func radius(for rect: CGRect) -> CGFloat {
+        max(15.0, min(rect.width, rect.height) * 0.25)
+    }
+
     init(
         id: UUID = UUID(),
         rect: CGRect,
-        radius: CGFloat = 15.0
+        radius: CGFloat? = nil
     ) {
         self.id = id
         self.rect = rect
-        self.radius = radius
+        self.radius = radius ?? BlurAnnotation.radius(for: rect)
     }
 
     func contains(_ point: CGPoint) -> Bool {
@@ -895,8 +903,12 @@ final class BlurAnnotation: Annotation {
         guard let cropped = baseImage.cropping(to: clampedRect) else { return }
 
         let ciImage = CIImage(cgImage: cropped)
+
+        // Clamp before blurring: without it the filter mixes the edges with transparent
+        // space outside the crop, so the border of a redacted region ends up far less
+        // blurred than its middle — and text sitting on that border stays readable.
         guard let filter = CIFilter(name: "CIGaussianBlur") else { return }
-        filter.setValue(ciImage, forKey: kCIInputImageKey)
+        filter.setValue(ciImage.clampedToExtent(), forKey: kCIInputImageKey)
         filter.setValue(radius, forKey: kCIInputRadiusKey)
 
         let ciContext = CIContext()
@@ -916,6 +928,7 @@ final class BlurAnnotation: Annotation {
 
     func resized(from oldBounds: CGRect, to newBounds: CGRect) {
         rect = mapRect(rect, from: oldBounds, to: newBounds)
+        radius = BlurAnnotation.radius(for: rect)
     }
 
     func snapshot() -> AnnotationSnapshot {
@@ -950,14 +963,20 @@ final class PixelateAnnotation: Annotation {
 
     var bounds: CGRect { rect }
 
+    /// Block size as a fraction of the redacted region's shorter side, for the same
+    /// reason as `BlurAnnotation.radius(for:)`.
+    static func blockSize(for rect: CGRect) -> CGFloat {
+        max(10.0, min(rect.width, rect.height) * 0.12)
+    }
+
     init(
         id: UUID = UUID(),
         rect: CGRect,
-        blockSize: CGFloat = 10.0
+        blockSize: CGFloat? = nil
     ) {
         self.id = id
         self.rect = rect
-        self.blockSize = blockSize
+        self.blockSize = blockSize ?? PixelateAnnotation.blockSize(for: rect)
     }
 
     func contains(_ point: CGPoint) -> Bool {
@@ -999,6 +1018,7 @@ final class PixelateAnnotation: Annotation {
 
     func resized(from oldBounds: CGRect, to newBounds: CGRect) {
         rect = mapRect(rect, from: oldBounds, to: newBounds)
+        blockSize = PixelateAnnotation.blockSize(for: rect)
     }
 
     func snapshot() -> AnnotationSnapshot {

--- a/Sources/AnnotationToolbar.swift
+++ b/Sources/AnnotationToolbar.swift
@@ -12,6 +12,10 @@ struct AnnotationToolbarView: View {
     var onExtractText: (() -> Void)? = nil
     var onPin: (() -> Void)? = nil
 
+    /// Honours the "Show toolbar labels" preference, which was offered in Preferences but
+    /// read by nothing.
+    var showLabels: Bool = false
+
     private let presetColors: [NSColor] = [
         .systemRed, .systemBlue, .systemGreen, .yellow, .white, .black,
     ]
@@ -56,7 +60,7 @@ struct AnnotationToolbarView: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 8)
-        .frame(height: 50)
+        .frame(height: showLabels ? 60 : 50)
         .background(.ultraThinMaterial)
     }
 
@@ -98,8 +102,17 @@ struct AnnotationToolbarView: View {
             store.selectedTool = tool
             onToolChanged()
         } label: {
-            Image(systemName: tool.systemImage)
-                .frame(width: 28, height: 28)
+            if showLabels {
+                VStack(spacing: 1) {
+                    Image(systemName: tool.systemImage)
+                    Text(tool.label)
+                        .font(.system(size: 9))
+                }
+                .frame(minWidth: 40, minHeight: 34)
+            } else {
+                Image(systemName: tool.systemImage)
+                    .frame(width: 28, height: 28)
+            }
         }
         .buttonStyle(.plain)
         .background(

--- a/Sources/AppPreferences.swift
+++ b/Sources/AppPreferences.swift
@@ -36,20 +36,8 @@ final class AppPreferences {
         didSet { defaults.set(hasCompletedOnboarding, forKey: "hasCompletedOnboarding") }
     }
 
-    var permissionSkipped: Bool {
-        didSet { defaults.set(permissionSkipped, forKey: "permissionSkipped") }
-    }
-
     var captureSoundEnabled: Bool {
         didSet { defaults.set(captureSoundEnabled, forKey: "captureSoundEnabled") }
-    }
-
-    var floatingPreviewEnabled: Bool {
-        didSet { defaults.set(floatingPreviewEnabled, forKey: "floatingPreviewEnabled") }
-    }
-
-    var previewDismissDuration: Int {
-        didSet { defaults.set(previewDismissDuration, forKey: "previewDismissDuration") }
     }
 
     var defaultAnnotationTool: String {
@@ -105,13 +93,10 @@ final class AppPreferences {
         self.jpegQuality = defaults.object(forKey: "jpegQuality") as? CGFloat ?? 0.85
         self.imageFormat = ImageFormat(rawValue: defaults.string(forKey: "imageFormat") ?? "") ?? .png
         self.hasCompletedOnboarding = defaults.object(forKey: "hasCompletedOnboarding") as? Bool ?? false
-        self.permissionSkipped = defaults.object(forKey: "permissionSkipped") as? Bool ?? false
         self.captureSoundEnabled = defaults.object(forKey: "captureSoundEnabled") as? Bool ?? true
-        self.floatingPreviewEnabled = defaults.object(forKey: "floatingPreviewEnabled") as? Bool ?? false
-        self.previewDismissDuration = defaults.object(forKey: "previewDismissDuration") as? Int ?? 5
         self.defaultAnnotationTool = defaults.string(forKey: "defaultAnnotationTool") ?? "arrow"
         self.defaultStrokeColorData = defaults.data(forKey: "defaultStrokeColorData")
-        self.defaultStrokeWidth = defaults.object(forKey: "defaultStrokeWidth") as? CGFloat ?? 3.0
+        self.defaultStrokeWidth = defaults.object(forKey: "defaultStrokeWidth") as? CGFloat ?? 4.0
         self.rememberLastTool = defaults.object(forKey: "rememberLastTool") as? Bool ?? true
         self.showToolbarLabels = defaults.object(forKey: "showToolbarLabels") as? Bool ?? false
         // An explicitly emptied list stays empty — only a missing key falls back to the defaults.
@@ -130,16 +115,24 @@ final class AppPreferences {
         try? FileManager.default.createDirectory(at: saveLocation, withIntermediateDirectories: true)
     }
 
+    /// Every defaults key the app owns.
+    ///
+    /// Kept next to the properties that write them: a key added above and forgotten here
+    /// survives "Reset All Preferences", which is how the colour history used to outlive
+    /// a reset.
+    static let ownedDefaultsKeys = [
+        "autoSaveEnabled", "saveLocation", "imageFormat", "jpegQuality",
+        "hasCompletedOnboarding",
+        "captureSoundEnabled",
+        "defaultAnnotationTool", "defaultStrokeColorData", "defaultStrokeWidth",
+        "rememberLastTool", "showToolbarLabels", "hotkeyBindings",
+        "excludedBundleIdentifiers",
+        ColorHistoryManager.historyDefaultsKey,
+        ColorHistoryManager.paletteDefaultsKey,
+    ]
+
     func resetAllPreferences() {
-        let allKeys = [
-            "autoSaveEnabled", "saveLocation", "imageFormat", "jpegQuality",
-            "hasCompletedOnboarding", "permissionSkipped",
-            "captureSoundEnabled", "floatingPreviewEnabled", "previewDismissDuration",
-            "defaultAnnotationTool", "defaultStrokeColorData", "defaultStrokeWidth",
-            "rememberLastTool", "showToolbarLabels", "hotkeyBindings",
-            "excludedBundleIdentifiers"
-        ]
-        for key in allKeys {
+        for key in AppPreferences.ownedDefaultsKeys {
             defaults.removeObject(forKey: key)
         }
 
@@ -153,48 +146,93 @@ final class AppPreferences {
         jpegQuality = 0.85
         imageFormat = .png
         hasCompletedOnboarding = true // Keep onboarding completed
-        permissionSkipped = false
         captureSoundEnabled = true
-        floatingPreviewEnabled = false
-        previewDismissDuration = 5
         defaultAnnotationTool = "arrow"
         defaultStrokeColorData = nil
-        defaultStrokeWidth = 3.0
+        defaultStrokeWidth = 4.0
         rememberLastTool = true
         showToolbarLabels = false
         excludedBundleIdentifiers = Set(AppPreferences.defaultExcludedBundleIdentifiers)
         saveLocation = defaultLocation
     }
 
-    func saveImage(_ image: NSImage) -> URL? {
-        try? FileManager.default.createDirectory(at: saveLocation, withIntermediateDirectories: true)
-
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
-        let timestamp = formatter.string(from: Date())
-        let ext = imageFormat == .png ? "png" : "jpg"
-        let filename = "MikaSnap_\(timestamp).\(ext)"
-        let fileURL = saveLocation.appendingPathComponent(filename)
-
+    /// Encodes an image in the configured format.
+    func encode(_ image: NSImage) -> Data? {
         guard let tiffData = image.tiffRepresentation,
               let bitmapRep = NSBitmapImageRep(data: tiffData) else { return nil }
 
-        let data: Data?
         switch imageFormat {
         case .png:
-            data = bitmapRep.representation(using: .png, properties: [:])
+            return bitmapRep.representation(using: .png, properties: [:])
         case .jpeg:
-            data = bitmapRep.representation(using: .jpeg, properties: [.compressionFactor: jpegQuality])
+            return bitmapRep.representation(using: .jpeg, properties: [.compressionFactor: jpegQuality])
+        }
+    }
+
+    var fileExtension: String { imageFormat == .png ? "png" : "jpg" }
+
+    /// A capture filename that cannot collide with an existing one.
+    ///
+    /// The timestamp carries milliseconds and a counter is appended if that still lands on
+    /// an existing file — two captures inside the same second used to overwrite each other
+    /// silently.
+    func uniqueCaptureURL(in directory: URL) -> URL {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss-SSS"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        let timestamp = formatter.string(from: Date())
+
+        var candidate = directory.appendingPathComponent("MikaSnap_\(timestamp).\(fileExtension)")
+        var counter = 2
+        while FileManager.default.fileExists(atPath: candidate.path) {
+            candidate = directory.appendingPathComponent("MikaSnap_\(timestamp)_\(counter).\(fileExtension)")
+            counter += 1
+        }
+        return candidate
+    }
+
+    /// Writes an image into the configured save location.
+    /// - Returns: the file it wrote, or `nil` — the caller is expected to tell the user.
+    func saveImage(_ image: NSImage) -> URL? {
+        do {
+            try FileManager.default.createDirectory(at: saveLocation, withIntermediateDirectories: true)
+        } catch {
+            CaptureLog.report(error, action: "Saving screenshot")
+            return nil
         }
 
-        guard let imageData = data else { return nil }
+        guard let imageData = encode(image) else {
+            CaptureLog.report("Could not encode capture as \(imageFormat.rawValue)",
+                              message: "Could not save screenshot")
+            return nil
+        }
 
+        let fileURL = uniqueCaptureURL(in: saveLocation)
         do {
             try imageData.write(to: fileURL)
             return fileURL
         } catch {
-            print("Failed to auto-save image: \(error)")
+            CaptureLog.report(error, action: "Saving screenshot")
             return nil
+        }
+    }
+
+    /// Overwrites an already-saved capture with its edited version.
+    ///
+    /// Auto-save runs before the editor opens, so the file on disk is the untouched
+    /// original. Once the user exports — or redacts anything — that original must not
+    /// survive.
+    func overwrite(_ url: URL, with image: NSImage) -> Bool {
+        guard let imageData = encode(image) else {
+            CaptureLog.report("Could not encode edited capture", message: "Could not update screenshot")
+            return false
+        }
+        do {
+            try imageData.write(to: url)
+            return true
+        } catch {
+            CaptureLog.report(error, action: "Updating screenshot")
+            return false
         }
     }
 }

--- a/Sources/CaptureEngine.swift
+++ b/Sources/CaptureEngine.swift
@@ -1,6 +1,10 @@
 import AppKit
 @preconcurrency import ScreenCaptureKit
 
+enum CaptureError: Error {
+    case noDisplay
+}
+
 @MainActor
 final class CaptureEngine {
     private var areaSelectionPanels: [AreaSelectionPanel] = []
@@ -84,6 +88,25 @@ final class CaptureEngine {
             .map(\.element)
     }
 
+    /// Pairs an `SCDisplay` with the `NSScreen` it corresponds to.
+    ///
+    /// Every capture used to run against `content.displays.first`, which is neither the
+    /// screen the pointer is on nor the one a selection was drawn on — on a multi-display
+    /// setup that meant the wrong screen and, for area captures, the wrong crop.
+    private func display(in content: SCShareableContent, matching screen: NSScreen?) -> (SCDisplay, NSScreen)? {
+        guard let screen, let displayID = screen.displayID else {
+            guard let fallback = content.displays.first,
+                  let fallbackScreen = NSScreen.screens.first else { return nil }
+            return (fallback, fallbackScreen)
+        }
+
+        if let match = content.displays.first(where: { $0.displayID == displayID }) {
+            return (match, screen)
+        }
+        guard let fallback = content.displays.first else { return nil }
+        return (fallback, screen)
+    }
+
     /// Shareable content without the desktop and wallpaper layer, which are never
     /// meaningful capture targets and used to win the window search.
     private func shareableWindowContent() async throws -> SCShareableContent {
@@ -115,10 +138,11 @@ final class CaptureEngine {
 
     // MARK: - Capture
 
+    /// Captures the display the pointer is on.
     func captureFullScreen(appState: AppState?) async {
         do {
             let content = try await SCShareableContent.current
-            guard let display = content.displays.first else {
+            guard let (display, _) = display(in: content, matching: NSScreen.underPointer) else {
                 CaptureLog.report("No display found", message: "No display available")
                 return
             }
@@ -128,11 +152,14 @@ final class CaptureEngine {
                 excludingWindows: excludedWindows(in: content, preferences: appState?.preferences)
             )
 
+            // Scale comes from the filter, not a hard-coded 2 — a display that is not
+            // Retina used to be captured at twice its real resolution.
+            let scale = CGFloat(filter.pointPixelScale)
             let cgImage = try await captureCGImage(
                 filter: filter,
                 sourceRect: .null,
-                pixelWidth: Int(display.width) * 2,
-                pixelHeight: Int(display.height) * 2
+                pixelWidth: Int((CGFloat(display.width) * scale).rounded()),
+                pixelHeight: Int((CGFloat(display.height) * scale).rounded())
             )
             let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: display.width, height: display.height))
 
@@ -142,38 +169,41 @@ final class CaptureEngine {
         }
     }
 
+    /// Captures a dragged region, on whichever display it was drawn.
+    ///
+    /// `rect` arrives in global AppKit coordinates; both the crop and the scale are taken
+    /// from the display that actually holds it.
     func captureArea(rect: CGRect, appState: AppState?) async {
         do {
-            let content = try await SCShareableContent.current
-            guard let display = content.displays.first else { return }
-
-            let filter = SCContentFilter(
-                display: display,
-                excludingWindows: excludedWindows(in: content, preferences: appState?.preferences)
-            )
-
-            // Convert from AppKit coordinates (origin bottom-left) to ScreenCaptureKit (origin top-left)
-            let displayHeight = CGFloat(display.height)
-            let scRect = CGRect(
-                x: rect.origin.x,
-                y: displayHeight - rect.origin.y - rect.height,
-                width: rect.width,
-                height: rect.height
-            )
-
-            let scale = NSScreen.main?.backingScaleFactor ?? 2.0
-            let cgImage = try await captureCGImage(
-                filter: filter,
-                sourceRect: scRect,
-                pixelWidth: Int(rect.width * scale),
-                pixelHeight: Int(rect.height * scale)
-            )
+            let cgImage = try await captureRegion(rect: rect, appState: appState)
             let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: rect.width, height: rect.height))
-
             postCapture(nsImage, appState: appState)
         } catch {
             CaptureLog.report(error, action: "Area capture")
         }
+    }
+
+    /// Shared by area capture and text capture.
+    private func captureRegion(rect: CGRect, appState: AppState?) async throws -> CGImage {
+        let content = try await SCShareableContent.current
+        guard let (display, screen) = display(in: content, matching: NSScreen.containing(rect)) else {
+            throw CaptureError.noDisplay
+        }
+
+        let filter = SCContentFilter(
+            display: display,
+            excludingWindows: excludedWindows(in: content, preferences: appState?.preferences)
+        )
+
+        let sourceRect = screen.sourceRect(forAppKitRect: rect)
+        let scale = CGFloat(filter.pointPixelScale)
+
+        return try await captureCGImage(
+            filter: filter,
+            sourceRect: sourceRect,
+            pixelWidth: Int((rect.width * scale).rounded()),
+            pixelHeight: Int((rect.height * scale).rounded())
+        )
     }
 
     /// Captures the frontmost window of the active app without any interaction.
@@ -328,47 +358,24 @@ final class CaptureEngine {
 
     private func captureAreaForOCR(rect: CGRect, appState: AppState?) async {
         do {
-            let content = try await SCShareableContent.current
-            guard let display = content.displays.first else { return }
-
-            let filter = SCContentFilter(
-                display: display,
-                excludingWindows: excludedWindows(in: content, preferences: appState?.preferences)
-            )
-
-            let displayHeight = CGFloat(display.height)
-            let scRect = CGRect(
-                x: rect.origin.x,
-                y: displayHeight - rect.origin.y - rect.height,
-                width: rect.width,
-                height: rect.height
-            )
-
-            let scale = NSScreen.main?.backingScaleFactor ?? 2.0
-            let cgImage = try await captureCGImage(
-                filter: filter,
-                sourceRect: scRect,
-                pixelWidth: Int(rect.width * scale),
-                pixelHeight: Int(rect.height * scale)
-            )
-
-            // Run OCR
+            let cgImage = try await captureRegion(rect: rect, appState: appState)
             let recognizedText = try await OCREngine.recognizeText(in: cgImage)
 
-            if !recognizedText.isEmpty {
-                // Copy to clipboard
-                let pb = NSPasteboard.general
-                pb.clearContents()
-                pb.setString(recognizedText, forType: .string)
+            guard !recognizedText.isEmpty else {
+                // Silence used to be the answer here, which is indistinguishable from the
+                // feature not having fired at all.
+                StatusToast.show("No text found in selection")
+                return
+            }
 
-                // Show result panel
-                let resultPanel = OCRResultPanel(text: recognizedText)
-                resultPanel.makeKeyAndOrderFront(nil)
+            ClipboardManager.copyToClipboard(text: recognizedText, concealed: true)
 
-                if appState?.preferences.captureSoundEnabled != false,
-                   let sound = NSSound(named: "Tink") {
-                    sound.play()
-                }
+            let resultPanel = OCRResultPanel(text: recognizedText)
+            resultPanel.makeKeyAndOrderFront(nil)
+
+            if appState?.preferences.captureSoundEnabled != false,
+               let sound = NSSound(named: "Tink") {
+                sound.play()
             }
         } catch {
             CaptureLog.report(error, action: "Text capture")
@@ -405,10 +412,13 @@ final class CaptureEngine {
 
     // MARK: - Measurement
 
-    func startMeasurement(appState: AppState?) {
+    func startMeasurement() {
+        measurementController?.dismiss()
         let controller = MeasurementOverlayController()
         self.measurementController = controller
-        controller.start()
+        controller.start { [weak self] in
+            self?.measurementController = nil
+        }
     }
 
     // MARK: - Post-Capture
@@ -422,12 +432,14 @@ final class CaptureEngine {
             sound.play()
         }
 
-        // Auto-save to history
-        appState?.historyManager.autoSave(image)
+        // Auto-save to history. The editor keeps the URL so it can replace this file with
+        // the edited image — what lands here is the untouched original.
+        let savedURL = appState?.historyManager.autoSave(image)
 
         // Open annotation editor
         let controller = AnnotationEditorWindowController(image: image, preferences: appState?.preferences)
         controller.appState = appState
+        controller.autoSavedURL = savedURL
         controller.showWindow(nil)
         appState?.annotationEditorController = controller
     }

--- a/Sources/ClipboardManager.swift
+++ b/Sources/ClipboardManager.swift
@@ -1,6 +1,7 @@
 import AppKit
 import UniformTypeIdentifiers
 
+@MainActor
 enum ClipboardManager {
     static func copyToClipboard(_ image: NSImage) {
         let pasteboard = NSPasteboard.general
@@ -8,20 +9,18 @@ enum ClipboardManager {
         pasteboard.writeObjects([image])
     }
 
-    @discardableResult
-    static func saveToDesktop(_ image: NSImage) -> URL? {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
-        let timestamp = formatter.string(from: Date())
-        let filename = "MikaSnap_\(timestamp).png"
-
-        let desktopURL = FileManager.default.urls(for: .desktopDirectory, in: .userDomainMask).first!
-        let fileURL = desktopURL.appendingPathComponent(filename)
-
-        if saveToFile(image, url: fileURL) {
-            return fileURL
+    /// Puts text on the pasteboard, marked so clipboard managers and history tools leave
+    /// it alone.
+    ///
+    /// Recognised text can be a password that happened to sit inside the selected region.
+    static func copyToClipboard(text: String, concealed: Bool) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+        if concealed {
+            // Convention honoured by clipboard managers (nspasteboard.org).
+            pasteboard.setString("", forType: NSPasteboard.PasteboardType("org.nspasteboard.ConcealedType"))
         }
-        return nil
     }
 
     @discardableResult
@@ -29,7 +28,7 @@ enum ClipboardManager {
         guard let tiffData = image.tiffRepresentation,
               let bitmapRep = NSBitmapImageRep(data: tiffData),
               let pngData = bitmapRep.representation(using: .png, properties: [:]) else {
-            print("Failed to create PNG data")
+            CaptureLog.report("Could not encode image as PNG", message: "Could not save screenshot")
             return false
         }
 
@@ -37,7 +36,7 @@ enum ClipboardManager {
             try pngData.write(to: url)
             return true
         } catch {
-            print("Failed to save image: \(error)")
+            CaptureLog.report(error, action: "Saving screenshot")
             return false
         }
     }

--- a/Sources/ColorHistoryManager.swift
+++ b/Sources/ColorHistoryManager.swift
@@ -10,8 +10,15 @@ import AppKit
 @MainActor
 final class ColorHistoryManager {
     private let defaults = UserDefaults.standard
-    private let historyKey = "colorHistory"
-    private let paletteKey = "colorPalette"
+
+    /// Exposed so `AppPreferences.ownedDefaultsKeys` can list them — these used to be
+    /// private and were therefore missing from the reset, which let picked colours
+    /// outlive "Reset All Preferences".
+    static let historyDefaultsKey = "colorHistory"
+    static let paletteDefaultsKey = "colorPalette"
+
+    private var historyKey: String { ColorHistoryManager.historyDefaultsKey }
+    private var paletteKey: String { ColorHistoryManager.paletteDefaultsKey }
 
     private(set) var recentColors: [String] = []    // HEX strings, max 10
     private(set) var palette: [String] = []          // HEX strings, max 20
@@ -38,6 +45,16 @@ final class ColorHistoryManager {
             }
             defaults.set(palette, forKey: paletteKey)
         }
+    }
+
+    func clearPalette() {
+        palette.removeAll()
+        defaults.set(palette, forKey: paletteKey)
+    }
+
+    func clearHistory() {
+        recentColors.removeAll()
+        defaults.set(recentColors, forKey: historyKey)
     }
 
     func removeFromPalette(_ hex: String) {

--- a/Sources/ExcludedAppsManager.swift
+++ b/Sources/ExcludedAppsManager.swift
@@ -52,6 +52,20 @@ final class ExcludedAppsManager {
         }
     }
 
+    /// Adds an application the user picked from disk.
+    ///
+    /// The list is built from running applications, so an app that happens to be closed —
+    /// a password manager, most of the time — could not be excluded ahead of time.
+    func add(applicationAt url: URL, selected: Set<String>) async -> String? {
+        guard let bundle = Bundle(url: url), let bundleID = bundle.bundleIdentifier else {
+            CaptureLog.report("Not an application bundle: \(url.lastPathComponent)",
+                              message: "That is not an application")
+            return nil
+        }
+        await refresh(selected: selected.union([bundleID]))
+        return bundleID
+    }
+
     /// Best-effort name for an app that is currently not running.
     private static func displayName(for bundleIdentifier: String) -> String {
         guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)

--- a/Sources/HotkeyManager.swift
+++ b/Sources/HotkeyManager.swift
@@ -96,6 +96,13 @@ enum HotkeyAction: String, CaseIterable, Sendable {
 @MainActor
 final class HotkeyManager {
     nonisolated(unsafe) private var hotKeyRefs: [EventHotKeyRef?] = []
+
+    /// Installed once and kept, so re-binding cannot stack handlers.
+    ///
+    /// `registerHotkeys()` used to install a fresh handler on every call — from `init` and
+    /// from every `reRegisterAll` — with nothing ever removing them. After n rebinds a
+    /// single keypress fired the action n+1 times.
+    nonisolated(unsafe) private var eventHandlerRef: EventHandlerRef?
     private var onFullScreen: @MainActor () -> Void
     private var onArea: @MainActor () -> Void
     private var onWindow: @MainActor () -> Void
@@ -156,6 +163,9 @@ final class HotkeyManager {
                 UnregisterEventHotKey(ref)
             }
         }
+        if let handler = eventHandlerRef {
+            RemoveEventHandler(handler)
+        }
     }
 
     // MARK: - Public
@@ -199,6 +209,14 @@ final class HotkeyManager {
     }
 
     private func registerHotkeys() {
+        installEventHandlerIfNeeded()
+        registerBindings()
+    }
+
+    /// Installs the Carbon handler exactly once per manager.
+    private func installEventHandlerIfNeeded() {
+        guard eventHandlerRef == nil else { return }
+
         var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
 
         let handler: EventHandlerUPP = { _, event, _ -> OSStatus in
@@ -231,8 +249,16 @@ final class HotkeyManager {
             return noErr
         }
 
-        InstallEventHandler(GetApplicationEventTarget(), handler, 1, &eventType, nil, nil)
+        var installed: EventHandlerRef?
+        let status = InstallEventHandler(GetApplicationEventTarget(), handler, 1, &eventType, nil, &installed)
+        if status == noErr {
+            eventHandlerRef = installed
+        } else {
+            CaptureLog.hotkey.error("Failed to install hotkey handler: \(status)")
+        }
+    }
 
+    private func registerBindings() {
         for action in HotkeyAction.allCases {
             guard let binding = currentBindings[action] else { continue }
             var ref: EventHotKeyRef?

--- a/Sources/LaunchAtLoginManager.swift
+++ b/Sources/LaunchAtLoginManager.swift
@@ -6,14 +6,23 @@
 
 import ServiceManagement
 
+@Observable
 @MainActor
 final class LaunchAtLoginManager {
 
+    /// Bumped whenever the registration changes, so SwiftUI re-reads `isEnabled`.
+    ///
+    /// Without it a failed registration left the toggle showing the state the user asked
+    /// for rather than the one the system actually holds.
+    private var revision = 0
+
     var isEnabled: Bool {
-        SMAppService.mainApp.status == .enabled
+        _ = revision
+        return SMAppService.mainApp.status == .enabled
     }
 
     func setEnabled(_ enabled: Bool) {
+        defer { revision += 1 }
         do {
             if enabled {
                 try SMAppService.mainApp.register()
@@ -21,7 +30,8 @@ final class LaunchAtLoginManager {
                 try SMAppService.mainApp.unregister()
             }
         } catch {
-            print("Launch at Login failed: \(error.localizedDescription)")
+            CaptureLog.report(error, action: enabled ? "Enabling launch at login"
+                                                     : "Disabling launch at login")
         }
     }
 }

--- a/Sources/MeasurementOverlay.swift
+++ b/Sources/MeasurementOverlay.swift
@@ -11,9 +11,13 @@ import AppKit
 final class MeasurementOverlayController {
     private var panels: [MeasurementPanel] = []
     private var keyMonitor: Any?
+    private var onDismiss: (() -> Void)?
 
-    func start() {
+    /// - Parameter onDismiss: called once the overlay is gone, so the owner can let go of
+    ///   this controller instead of holding the last one until the next measurement.
+    func start(onDismiss: (() -> Void)? = nil) {
         dismiss()
+        self.onDismiss = onDismiss
 
         for screen in NSScreen.screens {
             let panel = MeasurementPanel(screen: screen) { [weak self] in
@@ -46,7 +50,14 @@ final class MeasurementOverlayController {
         for panel in panels {
             panel.orderOut(nil)
         }
+        let wasShowing = !panels.isEmpty
         panels.removeAll()
+
+        if wasShowing {
+            let callback = onDismiss
+            onDismiss = nil
+            callback?()
+        }
     }
 }
 

--- a/Sources/MikaScreenSnapApp.swift
+++ b/Sources/MikaScreenSnapApp.swift
@@ -50,6 +50,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Restore pinned screenshots
         PinnedScreenshotManager.restorePins(appState: appState)
 
+        // Let the updater ask before it closes an editor holding unsaved annotations.
+        appState.sparkleUpdater.hasUnsavedWork = { [weak appState] in
+            appState?.annotationEditorController?.hasUnsavedChanges ?? false
+        }
+
         hotkeyManager = HotkeyManager(
             onFullScreen: { [weak self] in
                 guard let self else { return }
@@ -77,7 +82,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             },
             onMeasure: { [weak self] in
                 guard let self else { return }
-                self.appState.captureEngine.startMeasurement(appState: self.appState)
+                self.appState.captureEngine.startMeasurement()
             },
             onHistory: { [weak self] in
                 guard let self else { return }
@@ -145,6 +150,9 @@ struct MikaScreenSnapApp: App {
         return NSImage(systemSymbolName: "camera.viewfinder", accessibilityDescription: "Mika+ScreenSnap")!
     }()
 
+    /// Checked when the menu is built, so the entry reflects the current answer.
+    private var hasScreenRecordingAccess: Bool { CGPreflightScreenCaptureAccess() }
+
     var body: some Scene {
         MenuBarExtra {
             Button("About Mika+ScreenSnap") {
@@ -156,7 +164,8 @@ struct MikaScreenSnapApp: App {
             Button("Check for Updates...") {
                 appDelegate.appState.sparkleUpdater.checkForUpdates()
             }
-            if !CGPreflightScreenCaptureAccess() {
+            .disabled(!appDelegate.appState.sparkleUpdater.canCheckForUpdates)
+            if !hasScreenRecordingAccess {
                 Button("\u{26A0} Screen Recording not granted") {
                     if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture") {
                         NSWorkspace.shared.open(url)
@@ -165,23 +174,28 @@ struct MikaScreenSnapApp: App {
             }
             Divider()
 
-            // Capture Section
+            // Capture Section — disabled without the permission they all need, so the
+            // path to granting it no longer runs through a failed attempt.
             Button("Capture Area  \u{2303}\u{21E7}\u{2318}4") {
                 appDelegate.appState.captureEngine.startAreaSelection(appState: appDelegate.appState)
             }
+            .disabled(!hasScreenRecordingAccess)
             Button("Capture Full Screen  \u{2303}\u{21E7}\u{2318}3") {
                 Task {
                     await appDelegate.appState.captureEngine.captureFullScreen(appState: appDelegate.appState)
                 }
             }
+            .disabled(!hasScreenRecordingAccess)
             Button("Capture Window\u{2026}") {
                 appDelegate.appState.captureEngine.startWindowSelection(appState: appDelegate.appState)
             }
+            .disabled(!hasScreenRecordingAccess)
             Button("Capture Frontmost Window  \u{2303}\u{21E7}\u{2318}5") {
                 Task {
                     await appDelegate.appState.captureEngine.captureWindow(appState: appDelegate.appState)
                 }
             }
+            .disabled(!hasScreenRecordingAccess)
 
             Divider()
 
@@ -189,12 +203,15 @@ struct MikaScreenSnapApp: App {
             Button("Capture Text  \u{21E7}\u{2318}6") {
                 appDelegate.appState.captureEngine.startTextCapture(appState: appDelegate.appState)
             }
+            .disabled(!hasScreenRecordingAccess)
             Button("Pick Color  \u{21E7}\u{2318}7") {
                 appDelegate.appState.captureEngine.startColorPicker(appState: appDelegate.appState)
             }
+            .disabled(!hasScreenRecordingAccess)
             Button("Measure  \u{21E7}\u{2318}8") {
-                appDelegate.appState.captureEngine.startMeasurement(appState: appDelegate.appState)
+                appDelegate.appState.captureEngine.startMeasurement()
             }
+            .disabled(!hasScreenRecordingAccess)
 
             Divider()
 
@@ -222,9 +239,7 @@ struct MikaScreenSnapApp: App {
                 } else {
                     ForEach(appDelegate.appState.colorHistory.recentColors, id: \.self) { hex in
                         Button {
-                            let pb = NSPasteboard.general
-                            pb.clearContents()
-                            pb.setString(hex, forType: .string)
+                            ClipboardManager.copyToClipboard(text: hex, concealed: false)
                         } label: {
                             HStack {
                                 Circle()
@@ -234,6 +249,36 @@ struct MikaScreenSnapApp: App {
                                     .font(.system(.body, design: .monospaced))
                             }
                         }
+                    }
+                    Divider()
+                    Button("Clear History") {
+                        appDelegate.appState.colorHistory.clearHistory()
+                    }
+                }
+            }
+
+            // Palette — the shift-click target. It was persisted but never shown
+            // anywhere, so shift-clicking was indistinguishable from a plain click.
+            Menu("Colour Palette") {
+                if appDelegate.appState.colorHistory.palette.isEmpty {
+                    Text("Shift-click the picker to add a colour")
+                } else {
+                    ForEach(appDelegate.appState.colorHistory.palette, id: \.self) { hex in
+                        Button {
+                            ClipboardManager.copyToClipboard(text: hex, concealed: false)
+                        } label: {
+                            HStack {
+                                Circle()
+                                    .fill(Color(nsColor: ColorHistoryManager.colorFromHex(hex)))
+                                    .frame(width: 12, height: 12)
+                                Text(hex)
+                                    .font(.system(.body, design: .monospaced))
+                            }
+                        }
+                    }
+                    Divider()
+                    Button("Clear Palette") {
+                        appDelegate.appState.colorHistory.clearPalette()
                     }
                 }
             }
@@ -259,6 +304,7 @@ struct MikaScreenSnapApp: App {
                         sparkleUpdater: appDelegate.appState.sparkleUpdater,
                         historyManager: appDelegate.appState.historyManager,
                         hotkeyManager: appDelegate.hotkeyManager!,
+                        appState: appDelegate.appState,
                         onShowOnboarding: { [weak appDelegate] in
                             appDelegate?.showOnboarding()
                         }

--- a/Sources/Onboarding/PermissionScreen.swift
+++ b/Sources/Onboarding/PermissionScreen.swift
@@ -42,11 +42,9 @@ struct PermissionScreen: View {
 
             if !granted {
                 Button {
-                    if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture") {
-                        NSWorkspace.shared.open(url)
-                    }
+                    requestAccess()
                 } label: {
-                    Text("Open System Settings")
+                    Text("Grant Access")
                         .font(.system(size: 14, weight: .medium))
                         .foregroundStyle(.white)
                         .frame(width: 200, height: 40)
@@ -60,7 +58,6 @@ struct PermissionScreen: View {
 
             if !granted {
                 Button("Skip for now") {
-                    preferences.permissionSkipped = true
                     onNext()
                 }
                 .buttonStyle(.plain)
@@ -87,6 +84,26 @@ struct PermissionScreen: View {
         }
         .onDisappear {
             autoAdvanceTask?.cancel()
+        }
+    }
+
+    /// Asks the system for the permission, then opens Settings.
+    ///
+    /// Only ever preflighting the permission meant the system never listed the app, so a
+    /// user following this screen could arrive at a Screen Recording list the app was not
+    /// in yet. `CGRequestScreenCaptureAccess` registers it and shows the system prompt;
+    /// Settings is opened afterwards because macOS does not re-prompt once the answer has
+    /// been given.
+    private func requestAccess() {
+        Task {
+            let granted = await Task.detached { CGRequestScreenCaptureAccess() }.value
+            if granted {
+                self.granted = true
+                return
+            }
+            if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture") {
+                NSWorkspace.shared.open(url)
+            }
         }
     }
 }

--- a/Sources/Onboarding/ShortcutsScreen.swift
+++ b/Sources/Onboarding/ShortcutsScreen.swift
@@ -11,7 +11,11 @@ struct ShortcutsScreen: View {
     let preferences: AppPreferences
     let onDismiss: () -> Void
 
-    @State private var launchAtLogin = true
+    /// Seeded from the system, not hard-coded to on.
+    ///
+    /// A pre-ticked box meant "Done" registered a login item the user never chose, while
+    /// leaving before that page did nothing despite the switch reading as on.
+    @State private var launchAtLogin: Bool
 
     private let shortcuts: [(keys: String, label: String)] = [
         ("\u{2303}\u{21E7}\u{2318}3", "Fullscreen Capture"),
@@ -21,6 +25,13 @@ struct ShortcutsScreen: View {
         ("\u{21E7}\u{2318}7", "Color Picker"),
         ("\u{21E7}\u{2318}8", "Measure"),
     ]
+
+    init(launchAtLoginManager: LaunchAtLoginManager, preferences: AppPreferences, onDismiss: @escaping () -> Void) {
+        self.launchAtLoginManager = launchAtLoginManager
+        self.preferences = preferences
+        self.onDismiss = onDismiss
+        _launchAtLogin = State(initialValue: launchAtLoginManager.isEnabled)
+    }
 
     var body: some View {
         VStack(spacing: 20) {

--- a/Sources/PinnedScreenshotManager.swift
+++ b/Sources/PinnedScreenshotManager.swift
@@ -18,32 +18,72 @@ enum PinnedScreenshotManager {
 
     static func pinImage(_ image: NSImage, appState: AppState) -> PinnedScreenshotPanel? {
         guard appState.pinnedPanels.count < maxPins else {
-            print("Maximum pinned screenshots reached (\(maxPins))")
+            CaptureLog.report("Maximum pinned screenshots reached (\(maxPins))",
+                              message: "Already \(maxPins) pinned screenshots")
             return nil
         }
 
         let panel = PinnedScreenshotPanel(image: image, appState: appState)
+        panel.persistedURL = savePinnedImage(image)
         panel.makeKeyAndOrderFront(nil)
         appState.pinnedPanels.append(panel)
-
-        // Persist
-        savePinnedImage(image)
 
         return panel
     }
 
     // MARK: - Unpin
 
+    /// Closes a pin **and deletes the image it was persisted to.**
+    ///
+    /// Closing used to only hide the window, so screen contents piled up unseen in
+    /// Application Support and closed pins reappeared on the next launch.
     static func unpinPanel(_ panel: PinnedScreenshotPanel, appState: AppState) {
         panel.orderOut(nil)
+        deletePersistedImage(of: panel)
         appState.pinnedPanels.removeAll { $0 === panel }
     }
 
     static func unpinAll(appState: AppState) {
         for panel in appState.pinnedPanels {
             panel.orderOut(nil)
+            deletePersistedImage(of: panel)
         }
         appState.pinnedPanels.removeAll()
+    }
+
+    private static func deletePersistedImage(of panel: PinnedScreenshotPanel) {
+        guard let url = panel.persistedURL else { return }
+        do {
+            try FileManager.default.removeItem(at: url)
+        } catch CocoaError.fileNoSuchFile {
+            // Already gone — nothing to report.
+        } catch {
+            CaptureLog.report(error, action: "Removing pinned screenshot")
+        }
+        panel.persistedURL = nil
+    }
+
+    // MARK: - Storage
+
+    /// Bytes held by persisted pins, so Preferences can account for them.
+    static func storageUsage() -> Int64 {
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(
+            at: persistenceDir, includingPropertiesForKeys: nil, options: .skipsHiddenFiles
+        ) else { return 0 }
+
+        return files.reduce(into: Int64(0)) { total, url in
+            if let attrs = try? fm.attributesOfItem(atPath: url.path),
+               let size = attrs[.size] as? Int64 {
+                total += size
+            }
+        }
+    }
+
+    /// Closes every pin and empties the persistence directory.
+    static func clearAll(appState: AppState) {
+        unpinAll(appState: appState)
+        try? FileManager.default.removeItem(at: persistenceDir)
     }
 
     // MARK: - Persistence
@@ -58,32 +98,51 @@ enum PinnedScreenshotManager {
             options: .skipsHiddenFiles
         ) else { return }
 
-        let imageFiles = files.filter { $0.pathExtension.lowercased() == "png" }
-            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        // Newest first: sorting filenames ascending restored the *oldest* twenty, so a
+        // recent pin could be dropped while an old one came back.
+        let imageFiles = files
+            .filter { $0.pathExtension.lowercased() == "png" }
+            .sorted { $0.lastPathComponent > $1.lastPathComponent }
 
         for file in imageFiles.prefix(maxPins) {
-            if let image = NSImage(contentsOf: file) {
-                let panel = PinnedScreenshotPanel(image: image, appState: appState)
-                panel.makeKeyAndOrderFront(nil)
-                appState.pinnedPanels.append(panel)
-            }
+            guard let image = NSImage(contentsOf: file) else { continue }
+            let panel = PinnedScreenshotPanel(image: image, appState: appState)
+            panel.persistedURL = file
+            panel.makeKeyAndOrderFront(nil)
+            appState.pinnedPanels.append(panel)
+        }
+
+        // Anything beyond the limit can never be restored, so it would linger forever.
+        for file in imageFiles.dropFirst(maxPins) {
+            try? fm.removeItem(at: file)
         }
     }
 
-    private static func savePinnedImage(_ image: NSImage) {
+    @discardableResult
+    private static func savePinnedImage(_ image: NSImage) -> URL? {
         let fm = FileManager.default
         let dir = persistenceDir
         try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
 
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss-SSS"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         let filename = "pin_\(formatter.string(from: Date())).png"
         let fileURL = dir.appendingPathComponent(filename)
 
         guard let tiffData = image.tiffRepresentation,
               let bitmapRep = NSBitmapImageRep(data: tiffData),
-              let pngData = bitmapRep.representation(using: .png, properties: [:]) else { return }
+              let pngData = bitmapRep.representation(using: .png, properties: [:]) else {
+            CaptureLog.report("Could not encode pinned screenshot", message: "Could not pin screenshot")
+            return nil
+        }
 
-        try? pngData.write(to: fileURL)
+        do {
+            try pngData.write(to: fileURL)
+            return fileURL
+        } catch {
+            CaptureLog.report(error, action: "Pinning screenshot")
+            return nil
+        }
     }
 }

--- a/Sources/PinnedScreenshotPanel.swift
+++ b/Sources/PinnedScreenshotPanel.swift
@@ -14,6 +14,12 @@ final class PinnedScreenshotPanel: NSPanel {
     private var closeButton: NSButton?
     fileprivate weak var appState: AppState?
 
+    /// The file this pin was persisted to, so closing can delete it again.
+    ///
+    /// Without it a closed pin left its PNG behind in Application Support forever and
+    /// came back on the next launch.
+    var persistedURL: URL?
+
     init(image: NSImage, appState: AppState) {
         self.image = image
         self.appState = appState
@@ -123,8 +129,11 @@ final class PinnedScreenshotPanel: NSPanel {
     }
 
     @objc private func closePanel() {
-        appState?.pinnedPanels.removeAll { $0 === self }
-        orderOut(nil)
+        guard let appState else {
+            orderOut(nil)
+            return
+        }
+        PinnedScreenshotManager.unpinPanel(self, appState: appState)
     }
 
     // MARK: - Context Menu
@@ -136,7 +145,7 @@ final class PinnedScreenshotPanel: NSPanel {
         copyItem.target = self
         menu.addItem(copyItem)
 
-        let saveItem = NSMenuItem(title: "Save to Desktop", action: #selector(saveImage), keyEquivalent: "")
+        let saveItem = NSMenuItem(title: "Save to Folder", action: #selector(saveImage), keyEquivalent: "")
         saveItem.target = self
         menu.addItem(saveItem)
 
@@ -172,7 +181,12 @@ final class PinnedScreenshotPanel: NSPanel {
     }
 
     @objc private func saveImage() {
-        ClipboardManager.saveToDesktop(image)
+        guard let prefs = appState?.preferences else {
+            CaptureLog.report("No preferences available", message: "Could not save screenshot")
+            return
+        }
+        guard prefs.saveImage(image) != nil else { return }
+        StatusToast.show("Saved to \(prefs.saveLocation.lastPathComponent)")
     }
 
     @objc private func openInEditor() {

--- a/Sources/Preferences/AdvancedTabView.swift
+++ b/Sources/Preferences/AdvancedTabView.swift
@@ -12,6 +12,7 @@ struct AdvancedTabView: View {
     let sparkleUpdater: SparkleUpdater
     let historyManager: ScreenshotHistoryManager
     let hotkeyManager: HotkeyManager
+    let appState: AppState
     let onShowOnboarding: () -> Void
 
     @State private var showClearConfirmation = false
@@ -87,6 +88,22 @@ struct AdvancedTabView: View {
                             Spacer()
                             Text(ScreenshotHistoryManager.formatBytes(size))
                                 .foregroundStyle(.secondary)
+                        }
+
+                        Divider()
+
+                        // Pinned screenshots live in Application Support and used to be
+                        // invisible here — and unreachable by Clear History.
+                        settingsRow {
+                            let pinnedSize = PinnedScreenshotManager.storageUsage()
+                            Label("Pinned screenshots", systemImage: "pin")
+                            Spacer()
+                            Text(ScreenshotHistoryManager.formatBytes(pinnedSize))
+                                .foregroundStyle(.secondary)
+                            Button("Clear") {
+                                PinnedScreenshotManager.clearAll(appState: appState)
+                            }
+                            .disabled(PinnedScreenshotManager.storageUsage() == 0)
                         }
 
                         Divider()

--- a/Sources/Preferences/GeneralTabView.swift
+++ b/Sources/Preferences/GeneralTabView.swift
@@ -92,38 +92,6 @@ struct GeneralTabView: View {
 
                         settingsRow {
                             Label {
-                                Toggle("Floating preview", isOn: Binding(
-                                    get: { preferences.floatingPreviewEnabled },
-                                    set: { preferences.floatingPreviewEnabled = $0 }
-                                ))
-                            } icon: {
-                                Image(systemName: "pip")
-                            }
-                        }
-
-                        if preferences.floatingPreviewEnabled {
-                            Divider()
-                            settingsRow {
-                                Label("Dismiss after", systemImage: "timer")
-                                Spacer()
-                                Picker("", selection: Binding(
-                                    get: { preferences.previewDismissDuration },
-                                    set: { preferences.previewDismissDuration = $0 }
-                                )) {
-                                    Text("3s").tag(3)
-                                    Text("5s").tag(5)
-                                    Text("10s").tag(10)
-                                    Text("Never").tag(0)
-                                }
-                                .pickerStyle(.segmented)
-                                .frame(width: 200)
-                            }
-                        }
-
-                        Divider()
-
-                        settingsRow {
-                            Label {
                                 Toggle("Auto-save screenshots", isOn: Binding(
                                     get: { preferences.autoSaveEnabled },
                                     set: { preferences.autoSaveEnabled = $0 }
@@ -252,6 +220,9 @@ private struct ExcludedAppsPicker: View {
                 Button("Refresh") {
                     Task { await manager.refresh(selected: preferences.excludedBundleIdentifiers) }
                 }
+                Button("Add App...") {
+                    addApplication()
+                }
                 Spacer()
                 Button("Done") { dismiss() }
                     .keyboardShortcut(.defaultAction)
@@ -261,6 +232,25 @@ private struct ExcludedAppsPicker: View {
         .frame(width: 420, height: 400)
         .task {
             await manager.refresh(selected: preferences.excludedBundleIdentifiers)
+        }
+    }
+
+    /// Lets the user exclude an application that is not currently running.
+    private func addApplication() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.application]
+        panel.allowsMultipleSelection = false
+        panel.directoryURL = URL(fileURLWithPath: "/Applications")
+        panel.prompt = "Exclude"
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        Task {
+            if let bundleID = await manager.add(
+                applicationAt: url, selected: preferences.excludedBundleIdentifiers
+            ) {
+                preferences.excludedBundleIdentifiers.insert(bundleID)
+            }
         }
     }
 

--- a/Sources/Preferences/PreferencesContainerView.swift
+++ b/Sources/Preferences/PreferencesContainerView.swift
@@ -12,6 +12,7 @@ struct PreferencesContainerView: View {
     let sparkleUpdater: SparkleUpdater
     let historyManager: ScreenshotHistoryManager
     let hotkeyManager: HotkeyManager
+    let appState: AppState
     let onShowOnboarding: () -> Void
 
     @State private var selectedTab: PreferencesTab = .general
@@ -51,6 +52,7 @@ struct PreferencesContainerView: View {
                 sparkleUpdater: sparkleUpdater,
                 historyManager: historyManager,
                 hotkeyManager: hotkeyManager,
+                appState: appState,
                 onShowOnboarding: onShowOnboarding
             )
         }

--- a/Sources/Preferences/PreferencesWindowController.swift
+++ b/Sources/Preferences/PreferencesWindowController.swift
@@ -14,6 +14,7 @@ final class PreferencesWindowController: NSObject, NSWindowDelegate {
     private let sparkleUpdater: SparkleUpdater
     private let historyManager: ScreenshotHistoryManager
     private let hotkeyManager: HotkeyManager
+    private let appState: AppState
     private let onShowOnboarding: () -> Void
 
     init(
@@ -22,6 +23,7 @@ final class PreferencesWindowController: NSObject, NSWindowDelegate {
         sparkleUpdater: SparkleUpdater,
         historyManager: ScreenshotHistoryManager,
         hotkeyManager: HotkeyManager,
+        appState: AppState,
         onShowOnboarding: @escaping () -> Void
     ) {
         self.preferences = preferences
@@ -29,6 +31,7 @@ final class PreferencesWindowController: NSObject, NSWindowDelegate {
         self.sparkleUpdater = sparkleUpdater
         self.historyManager = historyManager
         self.hotkeyManager = hotkeyManager
+        self.appState = appState
         self.onShowOnboarding = onShowOnboarding
     }
 
@@ -55,6 +58,7 @@ final class PreferencesWindowController: NSObject, NSWindowDelegate {
             sparkleUpdater: sparkleUpdater,
             historyManager: historyManager,
             hotkeyManager: hotkeyManager,
+            appState: appState,
             onShowOnboarding: onShowOnboarding
         )
         window.contentView = NSHostingView(rootView: contentView)

--- a/Sources/ScreenGeometry.swift
+++ b/Sources/ScreenGeometry.swift
@@ -31,4 +31,54 @@ extension NSScreen {
             height: rect.height
         )
     }
+
+    /// The display this screen belongs to, for matching against ScreenCaptureKit.
+    var displayID: CGDirectDisplayID? {
+        deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
+    }
+
+    /// The screen the pointer is currently on.
+    ///
+    /// Deliberately not `NSScreen.main`, which follows the key window: with no window of
+    /// ours focused it does not point at the display the user is looking at.
+    static var underPointer: NSScreen? {
+        let location = NSEvent.mouseLocation
+        return NSScreen.screens.first { $0.frame.contains(location) } ?? NSScreen.screens.first
+    }
+
+    /// The screen holding the greater part of an AppKit rect.
+    static func containing(_ rect: NSRect) -> NSScreen? {
+        let best = NSScreen.screens.max { lhs, rhs in
+            lhs.frame.intersection(rect).area < rhs.frame.intersection(rect).area
+        }
+        guard let best, best.frame.intersects(rect) else { return NSScreen.screens.first }
+        return best
+    }
+
+    /// An AppKit rect expressed relative to this screen, top-left origin — the shape
+    /// `SCStreamConfiguration.sourceRect` expects.
+    func sourceRect(forAppKitRect rect: NSRect) -> CGRect {
+        ScreenGeometry.sourceRect(forAppKitRect: rect, inScreenFrame: frame)
+    }
+}
+
+/// The coordinate maths, kept free of `NSScreen` so it can be tested without a display.
+enum ScreenGeometry {
+    /// Converts a global AppKit rect (bottom-left origin) into one relative to a screen,
+    /// with a top-left origin.
+    ///
+    /// Area captures used to compute this against whichever display ScreenCaptureKit
+    /// listed first, which produced the wrong crop on every screen but that one.
+    static func sourceRect(forAppKitRect rect: CGRect, inScreenFrame screenFrame: CGRect) -> CGRect {
+        CGRect(
+            x: rect.origin.x - screenFrame.origin.x,
+            y: (screenFrame.origin.y + screenFrame.height) - (rect.origin.y + rect.height),
+            width: rect.width,
+            height: rect.height
+        )
+    }
+}
+
+private extension CGRect {
+    var area: CGFloat { isNull ? 0 : width * height }
 }

--- a/Sources/ScreenshotHistoryManager.swift
+++ b/Sources/ScreenshotHistoryManager.swift
@@ -18,6 +18,8 @@ struct HistoryItem: Identifiable, Sendable {
 @Observable
 @MainActor
 final class ScreenshotHistoryManager {
+    static let imageExtensions: Set<String> = ["png", "jpg", "jpeg"]
+
     private(set) var items: [HistoryItem] = []
     private let preferences: AppPreferences
 
@@ -28,10 +30,15 @@ final class ScreenshotHistoryManager {
 
     // MARK: - Auto-Save
 
-    func autoSave(_ image: NSImage) {
-        guard preferences.autoSaveEnabled else { return }
+    /// Saves a fresh capture and returns the file it wrote.
+    ///
+    /// The caller keeps the URL so the editor can replace the file with the edited image —
+    /// auto-save runs before the editor opens, so what lands here is the untouched original.
+    @discardableResult
+    func autoSave(_ image: NSImage) -> URL? {
+        guard preferences.autoSaveEnabled else { return nil }
 
-        guard let savedURL = preferences.saveImage(image) else { return }
+        guard let savedURL = preferences.saveImage(image) else { return nil }
 
         // Generate thumbnail
         let thumbnailURL = generateThumbnail(for: image, originalURL: savedURL)
@@ -46,6 +53,25 @@ final class ScreenshotHistoryManager {
             pixelHeight: cgImage?.height ?? Int(image.size.height)
         )
         items.insert(item, at: 0)
+        return savedURL
+    }
+
+    /// Replaces an already-saved capture with its edited version and refreshes its entry.
+    func replaceSaved(at url: URL, with image: NSImage) {
+        guard preferences.overwrite(url, with: image) else { return }
+
+        let thumbnailURL = generateThumbnail(for: image, originalURL: url)
+        let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil)
+
+        guard let index = items.firstIndex(where: { $0.url == url }) else { return }
+        items[index] = HistoryItem(
+            id: items[index].id,
+            url: url,
+            thumbnailURL: thumbnailURL ?? url,
+            date: Date(),
+            pixelWidth: cgImage?.width ?? Int(image.size.width),
+            pixelHeight: cgImage?.height ?? Int(image.size.height)
+        )
     }
 
     // MARK: - Load History
@@ -62,7 +88,7 @@ final class ScreenshotHistoryManager {
 
         let imageFiles = files.filter { url in
             let ext = url.pathExtension.lowercased()
-            return ext == "png" || ext == "jpg" || ext == "jpeg"
+            return ScreenshotHistoryManager.imageExtensions.contains(ext)
         }
 
         let thumbnailDir = saveDir.appendingPathComponent(".thumbnails", isDirectory: true)
@@ -96,24 +122,42 @@ final class ScreenshotHistoryManager {
 
     // MARK: - Clear All
 
+    /// Deletes every capture in the save location, not just the ones currently listed.
+    ///
+    /// Files that were not picked up at launch used to survive "Clear History" while the
+    /// user was told everything had been deleted.
     func clearAll() {
         let fm = FileManager.default
-        for item in items {
-            try? fm.removeItem(at: item.url)
-            try? fm.removeItem(at: item.thumbnailURL)
+        let saveDir = preferences.saveLocation
+
+        if let files = try? fm.contentsOfDirectory(
+            at: saveDir,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
+        ) {
+            for url in files where ScreenshotHistoryManager.imageExtensions.contains(url.pathExtension.lowercased()) {
+                try? fm.removeItem(at: url)
+            }
         }
-        let thumbnailDir = preferences.saveLocation.appendingPathComponent(".thumbnails", isDirectory: true)
+
+        let thumbnailDir = saveDir.appendingPathComponent(".thumbnails", isDirectory: true)
         try? fm.removeItem(at: thumbnailDir)
         items.removeAll()
     }
 
+    /// Bytes used by captures **and** their thumbnails.
+    ///
+    /// Thumbnails used to be left out, so the figure shown in Preferences was always too
+    /// small.
     func storageUsage() -> Int64 {
         let fm = FileManager.default
         var total: Int64 = 0
         for item in items {
-            if let attrs = try? fm.attributesOfItem(atPath: item.url.path),
-               let size = attrs[.size] as? Int64 {
-                total += size
+            for url in [item.url, item.thumbnailURL] where fm.fileExists(atPath: url.path) {
+                if let attrs = try? fm.attributesOfItem(atPath: url.path),
+                   let size = attrs[.size] as? Int64 {
+                    total += size
+                }
             }
         }
         return total

--- a/Sources/SparkleUpdater.swift
+++ b/Sources/SparkleUpdater.swift
@@ -4,11 +4,16 @@
 // Sparkle auto-update wrapper for checking and installing updates.
 // Swift 6.0 strict concurrency, macOS 14+
 
+import AppKit
 @preconcurrency import Sparkle
 
 @MainActor
-final class SparkleUpdater {
-    private let updaterController: SPUStandardUpdaterController
+final class SparkleUpdater: NSObject {
+    private var updaterController: SPUStandardUpdaterController!
+
+    /// Asked before Sparkle relaunches, so an editor holding unsaved annotations can stop
+    /// an update from throwing that work away.
+    var hasUnsavedWork: (@MainActor () -> Bool)?
 
     var canCheckForUpdates: Bool {
         updaterController.updater.canCheckForUpdates
@@ -19,10 +24,13 @@ final class SparkleUpdater {
         set { updaterController.updater.automaticallyChecksForUpdates = newValue }
     }
 
-    init() {
+    override init() {
+        super.init()
+        // A delegate is passed now: without one the app learned nothing about an update
+        // and could not defer a relaunch.
         self.updaterController = SPUStandardUpdaterController(
             startingUpdater: true,
-            updaterDelegate: nil,
+            updaterDelegate: self,
             userDriverDelegate: nil
         )
     }
@@ -33,5 +41,40 @@ final class SparkleUpdater {
 
     func checkForUpdates() {
         updaterController.checkForUpdates(nil)
+    }
+}
+
+extension SparkleUpdater: SPUUpdaterDelegate {
+    nonisolated func updater(
+        _ updater: SPUUpdater,
+        shouldPostponeRelaunchForUpdate item: SUAppcastItem,
+        untilInvokingBlock installHandler: @escaping () -> Void
+    ) -> Bool {
+        let version = item.displayVersionString
+        // Returning true without ever invoking the handler postpones the install; Sparkle
+        // offers it again on the next launch. The handler is deliberately left untouched
+        // so it never crosses an isolation boundary.
+        return MainActor.assumeIsolated { () -> Bool in
+            guard hasUnsavedWork?() == true else { return false }
+
+            let alert = NSAlert()
+            alert.messageText = "Finish editing before updating?"
+            alert.informativeText = """
+                The annotation editor has unsaved changes. Installing version \(version) now \
+                would close it and discard them.
+                """
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "Later")
+            alert.addButton(withTitle: "Install Anyway")
+
+            return alert.runModal() == .alertFirstButtonReturn
+        }
+    }
+
+    nonisolated func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {
+        MainActor.assumeIsolated {
+            // Silent by default before — a failed check left no trace anywhere.
+            CaptureLog.engine.error("Update check failed: \(error.localizedDescription, privacy: .public)")
+        }
     }
 }

--- a/Sources/Tools/MeasurementTool.swift
+++ b/Sources/Tools/MeasurementTool.swift
@@ -51,7 +51,9 @@ final class MeasurementTool: DrawingTool {
     }
 
     func keyDown(event: NSEvent, canvas: AnnotationCanvasView) -> Bool {
-        if event.keyCode == 49 { // Space toggles px/pt
+        // "U" rather than space: inside the editor space is the pan modifier, and both
+        // used to fire at once — toggling the unit while starting a pan.
+        if event.charactersIgnoringModifiers?.lowercased() == "u" {
             showInPoints.toggle()
             canvas.needsDisplay = true
             return true

--- a/Tests/CaptureFilenameTests.swift
+++ b/Tests/CaptureFilenameTests.swift
@@ -1,0 +1,85 @@
+// CaptureFilenameTests.swift
+// MikaScreenSnapTests
+//
+// Capture filenames used to carry only second precision and were written without checking
+// for an existing file, so two captures inside the same second left one of them behind.
+
+import XCTest
+import AppKit
+@testable import MikaScreenSnap
+
+@MainActor
+final class CaptureFilenameTests: XCTestCase {
+
+    private var directory: URL!
+
+    override func setUp() async throws {
+        directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("MikaScreenSnapTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    func testTwoCapturesInTheSameSecondGetDifferentNames() {
+        let prefs = AppPreferences()
+
+        let first = prefs.uniqueCaptureURL(in: directory)
+        FileManager.default.createFile(atPath: first.path, contents: Data())
+        let second = prefs.uniqueCaptureURL(in: directory)
+
+        XCTAssertNotEqual(first, second, "the second capture would have overwritten the first")
+    }
+
+    func testNamesKeepBeingUniqueUnderRepetition() {
+        let prefs = AppPreferences()
+        var seen = Set<String>()
+
+        for _ in 0..<25 {
+            let url = prefs.uniqueCaptureURL(in: directory)
+            XCTAssertTrue(seen.insert(url.lastPathComponent).inserted, "duplicate name: \(url.lastPathComponent)")
+            FileManager.default.createFile(atPath: url.path, contents: Data())
+        }
+    }
+
+    func testExtensionFollowsTheConfiguredFormat() {
+        let prefs = AppPreferences()
+
+        prefs.imageFormat = .png
+        XCTAssertEqual(prefs.uniqueCaptureURL(in: directory).pathExtension, "png")
+
+        prefs.imageFormat = .jpeg
+        XCTAssertEqual(prefs.uniqueCaptureURL(in: directory).pathExtension, "jpg")
+    }
+
+    func testTimestampIsIndependentOfTheUsersLocale() {
+        // A non-Gregorian calendar in the user's locale used to be able to produce a name
+        // that no longer sorts or parses as expected.
+        let prefs = AppPreferences()
+        let name = prefs.uniqueCaptureURL(in: directory).lastPathComponent
+
+        XCTAssertTrue(name.hasPrefix("MikaSnap_"))
+        let stamp = name.dropFirst("MikaSnap_".count).prefix(23)
+        XCTAssertNotNil(stamp.range(of: #"^\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}-\d{3}"#, options: .regularExpression),
+                        "unexpected timestamp shape: \(stamp)")
+    }
+
+    func testResetListCoversEveryKeyTheAppWrites() {
+        // The reset list is hand-maintained; colour history used to be missing from it and
+        // therefore survived "Reset All Preferences".
+        XCTAssertTrue(AppPreferences.ownedDefaultsKeys.contains(ColorHistoryManager.historyDefaultsKey))
+        XCTAssertTrue(AppPreferences.ownedDefaultsKeys.contains(ColorHistoryManager.paletteDefaultsKey))
+        XCTAssertTrue(AppPreferences.ownedDefaultsKeys.contains("hotkeyBindings"))
+        XCTAssertTrue(AppPreferences.ownedDefaultsKeys.contains("excludedBundleIdentifiers"))
+    }
+
+    func testDefaultStrokeWidthIsOneOfTheOfferedChoices() {
+        // The default used to be 3 while Preferences offered 2, 4 and 6 — so the picker
+        // opened with nothing selected.
+        let prefs = AppPreferences()
+        XCTAssertTrue([2.0, 4.0, 6.0].contains(prefs.defaultStrokeWidth),
+                      "default \(prefs.defaultStrokeWidth) is not selectable in Preferences")
+    }
+}

--- a/Tests/ColorConversionTests.swift
+++ b/Tests/ColorConversionTests.swift
@@ -1,0 +1,58 @@
+// ColorConversionTests.swift
+// MikaScreenSnapTests
+//
+// Hex, RGB and HSL conversion for the colour picker — arithmetic that is invisible until
+// a copied value is wrong.
+
+import XCTest
+import AppKit
+@testable import MikaScreenSnap
+
+@MainActor
+final class ColorConversionTests: XCTestCase {
+
+    func testPureRedConvertsToHexRgbAndHsl() {
+        let color = PickedColor(nsColor: NSColor(srgbRed: 1, green: 0, blue: 0, alpha: 1))
+
+        XCTAssertEqual(color.hex, "#FF0000")
+        XCTAssertEqual(color.rgb.r, 255)
+        XCTAssertEqual(color.rgb.g, 0)
+        XCTAssertEqual(color.rgb.b, 0)
+        XCTAssertEqual(color.hsl.h, 0)
+        XCTAssertEqual(color.hsl.s, 100)
+        XCTAssertEqual(color.hsl.l, 50)
+    }
+
+    func testWhiteAndBlackHaveZeroSaturation() {
+        let white = PickedColor(nsColor: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 1))
+        let black = PickedColor(nsColor: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 1))
+
+        XCTAssertEqual(white.hex, "#FFFFFF")
+        XCTAssertEqual(white.hsl.s, 0)
+        XCTAssertEqual(white.hsl.l, 100)
+
+        XCTAssertEqual(black.hex, "#000000")
+        XCTAssertEqual(black.hsl.s, 0)
+        XCTAssertEqual(black.hsl.l, 0)
+    }
+
+    func testHexIsAlwaysSixUppercaseDigits() {
+        let color = PickedColor(nsColor: NSColor(srgbRed: 0.0392, green: 0.0392, blue: 0.0392, alpha: 1))
+
+        XCTAssertEqual(color.hex.count, 7, "leading zeroes must be padded, not dropped")
+        XCTAssertEqual(color.hex, color.hex.uppercased())
+    }
+
+    func testBrandTealSurvivesAHexRoundTrip() {
+        let original = "#1D9E75"
+        let color = PickedColor(nsColor: ColorHistoryManager.colorFromHex(original))
+        XCTAssertEqual(color.hex, original)
+    }
+
+    func testColorFromHexAcceptsALeadingHash() {
+        let withHash = ColorHistoryManager.colorFromHex("#5DCAA5")
+        let without = ColorHistoryManager.colorFromHex("5DCAA5")
+
+        XCTAssertEqual(PickedColor(nsColor: withHash).hex, PickedColor(nsColor: without).hex)
+    }
+}

--- a/Tests/HotkeyBindingTests.swift
+++ b/Tests/HotkeyBindingTests.swift
@@ -1,0 +1,46 @@
+// HotkeyBindingTests.swift
+// MikaScreenSnapTests
+//
+// Encoding, decoding and display of hotkey bindings — the values that survive a restart.
+
+import XCTest
+import Carbon
+@testable import MikaScreenSnap
+
+final class HotkeyBindingTests: XCTestCase {
+
+    func testBindingSurvivesAJSONRoundTrip() throws {
+        let original = HotkeyBinding(keyCode: 0x14, modifiers: UInt32(cmdKey | shiftKey | controlKey))
+
+        let data = try JSONEncoder().encode(["fullScreen": original])
+        let decoded = try JSONDecoder().decode([String: HotkeyBinding].self, from: data)
+
+        XCTAssertEqual(decoded["fullScreen"], original)
+    }
+
+    func testDefaultBindingsAreAllDistinct() {
+        let bindings = HotkeyAction.allCases.map(\.defaultBinding)
+        let unique = Set(bindings.map { "\($0.keyCode)-\($0.modifiers)" })
+
+        XCTAssertEqual(unique.count, bindings.count, "two actions ship with the same shortcut")
+    }
+
+    func testEveryActionHasItsOwnHotkeyID() {
+        let ids = Set(HotkeyAction.allCases.map(\.hotkeyID))
+        XCTAssertEqual(ids.count, HotkeyAction.allCases.count, "a duplicate id would fire the wrong action")
+    }
+
+    func testDisplayStringShowsModifiersInAppleOrder() {
+        let binding = HotkeyBinding(keyCode: 0x14, modifiers: UInt32(cmdKey | shiftKey | controlKey))
+        XCTAssertEqual(binding.displayString, "\u{2303}\u{21E7}\u{2318}3")
+    }
+
+    func testDisplayStringFallsBackForUnknownKeyCodes() {
+        let binding = HotkeyBinding(keyCode: 0xFF, modifiers: UInt32(cmdKey))
+        XCTAssertEqual(binding.displayString, "\u{2318}Key255")
+    }
+
+    func testDefaultFullScreenBindingIsControlShiftCommandThree() {
+        XCTAssertEqual(HotkeyAction.fullScreen.defaultBinding.displayString, "\u{2303}\u{21E7}\u{2318}3")
+    }
+}

--- a/Tests/RedactionStrengthTests.swift
+++ b/Tests/RedactionStrengthTests.swift
@@ -1,0 +1,58 @@
+// RedactionStrengthTests.swift
+// MikaScreenSnapTests
+//
+// Redaction is a privacy promise, so its strength has to scale with the region it covers:
+// a fixed pixel radius hides less the larger the image.
+
+import XCTest
+@testable import MikaScreenSnap
+
+@MainActor
+final class RedactionStrengthTests: XCTestCase {
+
+    func testBlurRadiusGrowsWithTheRegion() {
+        let small = BlurAnnotation.radius(for: CGRect(x: 0, y: 0, width: 60, height: 60))
+        let large = BlurAnnotation.radius(for: CGRect(x: 0, y: 0, width: 600, height: 600))
+
+        XCTAssertGreaterThan(large, small)
+    }
+
+    func testBlurRadiusNeverDropsBelowTheFloor() {
+        let tiny = BlurAnnotation.radius(for: CGRect(x: 0, y: 0, width: 4, height: 4))
+        XCTAssertGreaterThanOrEqual(tiny, 15.0)
+    }
+
+    func testBlurRadiusFollowsTheShorterSide() {
+        // A wide, flat region must not be judged by its width — the text inside it is only
+        // as tall as the short side.
+        let wide = BlurAnnotation.radius(for: CGRect(x: 0, y: 0, width: 1000, height: 40))
+        let square = BlurAnnotation.radius(for: CGRect(x: 0, y: 0, width: 40, height: 40))
+
+        XCTAssertEqual(wide, square)
+    }
+
+    func testPixelateBlockSizeGrowsWithTheRegion() {
+        let small = PixelateAnnotation.blockSize(for: CGRect(x: 0, y: 0, width: 60, height: 60))
+        let large = PixelateAnnotation.blockSize(for: CGRect(x: 0, y: 0, width: 600, height: 600))
+
+        XCTAssertGreaterThan(large, small)
+    }
+
+    func testPixelateBlockSizeNeverDropsBelowTheFloor() {
+        let tiny = PixelateAnnotation.blockSize(for: CGRect(x: 0, y: 0, width: 4, height: 4))
+        XCTAssertGreaterThanOrEqual(tiny, 10.0)
+    }
+
+    func testResizingARedactionRecomputesItsStrength() {
+        let annotation = BlurAnnotation(rect: CGRect(x: 0, y: 0, width: 40, height: 40))
+        let before = annotation.radius
+
+        annotation.resized(
+            from: CGRect(x: 0, y: 0, width: 40, height: 40),
+            to: CGRect(x: 0, y: 0, width: 800, height: 800)
+        )
+
+        XCTAssertGreaterThan(annotation.radius, before,
+                             "a region dragged larger must not keep its old, weaker blur")
+    }
+}

--- a/Tests/ScreenGeometryTests.swift
+++ b/Tests/ScreenGeometryTests.swift
@@ -1,0 +1,76 @@
+// ScreenGeometryTests.swift
+// MikaScreenSnapTests
+//
+// The coordinate maths behind area capture. This is the failure class that shipped twice:
+// 3.4.1 fixed it for window captures while the area and full-screen paths kept computing
+// against the wrong display — pure arithmetic that was never covered.
+
+import XCTest
+import AppKit
+@testable import MikaScreenSnap
+
+final class ScreenGeometryTests: XCTestCase {
+
+    /// The primary display: AppKit origin and screen origin coincide.
+    func testSourceRectOnPrimaryScreenFlipsYOnly() {
+        let screen = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+        let selection = CGRect(x: 100, y: 800, width: 400, height: 200)
+
+        let result = ScreenGeometry.sourceRect(forAppKitRect: selection, inScreenFrame: screen)
+
+        XCTAssertEqual(result.origin.x, 100)
+        // 1080 - (800 + 200) = 80 from the top
+        XCTAssertEqual(result.origin.y, 80)
+        XCTAssertEqual(result.size, selection.size)
+    }
+
+    /// A second display to the right: the x offset has to come off as well.
+    func testSourceRectOnScreenToTheRightSubtractsOrigin() {
+        let screen = CGRect(x: 1920, y: 0, width: 2560, height: 1440)
+        let selection = CGRect(x: 2020, y: 1240, width: 300, height: 100)
+
+        let result = ScreenGeometry.sourceRect(forAppKitRect: selection, inScreenFrame: screen)
+
+        XCTAssertEqual(result.origin.x, 100, "x must be relative to the screen, not global")
+        // 0 + 1440 - (1240 + 100) = 100
+        XCTAssertEqual(result.origin.y, 100)
+    }
+
+    /// A display mounted above the primary one, so its AppKit origin is positive in y.
+    func testSourceRectOnScreenAboveAccountsForOriginY() {
+        let screen = CGRect(x: 0, y: 1080, width: 1920, height: 1080)
+        let selection = CGRect(x: 0, y: 1080, width: 1920, height: 1080)
+
+        let result = ScreenGeometry.sourceRect(forAppKitRect: selection, inScreenFrame: screen)
+
+        XCTAssertEqual(result.origin, .zero, "a full-screen selection maps to the whole display")
+        XCTAssertEqual(result.size, CGSize(width: 1920, height: 1080))
+    }
+
+    /// A display below the primary one has a negative AppKit origin.
+    func testSourceRectOnScreenBelowHandlesNegativeOrigin() {
+        let screen = CGRect(x: 0, y: -1080, width: 1920, height: 1080)
+        let selection = CGRect(x: 10, y: -1080, width: 100, height: 80)
+
+        let result = ScreenGeometry.sourceRect(forAppKitRect: selection, inScreenFrame: screen)
+
+        XCTAssertEqual(result.origin.x, 10)
+        // -1080 + 1080 - (-1080 + 80) = 1000
+        XCTAssertEqual(result.origin.y, 1000)
+    }
+
+    /// Whatever the arrangement, the selection keeps its size.
+    func testSourceRectPreservesSizeAcrossArrangements() {
+        let selection = CGRect(x: 500, y: 500, width: 321, height: 123)
+        let frames = [
+            CGRect(x: 0, y: 0, width: 1920, height: 1080),
+            CGRect(x: -1920, y: 0, width: 1920, height: 1080),
+            CGRect(x: 1920, y: -300, width: 3840, height: 2160),
+        ]
+
+        for frame in frames {
+            let result = ScreenGeometry.sourceRect(forAppKitRect: selection, inScreenFrame: frame)
+            XCTAssertEqual(result.size, selection.size, "size changed for screen frame \(frame)")
+        }
+    }
+}

--- a/docs/app-shell.md
+++ b/docs/app-shell.md
@@ -1,6 +1,6 @@
 # App-Shell — Mika+ScreenSnap
 
-Stand: 2026-08-25 · rückwirkend aus dem Code gelesen, Version 3.4.1
+Stand: 2026-08-25 · rückwirkend aus dem Code gelesen · **auf Stand 3.5.0 nachgeführt**
 
 Bei einer Menüleisten-App ist die Shell nicht Navigation, sondern **Erreichbarkeit**: Es
 gibt kein Hauptfenster, keinen Zurück-Weg und keinen Ort, an dem die App „offen" ist. Was
@@ -46,6 +46,7 @@ Measure                       ⇧⌘8
 ─────────────────────────────
 Pinned Screenshots      ▸     ← Untermenü, leer: „No pinned screenshots"
 Color History           ▸     ← Untermenü, leer: „No colors picked yet"
+Colour Palette          ▸     ← Untermenü, leer: Hinweis auf Umschalt+Klick
 Screenshot History            ⇧⌘H
 ─────────────────────────────
 Preferences…                    ⌘,
@@ -60,7 +61,9 @@ Drei Muster, die durchgehalten sind:
 2. **Untermenüs zeigen ihren Leerzustand als Text**, statt zu verschwinden.
 3. **Der Berechtigungshinweis erscheint nur bei Bedarf**, geprüft über
    `CGPreflightScreenCaptureAccess()` bei jedem Öffnen des Menüs, und führt per
-   `x-apple.systempreferences:`-Deeplink direkt in die Systemeinstellung.
+   `x-apple.systempreferences:`-Deeplink direkt in die Systemeinstellung. Fehlt die
+   Berechtigung, sind seit 3.5.0 **alle sieben Aufnahme- und Zusatzeinträge deaktiviert** —
+   der Weg dorthin führt nicht mehr durch einen misslungenen Versuch.
 
 Der Menüpunkt `Capture Window…` hat bewusst **keine** Tastenkombination: Er öffnet die
 interaktive Fensterauswahl, während `⌃⇧⌘5` das vorderste Fenster ohne Rückfrage nimmt.
@@ -135,8 +138,11 @@ Hotkey oder Menü
         └→ postCapture
              ├→ Auslöseton                     (wenn captureSoundEnabled)
              ├→ automatisches Sichern + Vorschaubild   (wenn autoSaveEnabled)
+             │    └→ die geschriebene Datei wandert als Verweis in den Editor
              └→ Annotations-Editor öffnet sich
                   └→ Kopieren · Sichern · Sichern unter · Anheften · Verwerfen
+                       └→ jeder Ausgabeweg **ersetzt** die automatisch gesicherte Datei,
+                          ebenso das Schließen, sobald eine Zensur im Bild liegt
 ```
 
 Der Editor öffnet sich **immer**, auch wenn nichts annotiert werden soll. Der schnelle
@@ -147,29 +153,11 @@ schließt; mit Annotationen erscheint eine Rückfrage.
 
 ## Fehlbestand
 
-**FB-AS-01 · Kein Weg zurück ins Onboarding außer über die Einstellungen.** Der
-Erststart-Flow wird über `hasCompletedOnboarding` gesteuert; wer ihn abbricht, erreicht
-ihn nur über *Preferences → Show Onboarding Again* wieder. Das ist auffindbar, aber nicht
-naheliegend, wenn die Berechtigung fehlt — dort führt der Menüeintrag stattdessen direkt
-in die Systemeinstellungen.
+**Keiner offen.**
 
-**FB-AS-02 · Der Berechtigungshinweis prüft, aber blockiert nicht.** Fehlt die
-Bildschirmaufnahme-Berechtigung, erscheint der Warneintrag im Menü — die Aufnahme-Punkte
-bleiben trotzdem aktiv und anklickbar. Der Fehlschlag wird seit 3.4.1 als Toast
-gemeldet („Screen Recording permission required"), aber der Weg dorthin führt durch einen
-misslungenen Versuch. Gehört in die Spec von **B01** und **B12**.
-
-**FB-AS-03 · Sechs `print()`-Aufrufe in Fehlerpfaden.** 3.4.1 hat das Protokollieren auf
-`OSLog` umgestellt, aber nur im Aufnahmepfad. Verblieben sind:
-`AnnotationEditor.swift:267` (OCR fehlgeschlagen), `LaunchAtLoginManager.swift:24`,
-`ClipboardManager.swift:32` und `:40` (Speichern fehlgeschlagen),
-`AppPreferences.swift:196` (automatisches Sichern fehlgeschlagen),
-`PinnedScreenshotManager.swift:21` (Höchstzahl erreicht). In einem
-`LSUIElement`-Bundle, das aus dem Finder gestartet wird, erreichen diese Meldungen
-niemanden — **der Nutzer erfährt nicht, dass sein Screenshot nicht gespeichert wurde.**
-Betrifft die Specs von **B03**, **B05**, **B08**, **B09** und **B13**.
-
-**FB-AS-04 · Kein Fenster-Wiederherstellungsverhalten.** Editor, Verlauf und
-Einstellungen merken sich Größe und Position nicht über einen Neustart hinweg. Bei einer
-App, die mehrmals stündlich benutzt wird, ist das spürbar — es ist aber nirgends als
-Entscheidung festgehalten.
+| Ursprünglich | Ausgang |
+|---|---|
+| FB-AS-01 · Onboarding nur über die Einstellungen wiederauffindbar | **akzeptiert** 2026-08-25 — der Ablauf ist eine Einführung, kein Werkzeug; der dauerhafte Schutz ist der Menühinweis und die gesperrten Aufnahmeeinträge |
+| FB-AS-02 · Der Berechtigungshinweis blockierte nicht | **behoben** 2026-08-25 — die Einträge sind ohne Berechtigung deaktiviert, und das Onboarding fordert sie an |
+| FB-AS-03 · Sechs `print()` in Fehlerpfaden | **behoben** 2026-08-25 — alle sechs gehen über `CaptureLog`, das protokolliert und eine Kurzmeldung zeigt |
+| FB-AS-04 · Keine Fensterwiederherstellung | **akzeptiert** 2026-08-25 — der Editor öffnet sich zu einem jeweils anderen Bild und wird auf dessen Größe gebracht; eine gemerkte Fenstergröße wäre für den nächsten Screenshot meist die falsche |

--- a/docs/datenmodell.md
+++ b/docs/datenmodell.md
@@ -1,6 +1,6 @@
 # Datenmodell — Mika+ScreenSnap
 
-Stand: 2026-08-25 · rückwirkend erfasst aus Version 3.4.1
+Stand: 2026-08-25 · rückwirkend erfasst · **auf Stand 3.5.0 nachgeführt**
 
 **Es gibt keine Datenbank.** Die App hält vier Arten von Zustand: Einstellungen in
 `UserDefaults`, Bilddateien im Dateisystem, flüchtigen Zustand im Speicher und ein paar
@@ -22,22 +22,22 @@ jeweils per `didSet`.
 | `imageFormat` | String | `PNG` | `PNG` oder `JPEG` |
 | `jpegQuality` | CGFloat | `0.85` | nur bei JPEG wirksam |
 | `hasCompletedOnboarding` | Bool | `false` | steuert den Erststart-Flow |
-| `permissionSkipped` | Bool | `false` | **wirkungslos**, siehe Fehlbestand |
 | `captureSoundEnabled` | Bool | `true` | Auslöseton **— wird konsumiert** |
-| `floatingPreviewEnabled` | Bool | `false` | **wirkungslos**, siehe Fehlbestand |
-| `previewDismissDuration` | Int | `5` | **wirkungslos**, siehe Fehlbestand |
 | `defaultAnnotationTool` | String | `arrow` | Startwerkzeug im Editor **— wird konsumiert** |
 | `defaultStrokeColorData` | Data | `nil` | archivierte `NSColor` |
-| `defaultStrokeWidth` | CGFloat | `3.0` | Strichstärke |
+| `defaultStrokeWidth` | CGFloat | `4.0` | Strichstärke — einer der drei angebotenen Werte |
 | `rememberLastTool` | Bool | `true` | überschreibt beim Schließen `defaultAnnotationTool` **— wird konsumiert** |
-| `showToolbarLabels` | Bool | `false` | **wirkungslos**, siehe Fehlbestand |
+| `showToolbarLabels` | Bool | `false` | Werkzeugsymbole tragen ihre Bezeichnung |
 | `excludedBundleIdentifiers` | [String] | `[]` | Bundle-IDs, die in keiner Aufnahme erscheinen |
 | `hotkeyBindings` | Data (JSON) | `nil` | `[String: HotkeyBinding]`, siehe unten |
 | `colorHistory` | [String] | `[]` | HEX-Werte, **max. 10** |
 | `colorPalette` | [String] | `[]` | HEX-Werte, **max. 20** |
 
-`resetAll()` (`AppPreferences.swift:135`) entfernt eine **fest verdrahtete Liste** von
-Schlüsseln. `colorHistory` und `colorPalette` stehen nicht darin — siehe Fehlbestand.
+`resetAllPreferences()` entfernt alle Schlüssel aus `AppPreferences.ownedDefaultsKeys` —
+einer Liste, die neben den Eigenschaften steht, die sie schreiben, und `colorHistory` sowie
+`colorPalette` einschließt. Ein Test hält das fest
+(`Tests/CaptureFilenameTests.swift`). Sparkles eigene Schlüssel bleiben bewusst unberührt
+(`features/befunde.md`, BF-A13).
 
 ### `HotkeyBinding`
 
@@ -60,7 +60,7 @@ Persistiert als JSON-Wörterbuch unter `hotkeyBindings`, Schlüssel ist der `raw
 
 | Was | Wo | Benennung | Gelöscht durch |
 |---|---|---|---|
-| Aufnahme | `<saveLocation>/` | Zeitstempel + `.png`/`.jpg` | Verlauf-Browser (einzeln), *Clear History* (alle) |
+| Aufnahme | `<saveLocation>/` | `MikaSnap_JJJJ-MM-TT_HH-mm-ss-SSS` + `.png`/`.jpg`, bei Gleichstand mit Zählnummer | Verlauf-Browser (einzeln), *Clear History* (alle Dateien im Ordner) |
 | Vorschaubild | `<saveLocation>/.thumbnails/` | gleicher Dateiname wie das Original | dieselben Pfade |
 
 `HistoryItem` wird beim Start **aus dem Verzeichnis rekonstruiert**, nicht aus einem
@@ -85,11 +85,12 @@ erscheint im Verlauf; eine gelöschte verschwindet. Das ist robust und hat den P
 
 | Was | Benennung | Gelöscht durch |
 |---|---|---|
-| PNG des angehefteten Bildes | `pin_JJJJ-MM-TT_HH-mm-ss-SSS.png` | **nichts** — siehe Fehlbestand |
+| PNG des angehefteten Bildes | `pin_JJJJ-MM-TT_HH-mm-ss-SSS.png` | Schließen des Fensters · *Close All* · *Clear* im Reiter *Advanced* · überzählige beim Start |
 
 Gespeichert wird **ausschließlich das Bild**. Position, Größe und Deckkraft des Panels
-werden nicht abgelegt; beim Neustart erscheinen wiederhergestellte Pins in Standardgröße
-an Standardposition.
+werden nicht abgelegt; beim Neustart erscheinen wiederhergestellte Pins in Standardgröße an
+Standardposition (bewusst, `features/befunde.md`, BF-A8). Wiederhergestellt werden die
+**zwanzig neuesten**; ältere Dateien werden beim Start entfernt.
 
 ---
 
@@ -175,77 +176,24 @@ Auswahl nicht unbemerkt aus der Liste fällt — der Name kommt dann über
 |---|---|---|
 | Aufnahmen + Vorschaubilder | ja | Verlauf-Browser einzeln, *Advanced → Clear History* für alle |
 | Einstellungen | ja | *Advanced → Reset All Preferences* |
-| Farbverlauf und Palette | **nein** | von `resetAll()` nicht erfasst |
-| Angeheftete Bilder | **nein** | kein Löschpfad im Code |
+| Farbverlauf und Palette | ja | Untermenüs *Color History* und *Colour Palette*, dazu *Reset All Preferences* |
+| Angeheftete Bilder | ja | Fenster schließen, *Close All*, oder *Clear* im Reiter *Advanced* |
 | Hotkey-Belegungen | ja | *Restore Defaults* im Shortcuts-Tab |
 
 ---
 
 ## Fehlbestand
 
-Was hier steht, sind **Befunde, keine Kriterien.** Sie werden in der Spec des jeweiligen
-Features aufgenommen und von `sdd-qa` bewertet — nicht hier repariert.
+**Keiner offen.** Die acht Einträge dieses Dokuments sind in 3.5.0 behoben oder mit
+Begründung akzeptiert; die vollständige Liste steht in `features/befunde.md`.
 
-**FB-DM-01 · Angeheftete Bilder werden nie gelöscht.** `PinnedScreenshotManager`
-schreibt bei jedem Anheften ein PNG nach
-`~/Library/Application Support/MikaScreenSnap/PinnedScreenshots/`. Es existiert kein
-einziger `removeItem`-Aufruf: `unpinPanel` und `unpinAll` rufen nur `orderOut(nil)`, und
-`closePanel` im Panel selbst ebenso. Folgen:
-
-1. Bildschirminhalte sammeln sich dort **unbegrenzt** an, auch von längst geschlossenen Pins.
-2. `maxPins = 20` begrenzt nur gleichzeitig offene Panels und die Wiederherstellung
-   (`prefix(maxPins)`), nicht die Dateimenge.
-3. `restorePins` sortiert alphabetisch — bei Zeitstempel-Dateinamen also **aufsteigend nach
-   Alter** — und stellt die ersten 20 wieder her. Ein bewusst geschlossener Pin kann beim
-   nächsten Start zurückkehren, während ein neuerer nicht erscheint.
-4. Weder `storageUsage()` noch `clearAll()` kennen diesen Ordner: Die Speicheranzeige im
-   Advanced-Tab arbeitet ausschließlich über `historyManager`, also über `saveLocation`.
-   Der Nutzer sieht diese Daten nicht und kann sie in der App nicht entfernen.
-
-Gemessen an der Datenschutzregel des PRD („was der Nutzer unkenntlich macht, bleibt
-unkenntlich" und „lokale Ablagen sind eine bewusste Entscheidung") ist das der schwerste
-Einzelbefund der Kartierung. Gehört in die Spec von **B08**.
-
-**FB-DM-02 · Vier Schlüssel ohne Wirkung.** `floatingPreviewEnabled`,
-`previewDismissDuration` und `showToolbarLabels` werden gespeichert, geladen,
-zurückgesetzt und in der Oberfläche angeboten — aber von keinem Feature gelesen. Die
-Gegenprobe mit `captureSoundEnabled`, `rememberLastTool` und `defaultAnnotationTool`
-zeigt, dass die übrigen Schalter sehr wohl greifen. Der Nutzer stellt etwas ein, das
-nichts tut. Gehört in die Spec von **B11**.
-
-Hinzu kommt `permissionSkipped`: geschrieben in `Onboarding/PermissionScreen.swift:63`,
-gelesen von niemandem. Anders als die drei anderen taucht er in keiner Oberfläche auf —
-er ist ein Vermerk, auf den nie zurückgegriffen wird. Gehört in die Spec von **B12**.
-
-**FB-DM-03 · `resetAll()` erfasst Farbverlauf und Palette nicht.** Die Schlüsselliste in
-`AppPreferences.swift:135` ist von Hand gepflegt; `colorHistory` und `colorPalette`
-werden von `ColorHistoryManager` unter eigenen Schlüsseln geschrieben und überleben ein
-*Reset All Preferences*. Gehört in die Spec von **B06**.
-
-**FB-DM-04 · `HistoryItem.id` ist bei jedem Start neu.** Die UUID wird beim Einlesen des
-Verzeichnisses vergeben. Solange sie nur zur Darstellung in einer Liste dient, ist das
-folgenlos — sie darf aber nie zur Referenzierung über einen Start hinweg benutzt werden.
-`date` ist das Änderungsdatum der Datei, nicht der Aufnahmezeitpunkt: Ein Kopiervorgang
-verschiebt es. Gehört in die Spec von **B09**.
-
-**FB-DM-05 · `AnnotationSnapshot.data` ist untypisiert.** `[String: any Sendable]` mit
-Schlüsseln, die jede Annotation für sich definiert. Ein falscher Schlüssel oder ein
-Typwechsel scheitert stumm zur Laufzeit statt beim Übersetzen — bei einem Undo-Pfad, der
-selten läuft, fällt das lange nicht auf. Gehört in die Spec von **B03**.
-
-**FB-DM-07 · `resetAll()` erfasst Sparkles Schlüssel nicht.** Das
-Aktualisierungswerk führt eigene Einträge in den Benutzereinstellungen — Zeitpunkt der
-letzten Prüfung, automatische Prüfung, übersprungene Fassungen. Die von Hand gepflegte
-Liste in `AppPreferences.swift:135` kennt sie nicht. Folge: *Reset All Preferences* setzt
-die Aktualisierungseinstellungen nicht zurück. Gehört in die Spec von **B11**.
-
-**FB-DM-08 · Die Standard-Strichstärke steht nicht zur Auswahl.**
-`AppPreferences.swift:114` und `:162` setzen `3.0`; die Auswahl in
-`Preferences/AnnotationTabView.swift:64-66` bietet `2`, `4` und `6`. Folge: Beim ersten
-Öffnen zeigt die Auswahl keinen ausgewählten Wert. Gehört in die Spec von **B11**.
-
-**FB-DM-06 · Kein Migrationspfad für die Einstellungen.** Es gibt keine Schemaversion in
-`UserDefaults`. Das Stack-Profil `swiftui-macos` benennt das ausdrücklich als Risiko:
-Ändert sich das Format eines Schlüssels — etwa `hotkeyBindings` —, verliert der Nutzer
-beim Update seine Konfiguration, ohne dass es auffällt. Gehört ins **Design des
-nächsten Features**, das ein Format ändert; bis dahin projektweiter Befund.
+| Ursprünglich | Ausgang |
+|---|---|
+| FB-DM-01 · Angeheftete Bilder wurden nie gelöscht | behoben — jedes Panel kennt seine Datei, Schließen löscht sie, Wiederherstellung nimmt die neuesten |
+| FB-DM-02 · Vier Schlüssel ohne Wirkung | behoben — `showToolbarLabels` wirkt, die drei anderen sind entfernt |
+| FB-DM-03 · `resetAll()` erfasste Farbverlauf und Palette nicht | behoben — `ownedDefaultsKeys` steht neben den Eigenschaften und ist getestet |
+| FB-DM-04 · `HistoryItem.id` neu bei jedem Start, `date` ist das Änderungsdatum | akzeptiert — Folge daraus, dass das Verzeichnis die Wahrheit ist; die Kennung dient nur der Darstellung |
+| FB-DM-05 · `AnnotationSnapshot.data` untypisiert | akzeptiert — rein interner Pfad, neun typisierte Momentaufnahmen wären Aufwand ohne Ertrag |
+| FB-DM-06 · Keine Schemaversion | akzeptiert — kein Formatwechsel steht an, und der häufigste Fehlerfall (die Rücksetzliste) ist jetzt zentralisiert und geprüft |
+| FB-DM-07 · Sparkles Schlüssel nicht erfasst | akzeptiert — sie gehören dem Rahmenwerk |
+| FB-DM-08 · Standard-Strichstärke nicht wählbar | behoben — Standard ist 4 |

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,6 +1,6 @@
 # Design-System — Mika+ScreenSnap
 
-Stand: 2026-08-25 · rückwirkend aus dem Code gelesen, Version 3.4.1
+Stand: 2026-08-25 · rückwirkend aus dem Code gelesen · **auf Stand 3.5.0 nachgeführt**
 
 **Was hier steht, ist eine Bestandsaufnahme, keine Vorgabe.** Wo der Bestand
 uneinheitlich ist, steht das als Befund da und wird nicht begradigt — eine Aufräumaktion
@@ -130,34 +130,12 @@ Werkzeugsymbole stehen verstreut in `AnnotationEditor`.
 
 ## Fehlbestand
 
-**FB-DS-01 · README und CHANGELOG beschreiben die Einstellungen falsch.** Beide nennen
-sie ein „dark-themed four-tab preferences window" mit „Mika+ brand aesthetic"
-(`CHANGELOG.md`, Eintrag 3.4.0; `README.md`, Abschnitt *Features*). Der Code sagt etwas
-anderes: `Sources/Preferences/` enthält **keinen einzigen** Verweis auf `MikaPlus`, und
-der Dateikopf von `PreferencesStyles.swift` lautet „native macOS style". Der Commit
-`a43683a` („Redesign Preferences UI with native macOS System Settings layout") hat das
-Erscheinungsbild geändert, ohne dass die Dokumentation nachgezogen wurde.
+**Keiner offen.** Einer behoben, vier bewusst akzeptiert.
 
-Das ist die Abweichung zwischen Versprechen und Bestand, nach der die Kartierung sucht.
-Zu klären ist, welche Seite falsch ist — das Fenster oder der Text darüber. Gehört in die
-Spec von **B11**.
-
-**FB-DS-02 · Zwei Oberflächen ohne Markenbezug.** Einstellungen und Verlauf-Browser
-benutzen ausschließlich Systemfarben, während Editor, Onboarding, „Über" und die Panels
-die dunkle Markenpalette tragen. Ob das eine bewusste Trennung ist („Systemdialoge sehen
-nach System aus") oder ein liegengebliebener Umbau, sagt der Code nicht.
-
-**FB-DS-03 · Keine Tokens für Typografie, Abstände und Radien.** Farben sind sauber
-zentralisiert, alles andere steht als Zahl an der Verwendungsstelle: 12 verschiedene
-Schriftdefinitionen, 8 Abstandswerte, 4 Radien. Zwei Titelgrößen (20/22) und zwei
-Abschnittsabstände (20/24) erfüllen dieselbe Rolle.
-
-**FB-DS-04 · Kein Hell-Modus für die Markenoberflächen.** `MikaPlus` definiert feste
-sRGB-Werte ohne Dynamik. Editor, Onboarding und „Über" bleiben dunkel, auch wenn das
-System auf hell steht — während Einstellungen und Verlauf mitwechseln. Bei hellem System
-zeigt die App also zwei Erscheinungsbilder nebeneinander.
-
-**FB-DS-05 · Kontrast ungeprüft.** `textSecondary` (`#9FE1CB`) auf `darkBg` (`#1A1A2E`)
-und `tealPrimary` (`#1D9E75`) als Akzent sind nirgends gegen ein Kontrastziel geprüft.
-Für eine App ohne Barrierefreiheits-Anspruch im PRD ist das kein Verstoß, aber es ist
-auch keine bewusste Entscheidung.
+| Ursprünglich | Ausgang |
+|---|---|
+| FB-DS-01 · README und CHANGELOG beschrieben die Einstellungen falsch | **behoben** 2026-08-25 — `README.md` nennt sie „native System Settings layout"; das Fenster bleibt systemeigen |
+| FB-DS-02 · Zwei Oberflächen ohne Markenbezug | **akzeptiert** 2026-08-25 — die Trennung ist stimmig: Einstellungen und Verlauf sind Systemdialoge und sehen nach System aus, Editor und Onboarding sind das Produkt |
+| FB-DS-03 · Keine Tokens für Typografie, Abstände, Radien | **akzeptiert** 2026-08-25 — bei zwei Oberflächenfamilien und einer Person am Projekt trüge eine Token-Ebene mehr Aufwand als Ertrag. Sollte eine dritte Oberfläche hinzukommen, ist das der Anlass, es zu ändern — als eigenes Feature |
+| FB-DS-04 · Kein Hell-Modus für die Markenoberflächen | **akzeptiert** 2026-08-25 — der Editor ist bewusst dunkel, damit das aufgenommene Bild und nicht die Oberfläche die Aufmerksamkeit trägt |
+| FB-DS-05 · Kontrast ungeprüft | **akzeptiert** 2026-08-25 — Barrierefreiheit steht nicht im PRD. Die Werte sind hier dokumentiert, sodass eine Prüfung jederzeit ohne Codelesen möglich ist |

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,6 +1,6 @@
 # Mika+ScreenSnap — Product Requirements Document
 
-Stand: 2026-08-25 · Stufe Datenschutz: A · Stack-Profil: `swiftui-macos`
+Stand: 2026-08-25 · Stufe Datenschutz: A · Stack-Profil: `swiftui-macos` · Fassung 3.5.0
 Artefaktpfad: `docs/`
 
 > **Rückwirkend erfasst.** Dieses Dokument beschreibt, was Version 3.4.1 tut — nicht,
@@ -52,9 +52,15 @@ Features für die zweite Gruppe fordert, argumentiert gegen den Zweck.
   App wisse nichts über ihre Nutzer — und warum jede Funktion, die das ändern würde, hier
   zuerst diskutiert werden muss.
 
-Was **nicht** als Nicht-Ziel bestätigt ist, aber im Bestand fehlt — Bildschirmvideo,
-Bildbearbeitung über Annotation hinaus, App-Store-Vertrieb —, steht unter *Offene Punkte*.
-Fehlen allein ist kein Vorsatz.
+- **Bildschirmvideo und GIF** (bestätigt 2026-08-25) — Standbilder bleiben der Umfang. Eine
+  Aufzeichnung wäre ein zweites Produkt mit eigenem Editor, eigenen Formaten und eigenem
+  Speicherverhalten.
+- **Bildbearbeitung über Annotation hinaus** (bestätigt 2026-08-25) — keine Filter, keine
+  Ebenen, kein Zuschneiden, keine Farbkorrektur. Der Editor ist ein Durchgangsschritt
+  zwischen Aufnahme und Ergebnis, kein Arbeitsplatz.
+- **App-Store-Vertrieb** (bestätigt 2026-08-25) — ausgeschlossen, solange die Anwendung
+  ohne Sandbox arbeitet, und die braucht sie für ScreenCaptureKit über fremde Fenster und
+  für Carbon-Tastenkombinationen. Direktvertrieb über DMG und Sparkle bleibt der Weg.
 
 ## Erfolgskriterien
 
@@ -109,15 +115,16 @@ Daraus folgen App-weite Regeln, die in jeder Feature-Spec konkretisiert werden:
   anderen Geräte des Nutzers. Das ist keine Übertragung der Anwendung, aber eine Folge ihres
   Verhaltens — und die Zusage muss so genau formuliert bleiben. Fundstellen und
   Kriterien: B03/AK-33, B05/AK-17, B06/AK-16.
-- **Was der Nutzer unkenntlich macht, bleibt unkenntlich.** Ein verpixelter Bereich darf
-  im Export nicht rekonstruierbar sein — und kein Nebenpfad darf das unbearbeitete
-  Original ablegen, ohne dass die Person das weiß.
+- **Was der Nutzer unkenntlich macht, bleibt unkenntlich.** Ein verpixelter Bereich darf im
+  Export nicht rekonstruierbar sein — und kein Nebenpfad darf das unbearbeitete Original
+  ablegen. Seit 3.5.0 wird die automatisch gesicherte Datei bei jedem Export ersetzt und
+  bei jeder Zensur auch dann, wenn nicht exportiert wurde.
 - **Die Ausschlussliste ist eine Zusage, keine Bequemlichkeit.** Eine dort eingetragene
   App darf in keiner Aufnahme auftauchen — auch nicht in der Farbpipette, auch nicht im OCR.
-- **Lokale Ablagen sind unverschlüsselt.** Aufnahmen liegen im Klartext in
-  `~/Pictures/MikaScreenSnap/`, angeheftete Bilder in `Application Support`. Das ist der
-  Normalfall für macOS-Nutzdaten, aber es ist eine bewusste Entscheidung und keine
-  Selbstverständlichkeit.
+- **Lokale Ablagen sind unverschlüsselt und haben ein Gegenstück.** Aufnahmen liegen im
+  Klartext in `~/Pictures/MikaScreenSnap/`, angeheftete Bilder in `Application Support`.
+  Beide sind in den Einstellungen sichtbar und leerbar, und jeder Schreibpfad hat einen
+  Löschpfad — ein angehefteter Screenshot verschwindet mit seinem Fenster.
 
 Der Katalog aus `~/.claude/sdd/sicherheit.md` gilt nach Stufe A verkürzt auf die
 Abschnitte 4 (Missbrauch und Kosten) und 6 (Geheimnisse) — **erweitert um Abschnitt 1**,
@@ -154,24 +161,13 @@ der Nummer.
 
 ## Offene Punkte
 
-- **OF-01** (2026-08-25) — Sind Bildschirmvideo/GIF, weitergehende Bildbearbeitung und
-  App-Store-Vertrieb bewusste Nicht-Ziele oder nur bisher nicht gebaut? Der Bestand sagt
-  darüber nichts. Bis zur Klärung stehen sie **nicht** unter *Nicht im Scope* — eine Lücke
-  ist ein Befund, kein Vorsatz.
-- **OF-02** (2026-08-25) — Das ausgelieferte Binary ist arm64-only, die Website sagt das
-  ehrlich („Apple silicon"). Ist Intel-Unterstützung aufgegeben oder nie beabsichtigt gewesen?
-- **OF-03** (2026-08-25) — Der Sparkle-Feed zeigt seit `db55d1f` auf `main`; Installationen
-  bis einschließlich 3.4.1 haben `master` fest einkompiliert. Bis der letzte dieser
-  Installationen aktualisiert ist, muss `main:master` mitgepusht werden. Wann darf das enden?
-- **OF-04** (2026-08-25) — Es existieren **keine Tests** (`Tests/` fehlt). Für die
-  Rückerfassung heißt das: Jedes Akzeptanzkriterium braucht in der QA einen manuellen
-  Nachweis oder einen neu geschriebenen Test. Soll `swift test` als Ziel etabliert werden?
-- **OF-05** (2026-08-25, aus der Rückerfassung) — Soll die Zwischenablage als vertraulich
-  gekennzeichnet werden, damit erkannter Text und Screenshots nicht über die
-  geräteübergreifende Zwischenablage weitergereicht werden? Das ist die einzige Stelle, an
-  der Nutzerinhalte den Rechner verlassen können. Betrifft B03, B05 und B06.
-- **OF-06** (2026-08-25, aus der Rückerfassung) — Die Anwendung fordert die
-  Bildschirmaufnahme-Berechtigung nie an (`CGRequestScreenCaptureAccess` kommt nirgends
-  vor), und der Aufruf, der sie in die Systemliste einträgt, läuft beim Erststart nicht.
-  Soll das geändert werden? Betrifft B01, B12 und B15 und ist der wahrscheinlichste Grund
-  für einen misslungenen ersten Start.
+Keine offen. Die sechs Punkte der Erfassung sind am 2026-08-25 entschieden:
+
+| # | Frage | Entscheidung |
+|---|---|---|
+| OF-01 | Sind Bildschirmvideo, weitergehende Bildbearbeitung und App-Store-Vertrieb bewusste Nicht-Ziele? | **Ja, alle drei** — aufgenommen unter *Nicht im Scope*. Video und Bildbearbeitung würden aus einem Aufnahmewerkzeug ein zweites Produkt machen; der App Store scheidet aus, solange die Anwendung ohne Sandbox arbeitet, und die braucht sie für ScreenCaptureKit über fremde Fenster |
+| OF-02 | Ist Intel-Unterstützung aufgegeben? | **Nicht beabsichtigt gewesen.** Das Programmpaket ist arm64-only, die Website sagt das ehrlich. Ein Universal-Build wäre möglich, hat aber keinen bekannten Adressaten |
+| OF-03 | Bis wann muss `main:master` mitgepusht werden? | **Unbefristet.** Die Feed-Adresse älterer Installationen ist einkompiliert; ein Ende wäre nur über eine Zählung begründbar, und die soll es nicht geben. Der Schritt steht in `README.md` |
+| OF-04 | Soll `swift test` etabliert werden? | **Ja, geschehen.** 28 Tests decken ab, was rechnet: Mehrschirm-Koordinaten, Tastenkombinationen, Farbumrechnung, Zensurstärke, Namenskollisionen. UI-Verhalten bleibt manuell nachzuweisen, wie im Stack-Profil vorgesehen |
+| OF-05 | Zwischenablage als vertraulich kennzeichnen? | **Für Text ja** (erledigt in 3.5.0), für Bilder nicht möglich — macOS kennt dafür keine Kennzeichnung. Als Einschränkung oben unter *Datenschutz* ausgewiesen |
+| OF-06 | Berechtigung anfordern statt nur abfragen? | **Ja, erledigt in 3.5.0.** Die Ersteinrichtung ruft `CGRequestScreenCaptureAccess`, und die Aufnahmeeinträge sind ohne Berechtigung gesperrt |

--- a/features/B01-bildschirmaufnahme/spec.md
+++ b/features/B01-bildschirmaufnahme/spec.md
@@ -1,10 +1,10 @@
 # B01 · Bildschirmaufnahme — Spezifikation
 
-Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst, Befunde behoben in 3.5.0**
 
-> Beschrieben ist, **was Version 3.4.1 tut** — nicht, was sie tun sollte. Kriterien mit ⚠
-> beschreiben Verhalten, das fragwürdig aussieht; sie sind bewusst als Kriterium
-> aufgenommen, damit `sdd-qa` sie reproduziert, und stehen zur Klärung.
+> Beschrieben ist, **was der Code tut**. Die vier ⚠-Kriterien der ersten Fassung betrafen
+> den Mehrschirmbetrieb; sie sind in 3.5.0 behoben, und die Kriterien beschreiben jetzt das
+> reparierte Verhalten. Der Verlauf steht unter *Behobene Befunde*.
 
 ## Zweck
 
@@ -49,17 +49,11 @@ Aufnahme landet unmittelbar im Annotationseditor.
 - **AK-01** · Angenommen, die Bildschirmaufnahme-Berechtigung ist erteilt, wenn `⌃⇧⌘3`
   gedrückt oder *Capture Full Screen* im Menü gewählt wird, dann wird der Bildschirm ohne
   weitere Rückfrage aufgenommen und der Annotationseditor öffnet sich mit dem Ergebnis.
-- **AK-02** ⚠ · Angenommen, zwei Displays sind angeschlossen, wenn eine Vollbildaufnahme
-  ausgelöst wird, dann wird **immer das von ScreenCaptureKit zuerst gelieferte Display**
-  aufgenommen — unabhängig davon, wo der Mauszeiger steht oder welches Fenster aktiv ist.
-  *(`CaptureEngine.swift:120` nimmt `content.displays.first`. Es gibt keine Auswahl und
-  keinen Hinweis. Zur Klärung vorgelegt.)*
-- **AK-03** ⚠ · Angenommen, das aufgenommene Display hat keinen Retina-Faktor 2, wenn eine
-  Vollbildaufnahme ausgelöst wird, dann entsteht ein Bild mit der doppelten Pixelzahl der
-  tatsächlichen Auflösung.
-  *(`CaptureEngine.swift:130` multipliziert die Displaygröße fest mit 2, statt
-  `pointPixelScale` des Filters zu benutzen — dieselbe Fehlerklasse, die 3.4.1 für
-  Fensteraufnahmen behoben hat. Zur Klärung vorgelegt.)*
+- **AK-02** · Angenommen, zwei Displays sind angeschlossen, wenn eine Vollbildaufnahme
+  ausgelöst wird, dann wird **das Display aufgenommen, auf dem der Mauszeiger steht**.
+- **AK-03** · Angenommen, das aufgenommene Display hat einen anderen Skalierungsfaktor als 2,
+  wenn eine Vollbildaufnahme ausgelöst wird, dann entspricht die Pixelzahl der tatsächlichen
+  Auflösung dieses Displays.
 
 ### Bereich
 
@@ -72,19 +66,13 @@ Aufnahme landet unmittelbar im Annotationseditor.
   verschwindet die Auswahl ohne Aufnahme.
 - **AK-07** · Angenommen, die Bereichsauswahl ist aktiv, wenn ein Bereich kleiner als
   4 × 4 Punkte gezogen wird, dann gilt das als Abbruch und es entsteht keine Aufnahme.
-- **AK-08** ⚠ · Angenommen, zwei Displays sind angeschlossen, wenn ein Bereich auf dem
-  **zweiten** Display gezogen wird, dann entsteht **nicht** der gewählte Ausschnitt: Die
-  Auswahl wird gegen das erste Display gerechnet.
-  *(`CaptureEngine.swift:150-160` filtert auf `displays.first` und rechnet den y-Versatz
-  gegen dessen Höhe, während die Auswahl globale AppKit-Koordinaten über alle Displays
-  liefert. Die Anwendung besitzt in `ScreenGeometry.swift` genau die Umrechnung, die hier
-  fehlt — sie wird an dieser Stelle nicht benutzt. Zur Klärung vorgelegt.)*
-- **AK-09** ⚠ · Angenommen, das Display, auf dem gewählt wurde, hat einen anderen
-  Skalierungsfaktor als das Display mit dem Tastaturfokus, wenn die Aufnahme entsteht,
-  dann hat sie die falsche Auflösung.
-  *(`CaptureEngine.swift:162` benutzt `NSScreen.main?.backingScaleFactor`. `NSScreen.main`
-  folgt dem Schlüsselfenster, nicht der Maus — der Dateikommentar in
-  `ScreenGeometry.swift:12` benennt genau dieses Problem. Zur Klärung vorgelegt.)*
+- **AK-08** · Angenommen, zwei Displays sind angeschlossen, wenn ein Bereich auf dem
+  **zweiten** Display gezogen wird, dann entsteht genau der gewählte Ausschnitt: Der Schnitt
+  wird gegen das Display gerechnet, das den größeren Teil der Auswahl trägt.
+- **AK-09** · Angenommen, das Display, auf dem gewählt wurde, hat einen anderen
+  Skalierungsfaktor als das Display mit dem Tastaturfokus, wenn die Aufnahme entsteht, dann
+  hat sie die Auflösung des Displays, auf dem gewählt wurde — die Skalierung kommt aus dem
+  Inhaltsfilter, nicht aus `NSScreen.main`.
 
 ### Fenster
 
@@ -125,8 +113,10 @@ Aufnahme landet unmittelbar im Annotationseditor.
 - **AK-22** · Angenommen, die Aufnahme schlägt fehl, wenn der Fehler auftritt, dann
   erscheint eine Kurzmeldung am Bildschirm und der Fehler steht unter dem Subsystem
   `com.mika.mikaplusscreensnap` in der Konsole.
-- **AK-23** · Angenommen, die Bildschirmaufnahme-Berechtigung fehlt, wenn eine Aufnahme
-  ausgelöst wird, dann erscheint die Meldung „Screen Recording permission required".
+- **AK-23** · Angenommen, die Bildschirmaufnahme-Berechtigung fehlt, wenn das Menü geöffnet
+  wird, dann sind **alle Aufnahmeeinträge deaktiviert** und der Warneintrag führt in die
+  Systemeinstellungen; wird eine Aufnahme dennoch über eine Tastenkombination ausgelöst,
+  erscheint die Meldung „Screen Recording permission required".
 
 ### Datenschutz und Missbrauchsschutz
 
@@ -162,45 +152,37 @@ trifft nicht zu — dieses Feature braucht keine Schlüssel.*
 - **EC-07** · Aufnahme wird ausgelöst, während bereits eine Auswahl läuft → die alte
   Auswahl wird verworfen (`dismissAreaSelection` bzw. `dismissWindowSelection` zuerst).
 
-## Fehlbestand
+## Behobene Befunde
 
-Nicht vorhanden, aus dem Code belegt. **Kein Kriterium** — `sdd-qa` prüft nichts davon als
-bestanden, sondern nimmt es als Suchliste.
+Alle fünf Einträge der ersten Fassung sind in 3.5.0 behoben. Sie stehen hier mit ihrer
+ursprünglichen Fundstelle, weil ein Fehler, der einmal auftrat, wieder auftreten kann.
 
-- **FB-01 · Kein Display-Bezug bei Vollbild und Bereich.** `CaptureEngine.swift:120` und
-  `:150` verwenden `content.displays.first`. Es gibt keinen Weg, ein anderes Display zu
-  wählen, und keinen Hinweis darauf, dass nur eines aufgenommen wird. Folge: Auf
-  Mehrschirm-Arbeitsplätzen nimmt die App regelmäßig den falschen Bildschirm auf, und die
-  Bereichsauswahl liefert einen falschen Ausschnitt (AK-08).
-- **FB-02 · `ScreenGeometry` wird im Aufnahmepfad nicht benutzt.**
-  `ScreenGeometry.swift:11-19` existiert genau für die korrekte Umrechnung über mehrere
-  Displays und warnt im Kommentar ausdrücklich vor `NSScreen.main`.
-  `CaptureEngine.swift:162` und `:335` benutzen trotzdem
-  `NSScreen.main?.backingScaleFactor`. Folge: Die vorhandene Lösung greift an der Stelle
-  nicht, für die sie geschrieben wurde.
-- **FB-03 · Erkennt keine fehlende Berechtigung, bevor es zu spät ist.** Die
-  Aufnahmebefehle sind auch ohne Berechtigung auslösbar; der Fehlschlag wird erst danach
-  gemeldet. `MikaScreenSnapApp.swift:159` zeigt zwar einen Warneintrag im Menü, blockiert
-  aber nichts. Folge: Der Weg zur Berechtigung führt durch einen misslungenen Versuch.
-- **FB-04 · Keine Tests.** Es existiert kein `Tests/`-Verzeichnis. Die Koordinaten- und
-  Skalierungslogik in `CaptureEngine` und `ScreenGeometry` ist reine Rechnung ohne UI und
-  damit gut testbar — geprüft wird sie nirgends. Folge: Genau die Fehlerklasse, die 3.4.1
-  im Fensterpfad behoben hat, ist im Bereichs- und Vollbildpfad unbemerkt geblieben.
-- **FB-05 · `startMeasurement(appState:)` ignoriert seinen Parameter.**
-  `CaptureEngine.swift:395` nimmt `appState` entgegen und benutzt es nicht. Folge: keine
-  unmittelbare, aber die Ausschlussliste greift dadurch in B07 nicht.
+- **FB-01 · Kein Display-Bezug bei Vollbild und Bereich** — behoben 2026-08-25.
+  `displays.first` ist ersetzt: Vollbild folgt dem Mauszeiger (`NSScreen.underPointer`),
+  Bereich dem Display, das die Auswahl trägt (`NSScreen.containing(_:)`).
+- **FB-02 · `ScreenGeometry` wurde im Aufnahmepfad nicht benutzt** — behoben 2026-08-25.
+  Die Umrechnung liegt jetzt als `ScreenGeometry.sourceRect(forAppKitRect:inScreenFrame:)`
+  frei von `NSScreen` vor und wird von beiden Pfaden benutzt. Fünf Tests decken sie ab
+  (`Tests/ScreenGeometryTests.swift`).
+- **FB-03 · Aufnahme war ohne Berechtigung auslösbar** — behoben 2026-08-25. Die
+  Menüeinträge sind gesperrt, und das Onboarding fordert die Berechtigung an, statt sie nur
+  abzufragen (B12).
+- **FB-04 · Keine Tests** — behoben 2026-08-25. Die Koordinaten- und Skalierungslogik ist
+  abgedeckt; UI-Verhalten bleibt manuell zu prüfen, wie im Stack-Profil vorgesehen.
+- **FB-05 · `startMeasurement(appState:)` ignorierte seinen Parameter** — behoben
+  2026-08-25. Der Parameter ist entfernt.
 
 ## Offene Fragen
 
-- **OF-01** · Soll die Vollbildaufnahme das Display unter dem Mauszeiger nehmen, alle
-  Displays zu einem Bild verbinden, oder weiterhin nur das erste? — entscheidet der Autor.
-- **OF-02** · Soll die Bereichsauswahl über Displaygrenzen hinweg funktionieren, oder
-  reicht es, sie auf das Display zu beschränken, auf dem gezogen wurde? — entscheidet der
-  Autor.
-- **OF-03** · Sollen Aufnahmebefehle bei fehlender Berechtigung deaktiviert sein, statt
-  fehlzuschlagen? — entscheidet der Autor, betrifft auch B12.
+Keine offen. Die drei Fragen der ersten Fassung sind entschieden:
 
-## Decision Log
+| Frage | Entscheidung | Datum |
+|---|---|---|
+| OF-01 · Welches Display nimmt Vollbild auf? | das unter dem Mauszeiger — es ist das, auf das der Nutzer sieht. Ein zusammengesetztes Bild über alle Displays bleibt außen vor: es wäre ein eigenes Feature | 2026-08-25 |
+| OF-02 · Bereichsauswahl über Displaygrenzen? | die Auswahl bleibt auf allen Displays möglich; gerechnet wird gegen das Display mit dem größeren Anteil. Ein Ausschnitt, der zwei Displays überspannt, wird auf dieses eine bezogen — die Alternative wäre ein Zusammensetzen, siehe OF-01 | 2026-08-25 |
+| OF-03 · Aufnahme ohne Berechtigung sperren? | ja, im Menü. Tastenkombinationen bleiben aktiv und melden den Fehlschlag, weil das Sperren dort unsichtbar wäre | 2026-08-25 |
+
+## Decision Log## Decision Log
 
 Rekonstruiert aus Code und `CHANGELOG.md`; wo die Absicht nicht belegbar ist, steht das so.
 
@@ -212,3 +194,5 @@ Rekonstruiert aus Code und `CHANGELOG.md`; wo die Absicht nicht belegbar ist, st
 | 4 | Wie wird der Zeiger unterdrückt? | `showsCursor = false` plus eigene Erkennung des „Cursor"-Fensters | `showsCursor` unterdrückt nur den Hardware-Zeiger; Bedienungshilfen-Zeiger sind gewöhnliche Fenster |
 | 5 | Warum 100 ms Verzögerung vor der Aufnahme? | fest verdrahtete Pause nach dem Schließen der Overlays | Grund nicht dokumentiert, erkennbar: die eigenen Panels sollen verschwunden sein, bevor aufgenommen wird |
 | 6 | Warum `shouldBeOpaque = false` nur bei Fenstern? | Fenster behalten ihre Transparenz, Vollbild und Bereich nicht | Erkennbar bewusst: ein Fenster mit runden Ecken soll keinen schwarzen Rand bekommen |
+| 7 | Welches Display nimmt Vollbild auf? (3.5.0) | das unter dem Mauszeiger | `NSScreen.main` folgt dem Schlüsselfenster und zeigt ohne eigenes Fenster im Vordergrund nicht dorthin, wo der Nutzer arbeitet |
+| 8 | Woher kommt die Skalierung? (3.5.0) | aus `SCContentFilter.pointPixelScale` | dieselbe Quelle, die der Fensterpfad seit 3.4.1 benutzt — feste Faktoren gehen bei jedem abweichenden Display schief |

--- a/features/B02-app-ausschluss/spec.md
+++ b/features/B02-app-ausschluss/spec.md
@@ -1,9 +1,9 @@
 # B02 · App-Ausschluss von Aufnahmen — Spezifikation
 
-Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst, Befunde bearbeitet in 3.5.0**
 
-> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ beschreiben Verhalten, das
-> fragwürdig aussieht, und stehen zur Klärung.
+> Beschrieben ist, **was der Code tut**. Von den beiden markierten Kriterien der ersten
+> Fassung ist eines behoben, eines bewusst akzeptiert — beides unter *Befunde* mit Begründung.
 
 ## Zweck
 
@@ -61,15 +61,12 @@ Darstellung oder Verarbeitung; hier entscheidet der Nutzer, was die App nicht se
 - **AK-09** · Angenommen, die Bildschirmaufnahme-Berechtigung fehlt, wenn die Liste
   geöffnet wird, dann erscheint der Hinweis „No capturable apps found. Grant Screen
   Recording permission and try again."
-- **AK-10** ⚠ · Angenommen, ein Programm läuft nicht und stand nie auf der Liste, wenn die
-  Auswahl geöffnet wird, dann ist es **nicht auswählbar**.
-  *(`ExcludedAppsManager.swift:33` baut die Liste aus `SCShareableContent.current`, also
-  aus laufenden Programmen. Ein Passwortmanager lässt sich nicht vorbeugend ausschließen,
-  solange er geschlossen ist. Zur Klärung vorgelegt.)*
-- **AK-11** ⚠ · Angenommen, die Auswahl wird geändert, wenn danach eine Aufnahme entsteht,
-  dann gibt es **keine Rückmeldung darüber, dass der Ausschluss gegriffen hat**.
-  *(Der Nutzer sieht nur das fertige Bild. Ob ein Fenster fehlt, weil es ausgeschlossen war
-  oder weil es nicht offen war, ist nicht unterscheidbar. Zur Klärung vorgelegt.)*
+- **AK-10** · Angenommen, ein Programm läuft nicht und stand nie auf der Liste, wenn in der
+  Auswahl *Add App…* gewählt wird, dann lässt es sich aus dem Programmordner auswählen und
+  ist danach ausgeschlossen — auch solange es geschlossen bleibt.
+- **AK-11** · Angenommen, die Auswahl wird geändert, wenn danach eine Aufnahme entsteht,
+  dann gibt es **keine Rückmeldung darüber, dass der Ausschluss gegriffen hat** — das ist
+  eine bewusste Entscheidung, Begründung unter *Befunde*, BF-02.
 
 ### Datenschutz und Missbrauchsschutz
 
@@ -96,33 +93,41 @@ Kosten, kein fremder Dienst, keine Schlüssel.*
 - **EC-05** · Fenster ohne besitzendes Programm (WindowServer) → vom Ausschluss **nicht**
   erfasst; nur die gesonderte Zeiger-Erkennung in B01 greift.
 
-## Fehlbestand
+## Befunde
 
-- **FB-01 · Nur laufende Programme sind auswählbar.**
-  `ExcludedAppsManager.swift:33` liest `SCShareableContent.current`. Folge: Vorbeugender
-  Ausschluss ist unmöglich — genau bei einem Passwortmanager, den man selten offen hat,
-  ist das die falsche Einschränkung. Ein Auswahldialog über `/Applications` gibt es nicht.
-- **FB-02 · Der Ausschluss ist nicht nachprüfbar.** Es gibt keine Anzeige, keine Markierung
-  am Ergebnis und keinen Testweg. Folge: Eine Zusage, auf die sich der Nutzer verlässt,
-  ohne sie überprüfen zu können — und ohne Tests (siehe FB-04) auch ohne automatischen
-  Nachweis.
-- **FB-03 · Der Ausschluss greift nicht bei Fenstern ohne besitzendes Programm.**
-  `CaptureEngine.swift:19` bricht mit `guard let app = window.owningApplication` ab.
-  Folge: Systemüberlagerungen, die WindowServer ohne Programmbezug zeichnet, sind über
-  diese Liste nicht ausschließbar. Für den Zeiger gibt es eine Sonderbehandlung, für alles
-  Übrige nicht.
-- **FB-04 · Keine Tests.** Die Filterlogik ist reine Mengenoperation und damit gut prüfbar;
-  geprüft wird sie nicht. Folge: Die einzige Zugriffsregel der Anwendung hat keinen
-  automatischen Nachweis.
+### Behoben
+
+- **FB-01 · Nur laufende Programme waren auswählbar** — behoben 2026-08-25.
+  `ExcludedAppsManager.add(applicationAt:selected:)` nimmt ein Programmbündel von der
+  Platte auf; die Auswahl ist über *Add App…* erreichbar und öffnet im Programmordner.
+
+### Akzeptiert
+
+Bewusst nicht behoben, mit Begründung und Datum.
+
+- **BF-02 · Der Ausschluss ist nicht nachprüfbar** — akzeptiert 2026-08-25. Eine Anzeige
+  „hier wurde etwas ausgelassen" wäre irreführender als ihr Fehlen: Ein Fenster kann auch
+  deshalb fehlen, weil es nicht offen war oder verdeckt lag. Der Ausschluss wird
+  stattdessen dort abgesichert, wo er wirkt — er wird ScreenCaptureKit als Filter
+  übergeben, sodass der Inhalt im Prozess der Anwendung nie entsteht.
+- **BF-03 · Kein Ausschluss für Fenster ohne besitzendes Programm** — akzeptiert
+  2026-08-25. Die Liste ordnet über Bundle-Kennungen zu; ein Fenster ohne Programm hat
+  keine. Für den einzigen bekannten Fall dieser Art — den Bedienungshilfen-Zeiger — gibt
+  es die gesonderte Erkennung in B01.
+- **BF-04 · Keine Tests für die Filterlogik** — akzeptiert 2026-08-25. Der Filter arbeitet
+  auf `SCWindow`-Instanzen, die sich nicht ohne Bildschirmaufnahme herstellen lassen.
+  Nachweis bleibt manuell, wie im Stack-Profil für UI-Verhalten vorgesehen.
 
 ## Offene Fragen
 
-- **OF-01** · Soll ein Programm auch dann ausschließbar sein, wenn es nicht läuft? —
-  entscheidet der Autor.
-- **OF-02** · Soll die Anwendung sichtbar machen, dass ein Ausschluss gegriffen hat? —
-  entscheidet der Autor.
+Keine offen.
 
-## Decision Log
+| Frage | Entscheidung | Datum |
+|---|---|---|
+| OF-01 · Auch nicht laufende Programme ausschließbar? | ja, über *Add App…* aus dem Programmordner | 2026-08-25 |
+| OF-02 · Sichtbar machen, dass ein Ausschluss griff? | nein, siehe BF-02 | 2026-08-25 |
+
+## Decision Log## Decision Log
 
 | # | Frage | Entscheidung | Begründung |
 |---|---|---|---|
@@ -131,3 +136,4 @@ Kosten, kein fremder Dienst, keine Schlüssel.*
 | 3 | Was passiert bei einer leer geräumten Liste? | sie bleibt leer | ausdrücklich im Code vermerkt: nur ein **fehlender** Schlüssel fällt auf die Standardwerte zurück — sonst käme das Weggenommene bei jedem Start zurück |
 | 4 | Woher kommt die Auswahlliste? | aus den laufenden Programmen | **Grund nicht erkennbar**; naheliegend ist, dass ScreenCaptureKit ohnehin gefragt werden muss (siehe FB-01) |
 | 5 | Wie wird eine nicht laufende Auswahl dargestellt? | eingemischt, Name über `NSWorkspace` | ausdrücklich kommentiert: eine bestehende Auswahl soll nicht unbemerkt aus der Liste fallen |
+| 6 | Wie kommt ein geschlossenes Programm auf die Liste? (3.5.0) | Auswahl aus dem Programmordner | genau der Fall, für den die Liste gedacht ist — ein Passwortmanager ist selten offen, wenn man daran denkt |

--- a/features/B03-anmerkungs-editor/spec.md
+++ b/features/B03-anmerkungs-editor/spec.md
@@ -1,8 +1,9 @@
 # B03 · Anmerkungs-Editor — Spezifikation
 
-Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst, Befunde bearbeitet in 3.5.0**
 
-> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+> Beschrieben ist, **was der Code tut**. Von den fünf markierten Kriterien sind vier
+> behoben, eines liegt außerhalb der Anwendung und ist entschärft.
 >
 > Zensieren (Weichzeichnen, Verpixeln) ist als **B04** gesondert erfasst, das Lineal als
 > **B07**. Hier stehen der Rahmen, die neun übrigen Werkzeuge, Zoom, Auswahl und Ausgabe.
@@ -113,25 +114,22 @@ anheftet. Der Editor ist der Weg jeder Aufnahme nach draußen.
 
 - **AK-25** · Angenommen, Anmerkungen bestehen, wenn `⌘C` gedrückt wird, dann liegt das
   fertig gerenderte Bild in der Zwischenablage und der Editor schließt sich.
-- **AK-26** ⚠ · Angenommen, `⌘S` wird gedrückt, wenn die Aktion ausgeführt wird, dann wird
-  das Bild **auf den Schreibtisch** gesichert — nicht in den eingestellten Verlaufsordner —
-  **und zusätzlich in die Zwischenablage gelegt**.
-  *(`AnnotationEditor.swift:300-306` ruft beides. Der Speicherort ist fest der Schreibtisch
-  (`ClipboardManager.swift:18`) und ignoriert die Einstellung. Zur Klärung vorgelegt.)*
-- **AK-27** ⚠ · Angenommen, `⌘S` oder *Save As* werden benutzt, wenn die Datei entsteht, dann
-  ist sie **immer PNG** — auch wenn in den Einstellungen JPEG gewählt ist.
-  *(`ClipboardManager.swift:33` schreibt ausschließlich PNG. Der Verlauf beachtet die
-  Einstellung, der Editor nicht. Zur Klärung vorgelegt.)*
+- **AK-26** · Angenommen, `⌘S` wird gedrückt, wenn die Aktion ausgeführt wird, dann wird das
+  Bild **in den eingestellten Ordner** gesichert und die Zwischenablage bleibt unberührt.
+  Hat das automatische Sichern die Aufnahme bereits abgelegt, wird **diese Datei ersetzt**,
+  statt eine zweite anzulegen.
+- **AK-27** · Angenommen, `⌘S` wird benutzt, wenn die Datei entsteht, dann trägt sie das in
+  den Einstellungen gewählte Format. *Save As* schreibt weiterhin PNG, weil der Nutzer dort
+  Ort und Namen ohnehin selbst bestimmt.
 - **AK-28** · Angenommen, `⇧⌘S` wird gedrückt, wenn der Dialog erscheint, dann kann Ort und
   Name frei gewählt werden.
 - **AK-29** · Angenommen, keine Anmerkungen bestehen, wenn `Escape` gedrückt wird, dann wird
   das unveränderte Bild in die Zwischenablage gelegt und der Editor schließt sich.
 - **AK-30** · Angenommen, Anmerkungen bestehen und sind ungesichert, wenn `Escape` gedrückt
   wird, dann erscheint die Rückfrage „Discard Changes?".
-- **AK-31** ⚠ · Angenommen, zwei Bilder werden innerhalb derselben Sekunde mit `⌘S`
-  gesichert, wenn beide geschrieben werden, dann **überschreibt das zweite das erste**.
-  *(`ClipboardManager.swift:14` bildet den Namen mit Sekundengenauigkeit — dieselbe
-  Fehlerklasse wie B09/AK-07. Zur Klärung vorgelegt.)*
+- **AK-31** · Angenommen, zwei Bilder werden innerhalb derselben Sekunde mit `⌘S`
+  gesichert, wenn beide geschrieben werden, dann entstehen **zwei Dateien** — der Name trägt
+  Millisekunden und weicht bei Gleichstand über eine Zählnummer aus.
 
 ### Datenschutz und Missbrauchsschutz
 
@@ -140,16 +138,14 @@ Stufe A, Abschnitt 1 ausdrücklich in Kraft.
 - **AK-32** · Angenommen, ein Bild wird ausgegeben, wenn gerendert wird, dann enthält das
   Ergebnis alle Anmerkungen flach eingerechnet — keine Ebenen, keine wiederherstellbaren
   Originalbereiche.
-- **AK-33** ⚠ · Angenommen, ein Bild wird in die Zwischenablage gelegt, wenn die
-  geräteübergreifende Zwischenablage aktiv ist, dann überträgt das System **den gesamten
-  Screenshot** an die anderen Geräte des Nutzers.
-  *(`ClipboardManager.swift:8`, ohne Vertraulichkeitsmarkierung. Gewichtiger als bei B05,
-  weil es um das vollständige Bild geht. Zur Klärung vorgelegt.)*
-- **AK-34** ⚠ · Angenommen, das Sichern schlägt fehl, wenn der Fehler auftritt, dann erfährt
-  der Nutzer nichts — der Editor schließt sich trotzdem.
-  *(`ClipboardManager.swift:32` und `:40` schreiben in ein `print()`; `save()` ruft
-  anschließend `close()` unabhängig vom Ergebnis. Zur Klärung vorgelegt — dies bedeutet
-  stillen Datenverlust.)*
+- **AK-33** · Angenommen, ein Bild wird in die Zwischenablage gelegt, wenn die
+  geräteübergreifende Zwischenablage aktiv ist, dann überträgt **das System** den Screenshot
+  an die anderen Geräte des Nutzers. Für Bilder kennt macOS keine
+  Vertraulichkeitskennzeichnung, mit der sich das unterbinden ließe — anders als für Text
+  (B05/AK-17). Bewusst so belassen, Begründung unter *Befunde*, BF-07; im PRD als
+  Einschränkung der Datenschutzzusage ausgewiesen.
+- **AK-34** · Angenommen, das Sichern schlägt fehl, wenn der Fehler auftritt, dann erscheint
+  eine Kurzmeldung und **der Editor bleibt offen**, damit die Arbeit nicht verloren geht.
 - **AK-35** · Angenommen, Anmerkungen bestehen, wenn der Editor geschlossen wird, dann
   werden sie nirgends gespeichert.
 
@@ -165,41 +161,45 @@ Stufe A, Abschnitt 1 ausdrücklich in Kraft.
 - **EC-06** · Anheften bei erreichter Obergrenze → der Editor schließt sich, kein Fenster
   erscheint (B08/AK-11).
 
-## Fehlbestand
+## Befunde
 
-- **FB-01 · Kein bearbeitbarer Projektstand.** Anmerkungen leben ausschließlich im
-  Arbeitsspeicher (`AnnotationStore`). Folge: Ein geschlossener Editor verliert alles; ein
-  exportiertes PNG ist nicht wieder bearbeitbar. *Open in Editor* aus dem Verlauf öffnet
-  das Originalbild ohne die früheren Anmerkungen.
-- **FB-02 · `⌘S` sichert an einen festen Ort und im festen Format.** Fundstellen:
-  `ClipboardManager.swift:18` (Schreibtisch), `:33` (immer PNG). Folge: Die Einstellungen
-  zu Ordner und Format gelten nur für das automatische Sichern; der Nutzer hat zwei Orte
-  mit unterschiedlichem Verhalten.
-- **FB-03 · `⌘S` kopiert zusätzlich in die Zwischenablage.** Fundstelle:
-  `AnnotationEditor.swift:304`. Folge: Ein Sichern überschreibt unerwartet den
-  Zwischenablageinhalt.
-- **FB-04 · Fehlgeschlagenes Sichern bleibt unbemerkt und schließt trotzdem.** Fundstellen:
-  `ClipboardManager.swift:32`, `:40`, `AnnotationEditor.swift:306`. Folge: stiller
-  Datenverlust — die schwerste Ausprägung des projektweiten Befunds FB-AS-03.
-- **FB-05 · Namenskollision beim Sichern auf den Schreibtisch.** Fundstelle:
-  `ClipboardManager.swift:14`. Wie B09/FB-02.
-- **FB-06 · `AnnotationSnapshot.data` ist untypisiert.** Fundstelle:
-  `AnnotationModels.swift:104`. Folge: Fehler im Rückgängig-Pfad fallen erst zur Laufzeit
-  auf, und nur wenn genau dieser Pfad läuft.
-- **FB-07 · Die Zwischenablage ist nicht als vertraulich markiert.** Fundstelle:
-  `ClipboardManager.swift:6-9`. Folge: siehe AK-33.
-- **FB-08 · Keine Tests.** Die Koordinatenumrechnung zwischen Ansicht und Bildpixeln
-  (`viewToImage`, `imageToView`) ist reine Rechnung und ideal prüfbar — sie trägt AK-23,
-  von dem jede Anmerkung abhängt.
+### Behoben
+
+- **FB-02 · `⌘S` sicherte an einen festen Ort und im festen Format** — behoben 2026-08-25.
+  Es folgt den Einstellungen und ersetzt die automatisch gesicherte Datei.
+- **FB-03 · `⌘S` kopierte zusätzlich in die Zwischenablage** — behoben 2026-08-25.
+- **FB-04 · Fehlgeschlagenes Sichern blieb unbemerkt und schloss trotzdem** — behoben
+  2026-08-25. `CaptureLog` meldet, und der Editor bleibt offen.
+- **FB-05 · Namenskollision beim Sichern** — behoben 2026-08-25 über
+  `AppPreferences.uniqueCaptureURL(in:)`.
+- **FB-08 · Keine Tests** — teilweise behoben 2026-08-25: Die Umrechnung zwischen Ansicht
+  und Bildpixeln bleibt an `NSView` gebunden und damit manuell zu prüfen, die Zensurstärke
+  und die Namensbildung sind abgedeckt.
+
+### Akzeptiert
+
+- **BF-01 · Kein bearbeitbarer Projektstand** — akzeptiert 2026-08-25. Der Editor ist ein
+  Durchgangsschritt zwischen Aufnahme und Ergebnis; ein eigenes Dateiformat wäre ein
+  Produkt für sich und gehört als neues Feature durch die volle Kette.
+- **BF-06 · `AnnotationSnapshot.data` ist untypisiert** — akzeptiert 2026-08-25. Eine
+  typisierte Momentaufnahme je Annotationsart wäre neun zusätzliche Typen für einen Pfad,
+  der ausschließlich innerhalb einer Annotation gelesen und geschrieben wird.
+- **BF-07 · Die Zwischenablage trägt keine Vertraulichkeitskennzeichnung für Bilder** —
+  akzeptiert 2026-08-25. Für Text gibt es die Kennzeichnung und sie wird gesetzt (B05); für
+  Bilder kennt macOS keine, und die geräteübergreifende Zwischenablage lässt sich von einer
+  Anwendung nicht abwählen. Im PRD als Einschränkung der Datenschutzzusage ausgewiesen.
 
 ## Offene Fragen
 
-- **OF-01** · Soll `⌘S` in den eingestellten Ordner sichern und das eingestellte Format
-  benutzen? — entscheidet der Autor.
-- **OF-02** · Soll `⌘S` weiterhin zusätzlich kopieren? — entscheidet der Autor.
-- **OF-03** · Soll es einen bearbeitbaren Projektstand geben? — entscheidet der Autor.
+Keine offen.
 
-## Decision Log
+| Frage | Entscheidung | Datum |
+|---|---|---|
+| OF-01 · `⌘S` in den eingestellten Ordner? | ja, mit dem eingestellten Format — und es ersetzt die automatisch gesicherte Datei | 2026-08-25 |
+| OF-02 · `⌘S` weiterhin zusätzlich kopieren? | nein — Sichern und Kopieren sind zwei Absichten, und die stille Übernahme der Zwischenablage war überraschend | 2026-08-25 |
+| OF-03 · Bearbeitbarer Projektstand? | nein, siehe BF-01 | 2026-08-25 |
+
+## Decision Log## Decision Log
 
 | # | Frage | Entscheidung | Begründung |
 |---|---|---|---|
@@ -209,4 +209,5 @@ Stufe A, Abschnitt 1 ausdrücklich in Kraft.
 | 4 | Werkzeugleiste in SwiftUI, Zeichenfläche in AppKit | alles in einem | Zeichnen mit Mausereignissen ist in AppKit direkter; die Leisten sind eingebettete SwiftUI-Ansichten |
 | 5 | Wie wird die Leertaste erkannt? | eigener Ereignisbeobachter | ausdrücklich kommentiert: `flagsChanged` meldet die Leertaste nicht |
 | 6 | Warum schließt der Editor nach Kopieren und Sichern? | Aufnahme ist ein Durchgangsvorgang | erkennbar bewusst — der Editor ist kein Arbeitsplatz, sondern ein Zwischenschritt |
-| 7 | `⌘S` auf den Schreibtisch statt in den Verlaufsordner | in den eingestellten Ordner | **Grund nicht erkennbar** (FB-02) |
+| 7 | `⌘S` in den eingestellten Ordner (3.5.0) | auf den Schreibtisch | zwei Speicherorte mit verschiedenen Regeln waren nicht erklärbar; die Einstellung gab es bereits |
+| 8 | Fehlschlag hält den Editor offen (3.5.0) | trotzdem schließen | ein geschlossener Editor ohne Datei bedeutet Datenverlust ohne Rettungsweg |

--- a/features/B04-bereiche-zensieren/spec.md
+++ b/features/B04-bereiche-zensieren/spec.md
@@ -1,9 +1,9 @@
 # B04 · Bereiche zensieren — Spezifikation
 
-Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst, Befunde behoben in 3.5.0**
 
-> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ beschreiben Verhalten, das
-> fragwürdig aussieht, und stehen zur Klärung.
+> Beschrieben ist, **was der Code tut**. Alle drei ⚠-Kriterien der ersten Fassung sind in
+> 3.5.0 behoben — darunter der schwerste Befund der ganzen Erfassung (AK-12).
 >
 > **Dieses Feature ist eine Datenschutzzusage, kein Zeichenwerkzeug.** Wer einen Bereich
 > verpixelt, verlässt sich darauf, dass der Inhalt danach weg ist. Jede Abweichung davon
@@ -64,20 +64,16 @@ Verpixeln.
 
 ### Wirksamkeit der Zensur
 
-- **AK-09** ⚠ · Angenommen, ein Bereich wird zensiert, wenn er gerendert wird, dann ist die
-  Stärke **fest**: Weichzeichnen mit Radius 15, Verpixeln mit Blockgröße 10 — jeweils in
-  **Bildpixeln**, nicht in Bildschirmpunkten.
-  *(`AnnotationModels.swift:872` und `:956`. Bei einer Retina-Aufnahme entspricht
-  Blockgröße 10 nur 5 Bildschirmpunkten — die Zensur ist dort also feiner als auf einem
-  nicht skalierten Bildschirm. Es gibt keine Einstellung. Zur Klärung vorgelegt: Reicht
-  das, um kleine Schrift unlesbar zu machen?)*
-- **AK-10** ⚠ · Angenommen, ein Bereich wird weichgezeichnet, wenn er gerendert wird, dann
-  ist die Unschärfe **an den Rändern des Bereichs schwächer als in der Mitte**.
-  *(`AnnotationModels.swift:895` wendet `CIGaussianBlur` auf den zugeschnittenen Ausschnitt
-  an, ohne die Kanten vorher fortzusetzen (`clampedToExtent`). Der Filter mischt am Rand
-  mit dem transparenten Außenraum, wodurch dort weniger Originalinformation zerstört wird.
-  Zur Klärung vorgelegt: Ist Text am Rand eines weichgezeichneten Bereichs noch lesbar
-  oder rekonstruierbar?)*
+- **AK-09** · Angenommen, ein Bereich wird zensiert, wenn er gerendert wird, dann richtet
+  sich die Stärke nach der **kürzeren Seite des Bereichs**: Weichzeichnen mit einem Viertel
+  davon (mindestens 15), Verpixeln mit etwa einem Achtel (mindestens 10). Eine größere
+  Aufnahme wird damit ebenso wirksam zensiert wie eine kleine.
+- **AK-10** · Angenommen, ein Bereich wird weichgezeichnet, wenn er gerendert wird, dann ist
+  die Unschärfe **am Rand so stark wie in der Mitte**: Die Kanten werden vor dem Filtern
+  fortgesetzt, sodass nicht mit dem transparenten Außenraum gemischt wird.
+- **AK-14** · Angenommen, ein zensierter Bereich wird nachträglich vergrößert, wenn er
+  gerendert wird, dann wächst die Zensurstärke mit — eine aufgezogene Zensur bleibt nicht
+  auf der Stärke ihrer ursprünglichen Größe stehen.
 
 ### Datenschutz und Missbrauchsschutz
 
@@ -88,13 +84,13 @@ eine inhaltliche Zusage über seine Daten macht.
 - **AK-11** · Angenommen, ein Bereich ist zensiert, wenn das Ergebnis exportiert wird, dann
   enthält die Ausgabedatei die Originalpixel des Bereichs **nicht mehr** — auch nicht in
   Metadaten, Ebenen oder Vorschaubildern.
-- **AK-12** ⚠ · Angenommen, der Nutzer zensiert einen Bereich und exportiert das Bild, wenn
-  danach der Verlaufsordner geöffnet wird, dann liegt dort **die unzensierte
-  Originalaufnahme**.
-  *(`CaptureEngine.swift:427` ruft `historyManager.autoSave(image)` mit dem Originalbild,
-  **bevor** der Editor überhaupt öffnet. Kein Pfad ersetzt oder löscht diese Datei später.
-  Das exportierte Bild ist zensiert, die automatisch gesicherte Datei nicht. Zur Klärung
-  vorgelegt — dies ist der schwerwiegendste Einzelbefund der gesamten Erfassung.)*
+- **AK-12** · Angenommen, der Nutzer zensiert einen Bereich und exportiert das Bild, wenn
+  danach der Verlaufsordner geöffnet wird, dann liegt dort **die zensierte Fassung** — die
+  automatisch gesicherte Originaldatei wird beim Export ersetzt.
+- **AK-15** · Angenommen, der Nutzer zensiert einen Bereich und schließt den Editor **ohne**
+  zu exportieren, wenn danach der Verlaufsordner geöffnet wird, dann liegt auch dort die
+  zensierte Fassung. Eine Zensur wird beim Schließen immer angewandt, weil sie eine Zusage
+  über den Inhalt ist und nicht eine Gestaltungsentscheidung.
 - **AK-13** · Angenommen, ein Bereich ist zensiert, wenn das Bild in die Zwischenablage
   kopiert wird, dann enthält die Zwischenablage nur das gerenderte, zensierte Bild.
 
@@ -109,40 +105,39 @@ eine inhaltliche Zusage über seine Daten macht.
 - **EC-05** · Zensur und danach `⌘Z`, `⇧⌘Z`, dann Export → das Wiederherstellen muss die
   Zensur wieder wirksam machen.
 
-## Fehlbestand
+## Behobene Befunde
 
-- **FB-01 · Die unzensierte Originalaufnahme bleibt dauerhaft auf der Festplatte.**
-  Fundstelle: `CaptureEngine.swift:427` (`postCapture` sichert vor dem Öffnen des Editors),
-  `AppPreferences.swift:168` (`saveImage`). Folge: **Die Zensur schützt das Weitergegebene,
-  nicht das Gespeicherte.** Wer ein Passwort verpixelt und den Screenshot verschickt, hat
-  das unverpixelte Bild weiterhin in `~/Pictures/MikaScreenSnap/` liegen — sichtbar für
-  jeden mit Zugriff auf den Rechner, in jedem Backup, in jeder Cloud-Synchronisation dieses
-  Ordners. Der Nutzer wird darauf an keiner Stelle hingewiesen.
-- **FB-02 · Weichzeichnen ohne Kantenfortsetzung.** Fundstelle:
-  `AnnotationModels.swift:891-899`. Folge: Am Rand des Bereichs ist die Unschärfe
-  schwächer; ein Wort, das genau an der Kante liegt, kann teilweise lesbar bleiben. Der
-  übliche Weg — die Kanten vor dem Filtern fortzusetzen — wird nicht gegangen.
-- **FB-03 · Die Zensurstärke ist nicht einstellbar und nicht auflösungsbezogen.**
-  Fundstelle: `AnnotationModels.swift:872`, `:956`. Folge: Bei hoher Auflösung ist die
-  Zensur relativ schwächer, ohne dass der Nutzer gegensteuern kann.
-- **FB-04 · Keine Warnung vor unwirksamer Zensur.** Es gibt keine Prüfung, ob der zensierte
-  Bereich noch Kontrastkanten enthält, und keinen Hinweis auf FB-01. Folge: Der Nutzer hat
-  keinen Anlass zu misstrauen.
-- **FB-05 · Keine Tests.** Die Wirksamkeit einer Zensur ist maschinell prüfbar — etwa indem
-  Text ins Bild gerendert, zensiert und anschließend die Texterkennung darauf angesetzt
-  wird. Die Anwendung hat die Texterkennung bereits an Bord (B05). Geprüft wird nichts.
+Alle fünf Einträge sind in 3.5.0 behoben.
+
+- **FB-01 · Die unzensierte Originalaufnahme blieb auf der Festplatte** — behoben
+  2026-08-25. Der Editor merkt sich die von `autoSave` geschriebene Datei
+  (`AnnotationEditorWindowController.autoSavedURL`) und ersetzt sie bei jedem Export sowie
+  beim Schließen, sobald eine Zensur vorliegt. **Dies war der schwerste Befund der
+  Erfassung.**
+- **FB-02 · Weichzeichnen ohne Kantenfortsetzung** — behoben 2026-08-25. Der Ausschnitt
+  wird vor dem Filtern fortgesetzt (`clampedToExtent()`), danach auf die ursprüngliche
+  Ausdehnung zurückgeschnitten.
+- **FB-03 · Zensurstärke nicht auflösungsbezogen** — behoben 2026-08-25.
+  `BlurAnnotation.radius(for:)` und `PixelateAnnotation.blockSize(for:)` leiten die Stärke
+  aus der kürzeren Seite des Bereichs ab und ziehen beim Skalieren nach. Sechs Tests in
+  `Tests/RedactionStrengthTests.swift`.
+- **FB-04 · Keine Warnung vor unwirksamer Zensur** — gegenstandslos seit FB-01 und FB-03:
+  Das Original bleibt nicht mehr liegen, und die Stärke passt sich an. Eine Prüfung auf
+  Restkontrast wäre eine Scheinsicherheit.
+- **FB-05 · Keine Tests** — behoben 2026-08-25. Die Stärkeberechnung ist abgedeckt; die
+  Wirksamkeit selbst bleibt in der QA über die Texterkennung nachzuweisen.
 
 ## Offene Fragen
 
-- **OF-01** · Soll das automatische Sichern erst **nach** dem Schließen des Editors
-  geschehen, oder soll die Originaldatei beim Export ersetzt werden? — entscheidet der
-  Autor. Betrifft B09 unmittelbar.
-- **OF-02** · Soll die Zensurstärke einstellbar sein? — entscheidet der Autor.
-- **OF-03** · Ist Weichzeichnen als Zensurverfahren überhaupt zulässig, oder sollte nur
-  Verpixeln angeboten werden? — entscheidet der Autor. Weichzeichnen gilt allgemein als
-  das schwächere Verfahren.
+Keine offen.
 
-## Decision Log
+| Frage | Entscheidung | Datum |
+|---|---|---|
+| OF-01 · Wann wird automatisch gesichert? | weiterhin sofort — als Sicherheitsnetz gegen einen Absturz. Die Datei wird jedoch beim Export und bei jeder Zensur ersetzt, womit der Grund für die ursprüngliche Frage entfällt | 2026-08-25 |
+| OF-02 · Zensurstärke einstellbar? | nein — sie richtet sich nach der Bereichsgröße. Eine Einstellung würde nahelegen, dass eine schwächere Stufe vertretbar ist | 2026-08-25 |
+| OF-03 · Weichzeichnen als Verfahren zulassen? | ja, mit Kantenfortsetzung und größenbezogener Stärke. Verpixeln bleibt die Alternative; die Wahl trifft der Nutzer nach dem Bild, nicht nach der Sicherheit | 2026-08-25 |
+
+## Decision Log## Decision Log
 
 | # | Frage | Entscheidung | Begründung |
 |---|---|---|---|
@@ -150,4 +145,5 @@ eine inhaltliche Zusage über seine Daten macht.
 | 2 | Woher kommt der Inhalt des zensierten Bereichs? | aus dem Originalbild, bei jedem Zeichnen neu | erlaubt Verschieben und Skalieren ohne Qualitätsverlust — hat aber zur Folge, dass sich überlappende Zensuren nicht verstärken (EC-03) |
 | 3 | Welche Filter? | `CIGaussianBlur` und `CIPixellate` | Systemfilter, keine eigene Implementierung |
 | 4 | Feste Stärke | Radius 15 · Blockgröße 10 | **Grund nicht erkennbar** — keine Herleitung im Code, keine Einstellung |
-| 5 | Warum kein `clampedToExtent` vor dem Weichzeichnen? | — | **Grund nicht erkennbar**; erkennbar ist nur, dass auf die Originalausdehnung zurückgeschnitten wird (siehe FB-02) |
+| 5 | Kantenfortsetzung vor dem Weichzeichnen (3.5.0) | `clampedToExtent()` | ohne sie mischt der Filter den Rand mit dem transparenten Außenraum — genau dort, wo ein zensiertes Wort enden kann |
+| 6 | Stärke aus der Bereichsgröße (3.5.0) | kürzere Seite als Bezug | die kürzere Seite entspricht der Texthöhe; die längere sagt nichts darüber, wie fein der Inhalt ist |

--- a/features/B05-bildschirmtext-erfassen/spec.md
+++ b/features/B05-bildschirmtext-erfassen/spec.md
@@ -1,8 +1,8 @@
 # B05 · Bildschirmtext erfassen (OCR) — Spezifikation
 
-Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst, Befunde bearbeitet in 3.5.0**
 
-> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+> Beschrieben ist, **was der Code tut**. Alle drei markierten Kriterien sind bearbeitet.
 
 ## Zweck
 
@@ -50,11 +50,8 @@ Abtippen, ohne fremden Dienst.
   gedrückt wurde.
 - **AK-04** · Angenommen, der Auslöseton ist aktiviert, wenn Text erkannt wurde, dann
   erklingt „Tink".
-- **AK-05** ⚠ · Angenommen, im gewählten Bereich ist **kein** Text zu erkennen, wenn die
-  Erkennung fertig ist, dann geschieht **nichts**: kein Fenster, kein Ton, keine Meldung.
-  *(`CaptureEngine.swift:358` führt alles innerhalb von `if !recognizedText.isEmpty` aus.
-  Der Nutzer kann nicht unterscheiden, ob die Erkennung nichts fand oder die Funktion nicht
-  ausgelöst hat. Zur Klärung vorgelegt.)*
+- **AK-05** · Angenommen, im gewählten Bereich ist **kein** Text zu erkennen, wenn die
+  Erkennung fertig ist, dann erscheint die Kurzmeldung „No text found in selection".
 
 ### Weg 2 — im Editor
 
@@ -62,10 +59,9 @@ Abtippen, ohne fremden Dienst.
   gewählt wird, dann wechselt der Editor in einen Auswahlmodus mit sichtbarer Rückmeldung.
 - **AK-07** · Angenommen, der Auswahlmodus ist aktiv, wenn ein Bereich gezogen wird, dann
   erscheint dasselbe Ergebnisfenster wie bei Weg 1.
-- **AK-08** ⚠ · Angenommen, Text wird im Editor erkannt, wenn das Fenster erscheint, dann
-  liegt der Text **nicht** in der Zwischenablage — anders als bei Weg 1.
-  *(`AnnotationEditor.swift:262` öffnet nur das Ergebnisfenster. Zwei Wege desselben
-  Features verhalten sich unterschiedlich. Zur Klärung vorgelegt.)*
+- **AK-08** · Angenommen, Text wird im Editor erkannt, wenn das Fenster erscheint, dann
+  liegt der Text **ebenso in der Zwischenablage** wie bei Weg 1 — beide Wege verhalten sich
+  gleich.
 
 ### Erkennung
 
@@ -93,14 +89,11 @@ erfassen, die zufällig im gewählten Rahmen liegen.
   darüber gezogen wird, dann ist dessen Inhalt nicht Teil des erkannten Textes.
 - **AK-16** · Angenommen, Text wird erkannt, wenn der Vorgang abgeschlossen ist, dann steht
   weder der Text noch ein Teil davon in einem Protokoll.
-- **AK-17** ⚠ · Angenommen, erkannter Text wird in die Zwischenablage gelegt, wenn auf dem
-  Rechner die geräteübergreifende Zwischenablage aktiv ist, dann **überträgt macOS diesen
-  Text an die anderen Apple-Geräte des Nutzers**.
-  *(`CaptureEngine.swift:362` und `OCRResultPanel.swift:89` schreiben in die allgemeine
-  Zwischenablage ohne die Markierung, mit der Passwortverwaltungen eine Übernahme
-  unterbinden. Die Anwendung selbst überträgt nichts — der Systemdienst tut es. Das
-  schränkt die Zusage aus `docs/prd.md` ein, wonach kein Byte den Rechner verlässt. Zur
-  Klärung vorgelegt.)*
+- **AK-17** · Angenommen, erkannter Text wird in die Zwischenablage gelegt, wenn das
+  geschieht, dann trägt der Eintrag zusätzlich die Kennzeichnung
+  `org.nspasteboard.ConcealedType`, an der Zwischenablage-Verwaltungen und Verlaufswerkzeuge
+  erkennen, dass sie ihn nicht aufbewahren sollen — dieselbe Kennzeichnung, die
+  Passwortverwaltungen setzen.
 - **AK-18** · Angenommen, die Erkennung schlägt fehl, wenn der Fehler auftritt, dann
   erscheint bei Weg 1 eine Kurzmeldung.
 
@@ -119,39 +112,41 @@ Abschnitt 6 (Geheimnisse): trifft nicht zu.*
 - **EC-05** · Editor-Weg schlägt fehl → nur ein `print()`, der Nutzer sieht nichts.
 - **EC-06** · Mehrere Ergebnisfenster nacheinander → jedes hat seinen eigenen Zeitgeber.
 
-## Fehlbestand
+## Befunde
 
-- **FB-01 · Leeres Ergebnis bleibt stumm.** Fundstelle: `CaptureEngine.swift:358`,
-  `AnnotationEditor.swift:261`. Folge: Der häufigste Fall — der Nutzer trifft den Text
-  knapp nicht — sieht aus wie ein Programmfehler.
-- **FB-02 · Die beiden Wege verhalten sich unterschiedlich.** Fundstelle: Weg 1 kopiert
-  automatisch (`CaptureEngine.swift:362`), Weg 2 nicht (`AnnotationEditor.swift:262`).
-  Folge: Der Nutzer kann sich nicht darauf verlassen, dass der Text in der Zwischenablage
-  liegt.
-- **FB-03 · Der Erkennungs-Gütewert wird verworfen.** Fundstelle: `OCREngine.swift:26`
-  nimmt nur `topCandidates(1).first?.string` und ignoriert die mitgelieferte Bewertung.
-  Folge: Unsichere Erkennung ist von sicherer nicht unterscheidbar.
-- **FB-04 · Die Sprachen sind fest verdrahtet.** Fundstelle: `OCREngine.swift:32`. Folge:
-  Wer regelmäßig andere Sprachen liest, kann nichts daran ändern; die Einstellungen bieten
-  dafür nichts an.
-- **FB-05 · Fehler im Editor-Weg erreichen niemanden.** Fundstelle:
-  `AnnotationEditor.swift:267` — ein `print()`. Teil des projektweiten Befunds FB-AS-03.
-- **FB-06 · Die Zwischenablage ist nicht als vertraulich markiert.** Fundstellen:
-  `CaptureEngine.swift:362`, `OCRResultPanel.swift:89` und `:98`. Folge: siehe AK-17. Der
-  übliche Weg, dies zu unterbinden, ist ein zusätzlicher Eintrag im Zwischenablage-Element,
-  den Passwortverwaltungen verwenden; er fehlt.
-- **FB-07 · Keine Tests.** Die Erkennung ist mit einem bekannten Bild und erwartetem Text
-  gut prüfbar — und wäre zugleich der Nachweis für die Wirksamkeit der Zensur in B04.
+### Behoben
+
+- **FB-01 · Leeres Ergebnis blieb stumm** — behoben 2026-08-25 in beiden Wegen.
+- **FB-02 · Die beiden Wege verhielten sich unterschiedlich** — behoben 2026-08-25: Der
+  Editor-Weg kopiert ebenfalls.
+- **FB-05 · Fehler im Editor-Weg erreichten niemanden** — behoben 2026-08-25 über
+  `CaptureLog`.
+- **FB-06 · Die Zwischenablage war nicht als vertraulich markiert** — behoben 2026-08-25
+  über `ClipboardManager.copyToClipboard(text:concealed:)`.
+
+### Akzeptiert
+
+- **BF-03 · Der Erkennungs-Gütewert wird verworfen** — akzeptiert 2026-08-25. Der Nutzer
+  sieht den erkannten Text im Ergebnisfenster und beurteilt ihn selbst; ein Zahlenwert
+  daneben würde eine Genauigkeit suggerieren, die er nicht hat.
+- **BF-04 · Die Sprachen sind fest verdrahtet** — akzeptiert 2026-08-25. Deutsch, Englisch
+  und Französisch decken den Bedarf des Autors; eine Spracheinstellung wäre ein Feature mit
+  eigener Nummer.
+- **BF-07 · Keine Tests** — akzeptiert 2026-08-25. Die Erkennung selbst ist Apples Vision,
+  und ein Test darüber prüfte deren Güte, nicht diesen Code. Als Messwerkzeug für die
+  Wirksamkeit der Zensur (B04) bleibt sie in der QA vorgesehen.
 
 ## Offene Fragen
 
-- **OF-01** · Soll ein leeres Erkennungsergebnis gemeldet werden? — entscheidet der Autor.
-- **OF-02** · Soll der Editor-Weg ebenfalls automatisch kopieren? — entscheidet der Autor.
-- **OF-03** · Soll die Zwischenablage als vertraulich markiert werden, um die
-  geräteübergreifende Übernahme zu unterbinden? — entscheidet der Autor. Betrifft auch B03
-  (Bild) und B06 (Farbwert) und berührt eine Zusage im PRD.
+Keine offen.
 
-## Decision Log
+| Frage | Entscheidung | Datum |
+|---|---|---|
+| OF-01 · Leeres Ergebnis melden? | ja, als Kurzmeldung in beiden Wegen | 2026-08-25 |
+| OF-02 · Editor-Weg ebenfalls kopieren? | ja — zwei Wege desselben Features dürfen sich nicht unterschiedlich verhalten | 2026-08-25 |
+| OF-03 · Zwischenablage als vertraulich kennzeichnen? | ja für Text. Für Bilder gibt es keine entsprechende Kennzeichnung (B03/BF-07); das PRD weist die Einschränkung aus | 2026-08-25 |
+
+## Decision Log## Decision Log
 
 | # | Frage | Entscheidung | Begründung |
 |---|---|---|---|
@@ -161,4 +156,5 @@ Abschnitt 6 (Geheimnisse): trifft nicht zu.*
 | 4 | Drei Sprachen | Systemsprache übernehmen | **Grund nicht erkennbar** (FB-04) |
 | 5 | Zwei Einstiegswege | nur einer | vom Bildschirm für Fremdinhalte, aus dem Editor für bereits Aufgenommenes |
 | 6 | Selbstschließendes Ergebnisfenster nach 10 s | dauerhaft offen | es ist ein Zwischenergebnis, kein Dokument — Zeitgeber pausiert bei Mauskontakt |
-| 7 | Automatisches Kopieren bei Weg 1 | erst auf Knopfdruck | erspart den zweiten Handgriff; die Abweichung in Weg 2 ist vermutlich unbeabsichtigt (FB-02) |
+| 7 | Automatisches Kopieren in beiden Wegen (3.5.0) | erst auf Knopfdruck | erspart den zweiten Handgriff — und die frühere Abweichung zwischen den Wegen war für niemanden vorhersehbar |
+| 8 | Zwischenablage als vertraulich gekennzeichnet (3.5.0) | ohne Kennzeichnung | erkannter Text kann ein Passwort sein, das zufällig im Rahmen lag |

--- a/features/B06-farbpipette/spec.md
+++ b/features/B06-farbpipette/spec.md
@@ -1,8 +1,9 @@
 # B06 · Farbpipette — Spezifikation
 
-Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst, Befunde bearbeitet in 3.5.0**
 
-> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+> Beschrieben ist, **was der Code tut**. Von den vier markierten Kriterien sind drei
+> behoben, eines ist eine bewusste Entscheidung.
 
 ## Zweck
 
@@ -57,21 +58,12 @@ Lupe zeigt vergrößert, welches Pixel getroffen wird.
 - **AK-08** · Angenommen, mehrere Displays sind angeschlossen, wenn die Pipette über eines
   davon geführt wird, dann zeigt sie die Farbe des Pixels unter dem Zeiger — auf jedem
   Display, unabhängig von der Skalierung.
-- **AK-09** ⚠ · Angenommen, die Pipette ist aktiv, wenn sich der Bildschirminhalt ändert —
-  ein Video läuft, eine Animation spielt —, dann zeigt die Lupe **weiterhin den Stand vom
-  Start der Pipette**.
-  *(`ColorPickerEngine.swift:81` nimmt beim Start je Display **einen** Schnappschuss auf und
-  liest danach nur noch daraus. Der Dateikommentar begründet das mit der Notwendigkeit,
-  synchron zu bleiben. Zur Klärung vorgelegt: Der Nutzer greift damit eine Farbe ab, die so
-  gerade nicht mehr auf dem Bildschirm steht.)*
-- **AK-10** ⚠ · Angenommen, mit gedrückter Umschalttaste wird geklickt, wenn die Aktion
-  ausgeführt ist, dann wird die Farbe zusätzlich in eine Palette aufgenommen — **die
-  nirgends angezeigt wird**. Kurzmeldung und Verhalten sind von einem gewöhnlichen Klick
-  nicht unterscheidbar.
-  *(`ColorLoupePanel.swift:137` ruft `addToPalette`; `ColorHistoryManager.palette` wird
-  gespeichert, aber von keiner Oberfläche gelesen — das Menü zeigt ausschließlich den
-  Verlauf. Der Toast lautet in beiden Fällen „Copied …". Die Funktion ist im README
-  beschrieben. Zur Klärung vorgelegt.)*
+- **AK-09** · Angenommen, die Pipette ist aktiv, wenn sich der Bildschirminhalt ändert — ein
+  Video läuft, eine Animation spielt —, dann zeigt die Lupe **weiterhin den Stand vom Start
+  der Pipette**. Das ist eine bewusste Entscheidung, Begründung unter *Befunde*, BF-02.
+- **AK-10** · Angenommen, mit gedrückter Umschalttaste wird geklickt, wenn die Aktion
+  ausgeführt ist, dann wird die Farbe zusätzlich in eine Palette aufgenommen, die im
+  Menüleistenmenü unter *Colour Palette* steht und dort auch geleert werden kann.
 
 ### Datenschutz und Missbrauchsschutz
 
@@ -87,14 +79,16 @@ dieses Feature den gesamten Inhalt aller Bildschirme auf** und hält ihn im Spei
   dann sind die Bildschirmaufnahmen aus dem Speicher entfernt.
 - **AK-14** · Angenommen, eine Farbe wird abgegriffen, wenn der Vorgang läuft, dann enthält
   kein Protokoll Bildinhalte.
-- **AK-15** ⚠ · Angenommen, *Reset All Preferences* wird ausgeführt, wenn die Anwendung
-  danach startet, dann sind Farbverlauf und Palette **weiterhin vorhanden**.
-  *(`AppPreferences.swift:135` führt eine von Hand gepflegte Schlüsselliste; die Schlüssel
-  des Farbverlaufs stehen nicht darin. Zur Klärung vorgelegt.)*
-- **AK-16** ⚠ · Angenommen, ein Hex-Wert wird in die Zwischenablage gelegt, wenn die
+- **AK-15** · Angenommen, *Reset All Preferences* wird ausgeführt, wenn die Anwendung danach
+  startet, dann sind Farbverlauf und Palette **geleert** — beide Schlüssel stehen in der
+  Rücksetzliste.
+- **AK-16** · Angenommen, ein Hex-Wert wird in die Zwischenablage gelegt, wenn die
   geräteübergreifende Zwischenablage aktiv ist, dann überträgt das System ihn an andere
-  Geräte des Nutzers. *(Wie B05/AK-17; hier von geringer Tragweite, weil ein Farbwert kein
-  Geheimnis ist — der Vollständigkeit halber aufgenommen.)*
+  Geräte des Nutzers. Anders als bei erkanntem Text (B05) wird hier **keine**
+  Vertraulichkeitskennzeichnung gesetzt: Ein Farbwert ist kein Geheimnis, und die
+  Kennzeichnung würde Zwischenablage-Verwaltungen daran hindern, ihn aufzubewahren.
+- **AK-17** · Angenommen, Farben stehen im Verlauf, wenn im Untermenü *Clear History*
+  gewählt wird, dann ist der Verlauf leer; dasselbe gilt für *Clear Palette*.
 
 *Abschnitt 4 (Rate Limits): trifft nicht zu. Abschnitt 6 (Geheimnisse): trifft nicht zu.*
 
@@ -109,42 +103,50 @@ dieses Feature den gesamten Inhalt aller Bildschirme auf** und hält ihn im Spei
 - **EC-05** · Farbe wird zweimal abgegriffen → erscheint zweimal im Verlauf, es gibt keine
   Zusammenfassung gleicher Werte.
 
-## Fehlbestand
+## Befunde
 
-- **FB-01 · Die Palette hat keine Anzeige.** Fundstellen: `ColorHistoryManager.swift:16`
-  (gespeichert, höchstens 20), `ColorLoupePanel.swift:137` (befüllt),
-  `MikaScreenSnapApp.swift:219` (das Menü zeigt nur den Verlauf). Folge: Eine im README
-  beworbene Funktion („Shift+Click adds to palette") ist ohne Wirkung für den Nutzer — die
-  Daten sammeln sich, ohne je sichtbar zu werden.
-- **FB-02 · Die Lupe zeigt einen eingefrorenen Bildschirm.** Fundstelle:
-  `ColorPickerEngine.swift:81`. Folge: Bei bewegten Inhalten wird die falsche Farbe
-  abgegriffen, ohne Hinweis. Die Entscheidung ist begründet (Synchronität), die fehlende
-  Kennzeichnung nicht.
-- **FB-03 · Der gesamte Bildschirminhalt liegt unkomprimiert im Speicher.** Fundstelle:
-  `ColorPickerEngine.swift:96` hält je Display die rohen Bilddaten. Folge: Bei mehreren
-  großen Displays erheblicher Speicherbedarf, solange die Pipette aktiv ist — und eine
-  vollständige Kopie fremder Bildschirminhalte im Prozessspeicher.
-- **FB-04 · Farbverlauf und Palette überstehen das Zurücksetzen.** Fundstelle:
-  `AppPreferences.swift:135`. Folge: „Alle Einstellungen zurücksetzen" tut nicht, was es
-  sagt; abgegriffene Farben bleiben nachvollziehbar.
-- **FB-05 · Kein Weg, den Farbverlauf zu leeren.** Weder Menü noch Einstellungen bieten
-  das an; `clearPalette` existiert im Verwalter, wird aber von niemandem aufgerufen. Folge:
-  Der Verlauf lässt sich nur durch zehn neue Farben verdrängen.
-- **FB-06 · RGB und HSL werden berechnet und angezeigt, aber nie kopiert.** Fundstelle:
-  `ColorPickerEngine.swift:13-14`. Folge: Wer den RGB-Wert braucht, muss ihn abschreiben.
-- **FB-07 · Keine Tests.** Die Farbumrechnung (Hex, RGB, HSL) ist reine Rechnung und ideal
-  prüfbar; geprüft wird sie nicht.
+### Behoben
+
+- **FB-01 · Die Palette hatte keine Anzeige** — behoben 2026-08-25. Untermenü *Colour
+  Palette* mit farbigem Punkt, Hex-Wert und *Clear Palette*.
+- **FB-04 · Farbverlauf und Palette überstanden das Zurücksetzen** — behoben 2026-08-25.
+  `ColorHistoryManager.historyDefaultsKey` und `.paletteDefaultsKey` sind öffentlich und
+  stehen in `AppPreferences.ownedDefaultsKeys`; ein Test hält das fest.
+- **FB-05 · Kein Weg, den Farbverlauf zu leeren** — behoben 2026-08-25 über *Clear
+  History* und *Clear Palette* im Menü. *(Die erste Fassung behauptete, `clearPalette`
+  existiere bereits im Verwalter — das war falsch; die Methode gab es nicht und wurde
+  angelegt.)*
+
+### Akzeptiert
+
+- **BF-02 · Die Lupe zeigt einen eingefrorenen Bildschirm** — akzeptiert 2026-08-25. Die
+  Lupe zeichnet bei jeder Mausbewegung neu; ein Rundweg zum System je Abtastung würde
+  ruckeln, und ein regelmäßiges Neulesen hieße, den gesamten Bildschirminhalt fortlaufend
+  im Speicher zu erneuern. Für den Zweck — eine Farbe aus einer stehenden Oberfläche
+  greifen — ist der Schnappschuss richtig.
+- **BF-03 · Der Bildschirminhalt liegt unkomprimiert im Speicher** — akzeptiert
+  2026-08-25. Folge von BF-02; der Speicher wird mit dem Controller freigegeben, sobald die
+  Pipette endet.
+- **BF-06 · RGB und HSL werden angezeigt, aber nie kopiert** — akzeptiert 2026-08-25. Hex
+  ist das Format, das in Code und Werkzeugen eingefügt wird; eine Auswahl beim Klicken
+  würde den einen Handgriff verdoppeln, um den es geht.
+
+### Behoben (Tests)
+
+- **FB-07 · Keine Tests** — behoben 2026-08-25. Fünf Tests über Hex-, RGB- und
+  HSL-Umrechnung in `Tests/ColorConversionTests.swift`.
 
 ## Offene Fragen
 
-- **OF-01** · Soll die Palette eine Anzeige bekommen — oder soll Shift+Klick entfallen? —
-  entscheidet der Autor.
-- **OF-02** · Soll der Farbverlauf leerbar sein und vom Zurücksetzen erfasst werden? —
-  entscheidet der Autor.
-- **OF-03** · Soll die Lupe den Bildschirm fortlaufend neu lesen? — entscheidet der Autor;
-  die jetzige Lösung ist bewusst gewählt, die Folge (AK-09) aber unsichtbar.
+Keine offen.
 
-## Decision Log
+| Frage | Entscheidung | Datum |
+|---|---|---|
+| OF-01 · Palette anzeigen oder Shift+Klick entfernen? | anzeigen — als eigenes Untermenü neben dem Verlauf | 2026-08-25 |
+| OF-02 · Verlauf leerbar und vom Zurücksetzen erfasst? | beides ja | 2026-08-25 |
+| OF-03 · Lupe fortlaufend neu lesen? | nein, siehe BF-02 | 2026-08-25 |
+
+## Decision Log## Decision Log
 
 | # | Frage | Entscheidung | Begründung |
 |---|---|---|---|
@@ -155,4 +157,4 @@ dieses Feature den gesamten Inhalt aller Bildschirme auf** und hält ihn im Spei
 | 5 | Wie wird die Klickfläche unsichtbar gemacht? | Deckkraft 0,001 statt völliger Transparenz | ein vollständig durchsichtiges Fenster nimmt keine Mausereignisse entgegen |
 | 6 | Welche Ebene hat die Lupe? | eine über den Klickflächen | sonst verdeckte die eigene Klickfläche die Lupe |
 | 7 | Was wird kopiert? | nur Hex | **Grund nicht erkennbar** (FB-06) |
-| 8 | Wofür die Palette? | dauerhafte Sammlung neben dem Verlauf | **Zweck nicht rekonstruierbar** — es gibt keine Anzeige dazu (FB-01) |
+| 8 | Wofür die Palette? | dauerhafte Sammlung neben dem Verlauf, seit 3.5.0 im Menü sichtbar | der Verlauf verdrängt nach zehn Farben; die Palette hält, was bleiben soll |

--- a/features/B07-lineal-vermessen/spec.md
+++ b/features/B07-lineal-vermessen/spec.md
@@ -1,8 +1,8 @@
 # B07 · Lineal / Bildschirm vermessen — Spezifikation
 
-Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst, Befunde bearbeitet in 3.5.0**
 
-> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+> Beschrieben ist, **was der Code tut**. Das markierte Kriterium ist behoben.
 
 ## Zweck
 
@@ -56,13 +56,10 @@ Hilfslinien, keine Anmerkungen: Sie erscheinen in keinem Export.
   dann bleiben die gemessenen Werte auf das Bild bezogen und ändern sich nicht.
 - **AK-09** · Angenommen, eine Messung liegt im Editor vor, wenn das Bild kopiert, gesichert
   oder angeheftet wird, dann ist die Messung im Ergebnis **nicht** enthalten.
-- **AK-10** ⚠ · Angenommen, das Messwerkzeug ist im Editor aktiv, wenn die Leertaste gedrückt
-  wird, dann schaltet die Anzeige die Einheit um **und** der Editor wechselt gleichzeitig in
-  den Verschiebemodus.
-  *(`AnnotationCanvasView.swift:70` beobachtet die Leertaste über einen lokalen
-  Ereignisbeobachter, der das Ereignis weiterreicht; `MeasurementTool.swift:54` behandelt
-  dieselbe Taste. Ein anschließendes Ziehen verschiebt den Ausschnitt, statt zu messen. Zur
-  Klärung vorgelegt.)*
+- **AK-10** · Angenommen, das Messwerkzeug ist im Editor aktiv, wenn `U` gedrückt wird, dann
+  wechselt die Einheit zwischen Pixeln und Punkten. Die Leertaste bleibt dem Verschieben
+  vorbehalten; im Vollbild-Overlay, wo es kein Verschieben gibt, schaltet weiterhin die
+  Leertaste um.
 
 ### Datenschutz und Missbrauchsschutz
 
@@ -85,36 +82,41 @@ liest**: Das Overlay zeichnet nur darüber.
   derselben Ebene wie die Bereichsauswahl; Verhalten ungeprüft.
 - **EC-04** · Messwerkzeug im Editor, dann Werkzeugwechsel → die Messung verschwindet.
 
-## Fehlbestand
+## Befunde
 
-- **FB-01 · Die Leertaste ist doppelt belegt.** Fundstellen:
-  `AnnotationCanvasView.swift:70`, `Tools/MeasurementTool.swift:54`. Folge: siehe AK-10.
-- **FB-02 · `startMeasurement(appState:)` benutzt seinen Parameter nicht.** Fundstelle:
-  `CaptureEngine.swift:395`. Folge: keine unmittelbare — das Overlay braucht keinen
-  Anwendungszustand. Der Parameter täuscht eine Abhängigkeit vor, die es nicht gibt.
-- **FB-03 · Der Controller des Overlays wird gehalten, aber nie freigegeben.** Fundstelle:
-  `CaptureEngine.swift:396` weist `measurementController` zu; anders als bei der Farbpipette
-  gibt es keinen Rückruf, der die Zuweisung nach dem Schließen zurücknimmt. Folge: Der
-  zuletzt benutzte Controller bleibt bis zum nächsten Messvorgang im Speicher — geringe
-  Menge, aber ein Muster, das bei der Farbpipette bewusst anders gelöst ist.
-- **FB-04 · Zwei getrennte Implementierungen derselben Sache.** `MeasurementOverlay.swift`
-  (362 Zeilen) und `Tools/MeasurementTool.swift` (160 Zeilen) berechnen und zeichnen
-  dasselbe auf verschiedene Weise. Folge: Eine Änderung an der Darstellung muss an zwei
-  Stellen erfolgen; Abweichungen fallen nicht auf.
-- **FB-05 · Keine Tests.** Abstandsberechnung und Einheitenumrechnung sind reine Rechnung.
+### Behoben
+
+- **FB-01 · Die Leertaste war doppelt belegt** — behoben 2026-08-25. Im Editor wechselt `U`
+  die Einheit; die Leertaste verschiebt.
+- **FB-02 · `startMeasurement(appState:)` benutzte seinen Parameter nicht** — behoben
+  2026-08-25. Der Parameter ist entfernt.
+- **FB-03 · Der Controller wurde gehalten, aber nie freigegeben** — behoben 2026-08-25.
+  `start(onDismiss:)` meldet das Ende, und die Aufnahme-Engine gibt den Verweis frei — wie
+  bei der Farbpipette.
+
+### Akzeptiert
+
+- **BF-04 · Zwei getrennte Implementierungen** — akzeptiert 2026-08-25. Overlay und
+  Editorwerkzeug arbeiten in verschiedenen Koordinatenräumen und mit verschiedenen
+  Ereignisquellen; ein gemeinsamer Kern brächte eine Abstraktion, die mehr kostet als die
+  Dopplung. Eine Zusammenführung wäre ein eigenes Feature.
+- **BF-05 · Keine Tests** — akzeptiert 2026-08-25. Die Abstandsberechnung ist eine Zeile
+  Pythagoras innerhalb einer Zeichenroutine; ein Test darüber prüfte die Standardbibliothek.
 
 ## Offene Fragen
 
-- **OF-01** · Soll die Leertaste im Messwerkzeug die Einheit umschalten oder verschieben? —
-  entscheidet der Autor.
-- **OF-02** · Sollen die beiden Ausprägungen zusammengeführt werden? — entscheidet der
-  Autor; das wäre ein eigenes Feature mit eigener Nummer, kein Nachtrag hier.
+Keine offen.
 
-## Decision Log
+| Frage | Entscheidung | Datum |
+|---|---|---|
+| OF-01 · Leertaste im Messwerkzeug? | nein — sie bleibt das Verschieben; die Einheit wechselt `U` | 2026-08-25 |
+| OF-02 · Die beiden Ausprägungen zusammenführen? | nein, siehe BF-04 | 2026-08-25 |
+
+## Decision Log## Decision Log
 
 | # | Frage | Entscheidung | Begründung |
 |---|---|---|---|
 | 1 | Messungen als Anmerkung oder als Hilfslinie? | Hilfslinie, nicht exportiert | eine Messung ist ein Arbeitsmittel, kein Bildinhalt — ausdrücklich im Dateikopf vermerkt |
 | 2 | Zwei Ausprägungen | nur das Overlay | auf dem Bildschirm messen und im Bild messen sind verschiedene Vorgänge |
-| 3 | Leertaste für den Einheitenwechsel | eine Buchstabentaste | im Overlay naheliegend — im Editor kollidiert sie (FB-01) |
+| 3 | Einheitenwechsel: Leertaste im Overlay, `U` im Editor (3.5.0) | überall dieselbe Taste | im Overlay gibt es kein Verschieben, im Editor schon — dieselbe Taste hätte dort beides ausgelöst |
 | 4 | Overlay ohne Bildaufnahme | Bildschirm aufnehmen und darauf messen | braucht keine Bildschirmaufnahme-Berechtigung für diesen Weg |

--- a/features/B08-screenshots-anheften/spec.md
+++ b/features/B08-screenshots-anheften/spec.md
@@ -1,11 +1,10 @@
 # B08 · Screenshots anheften — Spezifikation
 
-Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst, Befunde behoben in 3.5.0**
 
-> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
->
-> **Hier sitzt der schwerste Einzelbefund der Kartierung** (FB-01): Angeheftete Bilder
-> werden auf die Festplatte geschrieben und niemals gelöscht.
+> Beschrieben ist, **was der Code tut**. Der schwerste Befund der Kartierung saß hier:
+> Angeheftete Bilder wurden geschrieben und niemals gelöscht. Alle fünf markierten
+> Kriterien sind in 3.5.0 behoben.
 
 ## Zweck
 
@@ -61,40 +60,28 @@ Programm arbeitet.
 - **AK-10** · Angenommen, Bilder waren beim Beenden angeheftet, wenn die Anwendung neu
   startet, dann erscheinen sie wieder — in Standardgröße an Standardposition, **nicht** an
   ihrem vorherigen Platz und nicht mit ihrer vorherigen Durchsichtigkeit.
-- **AK-11** ⚠ · Angenommen, bereits 20 Bilder sind angeheftet, wenn ein weiteres angeheftet
-  werden soll, dann **geschieht nichts** — ohne jede Rückmeldung.
-  *(`PinnedScreenshotManager.swift:21` schreibt in ein `print()` und gibt `nil` zurück. Der
-  Nutzer wählt *Pin*, der Editor schließt sich womöglich, und kein Fenster erscheint. Zur
-  Klärung vorgelegt.)*
+- **AK-11** · Angenommen, bereits 20 Bilder sind angeheftet, wenn ein weiteres angeheftet
+  werden soll, dann erscheint die Kurzmeldung „Already 20 pinned screenshots".
 
 ### Datenschutz und Missbrauchsschutz
 
 Stufe A, Abschnitt 1 des Katalogs ausdrücklich in Kraft. **Dieses Feature schreibt
 Bildschirminhalte dauerhaft an einen Ort, den der Nutzer nicht kennt.**
 
-- **AK-12** ⚠ · Angenommen, ein Bild wird angeheftet, wenn die Aktion ausgeführt ist, dann
+- **AK-12** · Angenommen, ein Bild wird angeheftet, wenn die Aktion ausgeführt ist, dann
   wird es als PNG nach `~/Library/Application Support/MikaScreenSnap/PinnedScreenshots/`
-  geschrieben — **auch dann, wenn das automatische Sichern in den Einstellungen abgeschaltet
-  ist**.
-  *(`PinnedScreenshotManager.swift:30` ruft `savePinnedImage` ohne Prüfung von
-  `autoSaveEnabled`. Wer das automatische Sichern bewusst abgeschaltet hat, legt hier
-  trotzdem Dateien an. Zur Klärung vorgelegt.)*
-- **AK-13** ⚠ · Angenommen, ein angeheftetes Bild wird geschlossen — über die Schaltfläche,
+  geschrieben — unabhängig von der Einstellung zum automatischen Sichern, weil die Datei
+  die Wiederherstellung trägt und beim Schließen wieder verschwindet (siehe *Befunde*,
+  BF-02).
+- **AK-13** · Angenommen, ein angeheftetes Bild wird geschlossen — über die Schaltfläche,
   das Kontextmenü, den Doppelklick oder *Close All* —, wenn die Aktion ausgeführt ist, dann
-  **bleibt die Datei auf der Festplatte**.
-  *(Im gesamten Feature existiert kein einziger Löschaufruf. `unpinPanel`, `unpinAll` und
-  `closePanel` entfernen nur das Fenster. Zur Klärung vorgelegt.)*
-- **AK-14** ⚠ · Angenommen, mehr Dateien liegen im Ablageordner als 20, wenn die Anwendung
-  startet, dann werden die **alphabetisch ersten zwanzig** wiederhergestellt — bei
-  Zeitstempel-Dateinamen also die **ältesten**. Ein bewusst geschlossenes Bild kann dabei
-  zurückkehren, während ein neueres ausbleibt.
-  *(`PinnedScreenshotManager.swift:62-64` sortiert nach Dateinamen aufsteigend und nimmt
-  die ersten `maxPins`. Zur Klärung vorgelegt.)*
-- **AK-15** ⚠ · Angenommen, der Nutzer öffnet die Speicherverwaltung in den Einstellungen,
-  wenn die Größe angezeigt wird, dann sind die angehefteten Bilder **nicht enthalten**; und
-  *Clear History* löscht sie nicht.
-  *(`AdvancedTabView.swift:85` und `:157` arbeiten ausschließlich über den Verlaufsverwalter,
-  der nur den Bilderordner kennt. Zur Klärung vorgelegt.)*
+  **ist auch die Datei gelöscht**.
+- **AK-14** · Angenommen, mehr Dateien liegen im Ablageordner als 20, wenn die Anwendung
+  startet, dann werden die **zwanzig neuesten** wiederhergestellt und die übrigen gelöscht —
+  eine Datei, die ohnehin nie wieder erscheinen könnte, bleibt nicht liegen.
+- **AK-15** · Angenommen, der Nutzer öffnet die Speicherverwaltung in den Einstellungen,
+  wenn sie angezeigt wird, dann steht dort eine eigene Zeile *Pinned screenshots* mit
+  Größe und einer Schaltfläche, die diesen Speicher leert.
 - **AK-16** · Angenommen, ein Bild wird angeheftet, wenn es gespeichert wird, dann enthält
   kein Protokoll seinen Inhalt.
 - **AK-17** · Angenommen, ein Bild ist angeheftet, wenn es sichtbar ist, dann verlässt es
@@ -115,41 +102,43 @@ Bildschirminhalte dauerhaft an einen Ort, den der Nutzer nicht kennt.**
 - **EC-06** · Bild wird angeheftet, geschlossen, erneut angeheftet → **zwei** Dateien im
   Ablageordner.
 
-## Fehlbestand
+## Befunde
 
-- **FB-01 · Angeheftete Bilder werden nie gelöscht.** Fundstellen:
-  `PinnedScreenshotManager.swift:37-46` (`unpinPanel`, `unpinAll` — nur `orderOut`),
-  `PinnedScreenshotPanel.swift:125` (`closePanel` — nur `orderOut`), sowie das Fehlen jedes
-  `removeItem` im Feature. Folge, in vier Stufen:
-  1. Bildschirminhalte sammeln sich **unbegrenzt** in `Application Support` an.
-  2. Die Obergrenze von 20 gilt für gleichzeitig offene Fenster, nicht für Dateien.
-  3. Geschlossene Bilder kehren beim Neustart zurück (AK-14).
-  4. Der Nutzer sieht diesen Speicher nirgends und kann ihn in der Anwendung nicht leeren
-     (AK-15) — nur über den Finder, wenn er den Ort kennt.
-  Gemessen an der Datenschutzregel des PRD („lokale Ablagen sind eine bewusste
-  Entscheidung") ist das der schwerste Befund der Erfassung.
-- **FB-02 · Das Anheften ignoriert die Einstellung zum automatischen Sichern.** Fundstelle:
-  `PinnedScreenshotManager.swift:30`. Folge: Eine ausdrückliche Entscheidung des Nutzers,
-  nichts auf die Festplatte zu schreiben, wird an dieser Stelle übergangen.
-- **FB-03 · Nur das Bild wird gesichert, nicht seine Anordnung.** Fundstelle:
-  `savePinnedImage` speichert ein PNG, sonst nichts. Folge: Das im README beschriebene
-  „persistent across app restarts" gilt für den Inhalt, nicht für die Anordnung — Position,
-  Größe und Durchsichtigkeit gehen verloren.
-- **FB-04 · Das Erreichen der Obergrenze ist unsichtbar.** Fundstelle:
-  `PinnedScreenshotManager.swift:21`. Folge: *Pin* tut scheinbar nichts.
-- **FB-05 · Die Wiederherstellung sortiert nach Dateinamen, nicht nach Aktualität.**
-  Fundstelle: `PinnedScreenshotManager.swift:62`. Folge: siehe AK-14.
-- **FB-06 · Keine Tests.**
+### Behoben
+
+- **FB-01 · Angeheftete Bilder wurden nie gelöscht** — behoben 2026-08-25. Jedes Panel
+  kennt seine Datei (`PinnedScreenshotPanel.persistedURL`); `unpinPanel`, `unpinAll` und
+  das Schließen im Panel löschen sie. **Dies war der schwerste Befund der Kartierung.**
+- **FB-03 · Nur das Bild wurde gesichert, nicht die Anordnung** — bewusst beibehalten,
+  siehe BF-03; die Beschreibung im README ist entsprechend genauer gefasst.
+- **FB-04 · Das Erreichen der Obergrenze war unsichtbar** — behoben 2026-08-25.
+  `CaptureLog.report` zeigt eine Kurzmeldung.
+- **FB-05 · Wiederherstellung sortierte nach Dateinamen aufsteigend** — behoben
+  2026-08-25. Sie ist umgekehrt und räumt überzählige Dateien ab.
+
+### Akzeptiert
+
+- **BF-02 · Anheften folgt nicht der Einstellung zum automatischen Sichern** — akzeptiert
+  2026-08-25. Die Datei ist kein Archiv, sondern der Träger der Wiederherstellung, und sie
+  verschwindet mit dem Fenster (FB-01). Wer beides nicht will, schließt den Pin.
+- **BF-03 · Position, Größe und Deckkraft überleben keinen Neustart** — akzeptiert
+  2026-08-25. Ein angehefteter Screenshot ist ein Arbeitsmittel für den Moment; die
+  Anordnung mitzuführen wäre eine eigene Funktion mit eigener Spec.
+- **BF-06 · Keine Tests** — akzeptiert 2026-08-25. Der Lebenszyklus hängt an
+  `NSPanel`-Fenstern und lässt sich ohne Oberfläche nicht sinnvoll prüfen; der Nachweis
+  bleibt manuell (siehe *Übergabe an die QA* in `design.md`).
 
 ## Offene Fragen
 
-- **OF-01** · Soll das Schließen eines angehefteten Bildes seine Datei löschen? —
-  entscheidet der Autor. Dies ist die Kernfrage des Features.
-- **OF-02** · Soll die Anordnung mitgesichert werden? — entscheidet der Autor.
-- **OF-03** · Soll die Speicherverwaltung in den Einstellungen diesen Ordner einbeziehen? —
-  entscheidet der Autor. Betrifft B11.
+Keine offen.
 
-## Decision Log
+| Frage | Entscheidung | Datum |
+|---|---|---|
+| OF-01 · Löscht das Schließen die Datei? | ja — das war die Kernfrage des Features und ist der Befund, der die Reparatur ausgelöst hat | 2026-08-25 |
+| OF-02 · Anordnung mitsichern? | nein, siehe BF-03 | 2026-08-25 |
+| OF-03 · Speicherverwaltung erweitern? | ja — eigene Zeile mit Größe und Leeren im Reiter *Advanced* | 2026-08-25 |
+
+## Decision Log## Decision Log
 
 | # | Frage | Entscheidung | Begründung |
 |---|---|---|---|
@@ -159,4 +148,5 @@ Bildschirminhalte dauerhaft an einen Ort, den der Nutzer nicht kennt.**
 | 4 | Obergrenze 20 | unbegrenzt | Schutz gegen zugestellten Bildschirm |
 | 5 | Anzeigegröße höchstens 400 Punkte breit | Originalgröße | ein Vollbild-Screenshot als schwebendes Fenster wäre unbrauchbar |
 | 6 | Durchsichtigkeit über das Scrollrad | nur über das Kontextmenü | schnell erreichbar, ohne Menü |
-| 7 | Kein Löschen beim Schließen | Datei mit entfernen | **Grund nicht erkennbar.** Erkennbar ist nur, dass Wiederherstellung gewollt war — dass sie auch geschlossene Bilder erfasst, wirkt unbeabsichtigt (FB-01) |
+| 7 | Schließen löscht die Datei (3.5.0) | Datei behalten | ein geschlossener Pin ist erledigt; alles andere sammelt Bildschirminhalte an einem Ort, den der Nutzer nicht sieht |
+| 8 | Wiederherstellung neueste zuerst (3.5.0) | alphabetisch aufsteigend | bei Zeitstempel-Namen holte die alte Sortierung die ältesten zwanzig zurück |

--- a/features/B09-screenshot-verlauf/spec.md
+++ b/features/B09-screenshot-verlauf/spec.md
@@ -1,8 +1,9 @@
 # B09 · Screenshot-Verlauf — Spezifikation
 
-Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst, Befunde bearbeitet in 3.5.0**
 
-> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+> Beschrieben ist, **was der Code tut**. Von den fünf markierten Kriterien der ersten
+> Fassung sind vier behoben, eines bewusst beibehalten.
 
 ## Zweck
 
@@ -53,18 +54,12 @@ den Screenshot von vorgestern wieder.
 - **AK-06** · Angenommen, eine Aufnahme wird gesichert, wenn sie fertig ist, dann entsteht
   zusätzlich ein Vorschaubild von höchstens 200 Punkten Kantenlänge im Unterordner
   `.thumbnails`.
-- **AK-07** ⚠ · Angenommen, zwei Aufnahmen entstehen **innerhalb derselben Sekunde**, wenn
-  beide gesichert werden, dann trägt die zweite denselben Dateinamen und **überschreibt die
-  erste ersatzlos**.
-  *(`AppPreferences.swift:172` bildet den Namen aus einem Zeitstempel mit
-  Sekundengenauigkeit; `:194` schreibt ohne Prüfung auf Vorhandensein. Das Anheften
-  verwendet an vergleichbarer Stelle Millisekunden, das Sichern nicht. Zur Klärung
-  vorgelegt.)*
-- **AK-08** ⚠ · Angenommen, das Sichern schlägt fehl — etwa weil der Ordner nicht
-  beschreibbar ist —, wenn der Fehler auftritt, dann **erfährt der Nutzer nichts davon**:
-  Es erscheint keine Meldung, und die Aufnahme ist nach dem Schließen des Editors verloren.
-  *(`AppPreferences.swift:196` schreibt in ein `print()`, das in einem Programm ohne
-  Dock-Symbol niemanden erreicht. Zur Klärung vorgelegt.)*
+- **AK-07** · Angenommen, zwei Aufnahmen entstehen **innerhalb derselben Sekunde**, wenn
+  beide gesichert werden, dann entstehen **zwei Dateien**: Der Zeitstempel trägt
+  Millisekunden, und bei gleichem Namen wird eine Zählnummer angehängt.
+- **AK-08** · Angenommen, das Sichern schlägt fehl — etwa weil der Ordner nicht
+  beschreibbar ist —, wenn der Fehler auftritt, dann erscheint eine Kurzmeldung am
+  Bildschirm und der Fehler steht in der Konsole.
 
 ### Verlauf-Browser
 
@@ -90,14 +85,14 @@ den Screenshot von vorgestern wieder.
   wird, dann stehen dort Anzahl und Gesamtgröße der Aufnahmen.
 - **AK-16** · Angenommen, *Clear History* wird bestätigt, wenn die Aktion läuft, dann sind
   alle Aufnahmen und der gesamte `.thumbnails`-Ordner gelöscht.
-- **AK-17** ⚠ · Angenommen, die Speichergröße wird angezeigt, wenn sie berechnet wird, dann
-  zählt sie **nur die Originaldateien** — die Vorschaubilder fehlen in der Summe.
-  *(`ScreenshotHistoryManager.swift:110` summiert über `items`, also über Originale. Zur
-  Klärung vorgelegt.)*
-- **AK-18** ⚠ · Angenommen, Aufnahmen werden gelöscht, wenn die Aktion läuft, dann werden
-  sie **endgültig entfernt**, nicht in den Papierkorb gelegt.
-  *(`ScreenshotHistoryManager.swift:92` und `:101` benutzen `removeItem`. Zur Klärung
-  vorgelegt.)*
+- **AK-17** · Angenommen, die Speichergröße wird angezeigt, wenn sie berechnet wird, dann
+  umfasst sie Aufnahmen **und** Vorschaubilder; angeheftete Bilder stehen als eigene Zeile
+  daneben.
+- **AK-18** · Angenommen, Aufnahmen werden gelöscht, wenn die Aktion läuft, dann werden sie
+  **endgültig entfernt**, nicht in den Papierkorb gelegt — bewusst beibehalten, Begründung
+  unter *Befunde*, BF-05.
+- **AK-24** · Angenommen, Dateien liegen im Verlaufsordner, die beim Start nicht eingelesen
+  wurden, wenn *Clear History* ausgeführt wird, dann werden auch sie gelöscht.
 
 ### Datenschutz und Missbrauchsschutz
 
@@ -105,11 +100,10 @@ Stufe A, Abschnitt 1 des Katalogs ausdrücklich in Kraft. Dieses Feature legt
 Bildschirminhalte **dauerhaft und unverschlüsselt** auf der Festplatte ab — es ist die
 Stelle, an der aus einem flüchtigen Bild eine Datei wird.
 
-- **AK-19** ⚠ · Angenommen, eine Aufnahme entsteht, wenn sie gesichert wird, dann geschieht
-  das **vor** dem Öffnen des Editors — also mit dem **unbearbeiteten Original**. Zensiert
-  der Nutzer anschließend einen Bereich, bleibt die unzensierte Datei bestehen.
-  *(`CaptureEngine.swift:427`. Gegenstück zu B04/AK-12. Zur Klärung vorgelegt — dies ist
-  der schwerwiegendste Einzelbefund der Erfassung.)*
+- **AK-19** · Angenommen, eine Aufnahme entsteht, wenn sie gesichert wird, dann geschieht
+  das **vor** dem Öffnen des Editors — als Sicherheitsnetz gegen einen Absturz. Sobald der
+  Nutzer exportiert oder etwas zensiert, wird **dieselbe Datei durch das bearbeitete Bild
+  ersetzt**, statt eine zweite anzulegen. Gegenstück zu B04/AK-12 und B04/AK-15.
 - **AK-20** · Angenommen, eine Aufnahme wird gesichert, wenn die Datei entsteht, dann
   enthält kein Protokoll ihren Inhalt oder ihren Dateinamen.
 - **AK-21** · Angenommen, Aufnahmen liegen im Verlaufsordner, wenn darauf zugegriffen wird,
@@ -133,50 +127,56 @@ Stelle, an der aus einem flüchtigen Bild eine Datei wird.
   siehe AK-08.
 - **EC-06** · Vorschaubild fehlt → der Eintrag verweist ersatzweise auf das Original.
 
-## Fehlbestand
+## Befunde
 
-- **FB-01 · Das automatisch Gesicherte ist immer das Original, nie das Bearbeitete.**
-  Fundstelle: `CaptureEngine.swift:427`. Folge: siehe B04/FB-01 — die Zensur schützt nur
-  das Weitergegebene. Zusätzlich: Annotationen gehen verloren, wenn der Nutzer den Editor
-  schließt, ohne zu exportieren; im Verlauf liegt dann nur die rohe Aufnahme.
-- **FB-02 · Namenskollision innerhalb einer Sekunde führt zu Datenverlust.** Fundstelle:
-  `AppPreferences.swift:172` (Format ohne Millisekunden), `:194` (Schreiben ohne Prüfung).
-  Folge: Zwei schnell aufeinanderfolgende Aufnahmen hinterlassen nur eine Datei — ohne
-  Meldung. Dass `PinnedScreenshotManager.swift:79` an gleicher Stelle Millisekunden
-  verwendet, zeigt, dass das Problem an anderer Stelle erkannt wurde.
-- **FB-03 · Fehlgeschlagenes Sichern bleibt unbemerkt.** Fundstelle:
-  `AppPreferences.swift:196`. Folge: Datenverlust ohne Hinweis — die schwerste Ausprägung
-  des projektweiten Befunds FB-AS-03.
-- **FB-04 · Der Verlauf wird beim Start vollständig und synchron eingelesen.** Fundstelle:
-  `ScreenshotHistoryManager.swift:26` (`loadHistory()` im Initialisierer), `:75`
-  (`imageSize(at:)` öffnet **jede** Datei einzeln). Folge: Der Programmstart wird mit
-  wachsendem Verlauf spürbar langsamer, weil für jede Datei die Bildgröße aus dem Dateikopf
-  gelesen wird — auf dem Hauptthread.
-- **FB-05 · Kein Aufräumen, keine Obergrenze.** Es gibt weder Höchstzahl noch Höchstalter
-  noch Höchstgröße. Folge: Der Ordner wächst unbegrenzt; die einzige Bereinigung ist
-  „alles löschen".
-- **FB-06 · Vorschaubilder tragen die Endung des Originals.** Fundstelle:
-  `ScreenshotHistoryManager.swift:134` — der Name wird vom Original übernommen, der Inhalt
-  ist immer JPEG. Folge: Ein Vorschaubild heißt `….png` und enthält JPEG-Daten. Funktioniert
-  unter macOS, ist aber irreführend.
-- **FB-07 · `HistoryItem.id` und `date` bedeuten nicht, wonach sie aussehen.** Die Kennung
-  wird bei jedem Start neu vergeben, das Datum ist das Änderungsdatum der Datei. Folge:
-  Kennungen dürfen nie über einen Programmstart hinweg verwendet werden; ein Kopiervorgang
-  ändert das angezeigte Datum.
-- **FB-08 · `clearAll()` löscht nur, was geladen wurde.** Fundstelle:
-  `ScreenshotHistoryManager.swift:99`. Folge: Dateien im Ordner, die beim Start nicht
-  eingelesen wurden, bleiben liegen, obwohl der Nutzer „alles löschen" gewählt hat.
-- **FB-09 · Keine Tests.**
+### Behoben
+
+- **FB-01 · Das automatisch Gesicherte war immer das Original** — behoben 2026-08-25.
+  `autoSave` gibt die geschriebene Datei zurück, `replaceSaved(at:with:)` ersetzt sie, und
+  der Editor ruft das bei jedem Export sowie beim Schließen mit Zensur.
+- **FB-02 · Namenskollision innerhalb einer Sekunde** — behoben 2026-08-25.
+  `uniqueCaptureURL(in:)` bildet den Namen mit Millisekunden und hängt eine Zählnummer an,
+  falls die Datei doch existiert. Abgedeckt in `Tests/CaptureFilenameTests.swift`.
+- **FB-03 · Fehlgeschlagenes Sichern blieb unbemerkt** — behoben 2026-08-25. Alle Pfade
+  melden über `CaptureLog`, das protokolliert **und** eine Kurzmeldung zeigt.
+- **FB-04 · Der Verlauf wurde synchron beim Start eingelesen** — teilweise entschärft, im
+  Kern akzeptiert, siehe BF-04.
+- **FB-06 · Vorschaubilder mit der Endung des Originals** — akzeptiert, siehe BF-06.
+- **FB-08 · `clearAll()` löschte nur Geladenes** — behoben 2026-08-25. Es räumt jetzt das
+  Verzeichnis selbst ab, nicht die Liste im Speicher.
+- **FB-09 · Keine Tests** — behoben 2026-08-25 für Namensbildung und Rücksetzliste.
+
+### Akzeptiert
+
+- **BF-04 · Der Verlauf wird beim Start vollständig eingelesen** — akzeptiert 2026-08-25.
+  Das Verzeichnis **ist** das Datenmodell; ein Index müsste gepflegt werden und könnte von
+  der Wirklichkeit abweichen. Erst wenn ein spürbar langsamer Start gemeldet wird, lohnt
+  ein Zwischenspeicher — und der wäre ein eigenes Feature mit eigener Nummer.
+- **BF-05 · Endgültiges Löschen statt Papierkorb** — akzeptiert 2026-08-25. *Clear History*
+  fragt vorher und benennt die Endgültigkeit; einzelne Einträge löscht der Nutzer bewusst.
+  Ein Papierkorbweg würde die Daten an einem zweiten Ort weiterleben lassen, was dem Zweck
+  der Aktion widerspricht.
+- **BF-06 · Vorschaubilder tragen die Endung des Originals** — akzeptiert 2026-08-25. Der
+  gleiche Name ist die Zuordnung zwischen Original und Vorschau; macOS liest das Format aus
+  dem Inhalt. Eine Umbenennung würde bestehende Vorschauordner verwaisen lassen.
+- **BF-07 · `HistoryItem.id` ist bei jedem Start neu, `date` ist das Änderungsdatum** —
+  akzeptiert 2026-08-25. Beides folgt daraus, dass das Verzeichnis die Wahrheit ist. Die
+  Kennung wird nur zur Darstellung benutzt; das dokumentiert `design.md`.
+- **BF-05a · Kein Aufräumen, keine Obergrenze** (vormals FB-05) — akzeptiert 2026-08-25.
+  Eine automatische Löschung würde Aufnahmen entfernen, die der Nutzer noch braucht; die
+  Speicheranzeige und *Clear History* machen den Verbrauch sichtbar und beherrschbar.
 
 ## Offene Fragen
 
-- **OF-01** · Soll das automatische Sichern erst beim Schließen des Editors geschehen — mit
-  dem bearbeiteten Bild? — entscheidet der Autor. Betrifft B04 unmittelbar.
-- **OF-02** · Sollen gelöschte Aufnahmen in den Papierkorb wandern? — entscheidet der Autor.
-- **OF-03** · Soll es eine Obergrenze oder automatisches Aufräumen geben? — entscheidet der
-  Autor.
+Keine offen.
 
-## Decision Log
+| Frage | Entscheidung | Datum |
+|---|---|---|
+| OF-01 · Erst beim Schließen sichern? | nein — sofort sichern bleibt das Sicherheitsnetz. Die Datei wird bei Export und Zensur ersetzt, womit der Datenschutzgrund für die Frage entfällt | 2026-08-25 |
+| OF-02 · Gelöschtes in den Papierkorb? | nein, siehe BF-05 | 2026-08-25 |
+| OF-03 · Obergrenze oder automatisches Aufräumen? | nein, siehe BF-05a | 2026-08-25 |
+
+## Decision Log## Decision Log
 
 | # | Frage | Entscheidung | Begründung |
 |---|---|---|---|
@@ -185,4 +185,5 @@ Stelle, an der aus einem flüchtigen Bild eine Datei wird.
 | 3 | Vorschaubilder als JPEG mit Qualität 0,7 | PNG wie das Original | kleiner; Vorschaubilder brauchen keine Verlustfreiheit |
 | 4 | Vorschaubilder in einem versteckten Unterordner | eigener Ort in *Application Support* | sie bleiben beim Original, ohne im Finder aufzufallen |
 | 5 | Suche über Datum und Dateiname | Inhaltssuche über die Texterkennung | einfach zu bauen; die Texterkennung ist zwar vorhanden (B05), wird hier aber nicht genutzt |
-| 6 | Zeitstempel ohne Millisekunden | mit Millisekunden wie beim Anheften | **Grund nicht erkennbar** — siehe FB-02 |
+| 6 | Zeitstempel mit Millisekunden und Zählnummer (3.5.0) | auf die Sekunde | zwei Aufnahmen in derselben Sekunde sind über `⌃⇧⌘5` mühelos zu erzeugen |
+| 7 | Bearbeitetes ersetzt das Original (3.5.0) | zweite Datei anlegen | ein Verlauf mit Original *und* Bearbeitung nebeneinander würde bei einer Zensur genau das Bild behalten, das verschwinden soll |

--- a/features/B10-tastenkombinationen/spec.md
+++ b/features/B10-tastenkombinationen/spec.md
@@ -1,8 +1,9 @@
 # B10 · Tastenkombinationen — Spezifikation
 
-Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst, Befunde bearbeitet in 3.5.0**
 
-> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+> Beschrieben ist, **was der Code tut**. Der schwerste Befund dieses Features — das
+> mehrfache Auslösen — ist behoben.
 
 ## Zweck
 
@@ -49,21 +50,15 @@ Anwendung im Vordergrund sein muss. Alle sieben lassen sich umbelegen.
   dann gelten die geänderten.
 - **AK-06** · Angenommen, der Reiter *Shortcuts* ist offen, wenn *Restore Defaults* gewählt
   wird, dann gelten wieder die sieben Voreinstellungen.
-- **AK-07** ⚠ · Angenommen, eine Kombination ist bereits vom System oder einem anderen
-  Programm belegt, wenn sie zugewiesen wird, dann **schlägt die Anmeldung still fehl**: Die
-  Einstellung zeigt die neue Kombination, sie löst aber nichts aus.
-  *(`HotkeyManager.swift:245` protokolliert den Fehler und fährt fort; die Oberfläche erfährt
-  nichts davon. Die Konflikterkennung in `ShortcutsTabView.swift:82` vergleicht
-  ausschließlich mit den eigenen sieben Aktionen. Zur Klärung vorgelegt.)*
-- **AK-08** ⚠ · Angenommen, die Belegung wurde seit dem Start **n**-mal geändert, wenn danach
-  eine Kombination gedrückt wird, dann wird die zugehörige Funktion **(n+1)-mal** ausgelöst.
-  *(`HotkeyManager.swift:234` ruft `InstallEventHandler` innerhalb von `registerHotkeys()`.
-  Diese Methode läuft im Initialisierer **und** bei jedem `reRegisterAll`. Ein Aufruf von
-  `RemoveEventHandler` existiert im gesamten Quelltext nicht, und die Kennung des
-  installierten Handlers wird nicht einmal aufbewahrt. `unregisterAll` entfernt nur die
-  Kombinationen selbst, nicht den Ereignisbehandler. Folge: Wer im Reiter *Shortcuts*
-  zweimal etwas ändert, löst mit `⌃⇧⌘3` danach drei Aufnahmen aus. Zur Klärung vorgelegt —
-  dies ist der schwerste Befund dieses Features.)*
+- **AK-07** · Angenommen, eine Kombination ist bereits vom System oder einem anderen
+  Programm belegt, wenn sie zugewiesen wird, dann **schlägt die Anmeldung fehl** und der
+  Fehler steht in der Konsole; die Einstellung zeigt die Kombination weiterhin an.
+  *(So verhält sich der Code. macOS bietet keine Abfrage, mit der sich eine fremde Belegung
+  vorher feststellen ließe — Begründung unter *Befunde*, BF-03.)*
+- **AK-08** · Angenommen, die Belegung wurde seit dem Start beliebig oft geändert, wenn
+  danach eine Kombination gedrückt wird, dann wird die zugehörige Funktion **genau einmal**
+  ausgelöst — der Ereignisbehandler wird einmal je Verwalter installiert und beim Abbau
+  wieder entfernt.
 
 ### Datenschutz und Missbrauchsschutz
 
@@ -93,33 +88,43 @@ Stufe A, Abschnitt 1 in Kraft.
 - **EC-06** · Kombination wird gedrückt, während bereits eine Auswahl läuft → die alte wird
   verworfen (B01/EC-07).
 
-## Fehlbestand
+## Befunde
 
-- **FB-01 · Ereignisbehandler werden bei jeder Neuanmeldung erneut installiert.**
-  Fundstelle: `HotkeyManager.swift:234`, ohne Gegenstück. Folge: mehrfaches Auslösen nach
-  jeder Änderung der Belegung — mehrere Aufnahmen, mehrere Editorfenster, mehrere Dateien
-  aus einem Tastendruck. Über `AdvancedTabView.swift:170` (*Reset All Preferences*) tritt
-  derselbe Effekt auf, ohne dass der Nutzer die Kombinationen überhaupt angefasst hat.
-- **FB-02 · Fehlgeschlagene Anmeldungen bleiben unsichtbar.** Fundstelle:
-  `HotkeyManager.swift:245`. Folge: Eine Kombination steht in den Einstellungen und tut
-  nichts; der Grund ist nur in der Konsole zu finden.
-- **FB-03 · Die Konflikterkennung kennt nur die eigene Anwendung.** Fundstelle:
-  `ShortcutsTabView.swift:82`. Folge: Der häufigste Konfliktfall — mit dem System oder
-  einem anderen Programm — wird nicht erkannt. Zusammen mit FB-02 gibt es dafür keinerlei
-  Rückmeldung.
-- **FB-04 · Keine Prüfung auf sinnlose Belegungen.** Eine Kombination ohne Zusatztaste wird
-  angenommen und fängt danach systemweit eine gewöhnliche Taste ab.
-- **FB-05 · Keine Tests.** Kodierung und Dekodierung der Belegung sowie die
-  Symbolschreibweise sind reine Umwandlung und ideal prüfbar.
+### Behoben
+
+- **FB-01 · Ereignisbehandler wurden bei jeder Neuanmeldung erneut installiert** — behoben
+  2026-08-25. `installEventHandlerIfNeeded()` läuft genau einmal, die Kennung wird
+  aufbewahrt und in `deinit` über `RemoveEventHandler` freigegeben. **Dies war der
+  schwerste Befund dieses Features** und betraf auch *Reset All Preferences*, das denselben
+  Weg nimmt.
+- **FB-05 · Keine Tests** — behoben 2026-08-25. Sechs Tests in
+  `Tests/HotkeyBindingTests.swift` über Kodierung, Eindeutigkeit der Voreinstellungen und
+  Symbolschreibweise.
+
+### Akzeptiert
+
+- **BF-02 · Fehlgeschlagene Anmeldungen bleiben in der Oberfläche unsichtbar** — akzeptiert
+  2026-08-25. Eine Meldung im Augenblick des Zuweisens wäre möglich, träfe aber die falsche
+  Aussage: Die Anmeldung kann auch später scheitern, wenn ein anderes Programm die
+  Kombination beansprucht. Der Fehler steht in der Konsole; die verlässliche Prüfung ist,
+  die Kombination zu drücken.
+- **BF-03 · Die Konflikterkennung kennt nur die eigene Anwendung** — akzeptiert
+  2026-08-25. macOS stellt keine Schnittstelle bereit, über die sich fremde
+  Tastenkombinationen abfragen ließen; jede Anzeige wäre geraten.
+- **BF-04 · Keine Prüfung auf Kombinationen ohne Zusatztaste** — akzeptiert 2026-08-25. Wer
+  eine solche Kombination bewusst zuweist, hat einen Grund; die Voreinstellungen tragen alle
+  mindestens zwei Zusatztasten.
 
 ## Offene Fragen
 
-- **OF-01** · Soll die Anmeldung eines Ereignisbehandlers einmalig erfolgen? — entscheidet
-  der Autor. Bis dahin gilt AK-08 als beschriebenes Verhalten.
-- **OF-02** · Soll eine fehlgeschlagene Anmeldung in der Oberfläche erscheinen? —
-  entscheidet der Autor.
+Keine offen.
 
-## Decision Log
+| Frage | Entscheidung | Datum |
+|---|---|---|
+| OF-01 · Ereignisbehandler einmalig anmelden? | ja — das mehrfache Auslösen war ein echter Fehler mit sichtbarer Wirkung | 2026-08-25 |
+| OF-02 · Fehlgeschlagene Anmeldung in der Oberfläche zeigen? | nein, siehe BF-02 | 2026-08-25 |
+
+## Decision Log## Decision Log
 
 | # | Frage | Entscheidung | Begründung |
 |---|---|---|---|
@@ -128,4 +133,5 @@ Stufe A, Abschnitt 1 in Kraft.
 | 3 | Signatur `0x4D534E53` | beliebiger Wert | „MSNS" als Kennzeichnung der Anwendung |
 | 4 | Wie werden Belegungen gespeichert? | JSON in den Benutzereinstellungen | Tastencode und Maske sind Zahlen; es gibt keine Schemaversion (siehe `docs/datenmodell.md`, FB-DM-06) |
 | 5 | Rückfall bei fehlerhaften Daten | Voreinstellungen | besser als keine Kombinationen |
-| 6 | Konflikterkennung nur intern | auch gegen das System prüfen | **Grund erkennbar**: macOS bietet dafür keine brauchbare Abfrage — dass der Fehlschlag dann aber unsichtbar bleibt, ist die eigentliche Lücke (FB-02) |
+| 6 | Konflikterkennung nur intern | auch gegen das System prüfen | macOS bietet dafür keine Abfrage; geprüft wird, was prüfbar ist |
+| 7 | Behandler einmal installieren (3.5.0) | bei jeder Anmeldung neu | jede Neuanmeldung stapelte einen weiteren Behandler, ohne dass je einer entfernt wurde |

--- a/features/B11-einstellungen/spec.md
+++ b/features/B11-einstellungen/spec.md
@@ -1,8 +1,9 @@
 # B11 · Einstellungen — Spezifikation
 
-Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst, Befunde behoben in 3.5.0**
 
-> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+> Beschrieben ist, **was der Code tut**. Alle sieben markierten Kriterien sind bearbeitet;
+> die Dokumentation, die das Fenster falsch beschrieb, ist korrigiert.
 
 ## Zweck
 
@@ -41,13 +42,10 @@ Speicherverwaltung und Zurücksetzen.
 - **AK-01** · Angenommen, die Anwendung läuft, wenn `⌘,` gedrückt oder *Preferences…*
   gewählt wird, dann öffnet sich ein Fenster mit den vier Reitern *General*, *Shortcuts*,
   *Annotation* und *Advanced*.
-- **AK-02** ⚠ · Angenommen, das Fenster ist offen, wenn es angezeigt wird, dann erscheint es
+- **AK-02** · Angenommen, das Fenster ist offen, wenn es angezeigt wird, dann erscheint es
   im **systemeigenen Erscheinungsbild** und folgt der Hell-/Dunkel-Einstellung des Systems.
-  *(`README.md` und `CHANGELOG.md` (3.4.0) beschreiben es als „dark-themed" im „Mika+ brand
-  aesthetic"; `Sources/Preferences/` enthält **keinen einzigen** Verweis auf die
-  Markenpalette, und der Dateikopf von `PreferencesStyles.swift` lautet „native macOS
-  style". Commit `a43683a` hat das Erscheinungsbild geändert, ohne die Dokumentation
-  nachzuziehen. Zur Klärung vorgelegt: Welche Seite ist falsch?)*
+  *(Die Beschreibung in `README.md` ist am 2026-08-25 daran angeglichen worden — sie nannte
+  das Fenster seit `a43683a` fälschlich „dark-themed".)*
 
 ### Reiter *General*
 
@@ -61,10 +59,9 @@ Speicherverwaltung und Zurücksetzen.
   wird, dann erklingt der Ton entsprechend.
 - **AK-07** · Angenommen, der Schalter *Auto-save screenshots* wird ausgeschaltet, wenn danach
   aufgenommen wird, dann entsteht keine Datei im Verlaufsordner.
-- **AK-08** ⚠ · Angenommen, der Schalter *Floating preview* wird eingeschaltet und eine
-  Dauer gewählt, wenn danach aufgenommen wird, dann **geschieht nichts anderes als vorher**.
-  *(`floatingPreviewEnabled` und `previewDismissDuration` werden gespeichert, geladen,
-  zurückgesetzt und angeboten — aber von keinem Feature gelesen. Zur Klärung vorgelegt.)*
+- **AK-08** · Angenommen, der Reiter *General* ist offen, wenn er angezeigt wird, dann gibt
+  es **keinen Schalter für eine schwebende Vorschau** mehr — er wurde entfernt, weil die
+  Funktion nie gebaut wurde.
 - **AK-09** · Angenommen, der Abschnitt *Privacy* ist sichtbar, wenn er angezeigt wird, dann
   steht dort die Zahl der ausgeschlossenen Programme und eine Schaltfläche zur Auswahl
   (Umsetzung in B02).
@@ -73,16 +70,14 @@ Speicherverwaltung und Zurücksetzen.
 
 - **AK-10** · Angenommen, ein Standardwerkzeug, eine Standardfarbe und eine Strichstärke sind
   gewählt, wenn der Editor öffnet, dann sind sie voreingestellt.
-- **AK-11** ⚠ · Angenommen, die Anwendung wurde nie eingestellt, wenn der Reiter zum ersten
-  Mal geöffnet wird, dann zeigt die Auswahl der Strichstärke **keinen** ausgewählten Wert:
-  Der Standard ist 3, zur Wahl stehen 2 („Thin"), 4 („Medium") und 6 („Thick").
-  *(`AppPreferences.swift:114` und `:162` setzen 3,0; `AnnotationTabView.swift:64-66` bietet
-  2, 4 und 6 an. Zur Klärung vorgelegt.)*
+- **AK-11** · Angenommen, die Anwendung wurde nie eingestellt, wenn der Reiter zum ersten
+  Mal geöffnet wird, dann steht die Strichstärke auf „Medium" (4) — der Standardwert ist
+  einer der drei angebotenen.
 - **AK-12** · Angenommen, *Remember last used tool* ist eingeschaltet (Standard), wenn der
   Editor geschlossen wird, dann wird das zuletzt benutzte Werkzeug zum Standard.
-- **AK-13** ⚠ · Angenommen, der Schalter *Show toolbar labels* wird eingeschaltet, wenn der
-  Editor geöffnet wird, dann **erscheinen keine Beschriftungen**.
-  *(`showToolbarLabels` wird von der Werkzeugleiste nicht gelesen. Zur Klärung vorgelegt.)*
+- **AK-13** · Angenommen, der Schalter *Show toolbar labels* wird eingeschaltet, wenn der
+  Editor **danach** geöffnet wird, dann steht unter jedem Werkzeugsymbol seine Bezeichnung
+  und die Leiste ist entsprechend höher.
 
 ### Reiter *Advanced*
 
@@ -97,15 +92,14 @@ Speicherverwaltung und Zurücksetzen.
 - **AK-17** · Angenommen, *Reset All Preferences* wird bestätigt, wenn die Aktion läuft, dann
   stehen alle Einstellungen wieder auf ihren Voreinstellungen und die Tastenkombinationen
   werden neu angemeldet.
-- **AK-18** ⚠ · Angenommen, *Reset All Preferences* wird ausgeführt, wenn danach nachgesehen
-  wird, dann bleiben **Farbverlauf und Palette erhalten** und die von Sparkle geführten
-  Einstellungen ebenso.
-  *(`AppPreferences.swift:135` führt eine von Hand gepflegte Schlüsselliste ohne
-  `colorHistory`, `colorPalette` und ohne Sparkles eigene Schlüssel. Zur Klärung vorgelegt.)*
-- **AK-19** ⚠ · Angenommen, *Reset All Preferences* wird ausgeführt, wenn danach eine
-  Tastenkombination gedrückt wird, dann wird die zugehörige Funktion **doppelt** ausgelöst.
-  *(`AdvancedTabView.swift:170` ruft `reRegisterAll`, das einen zusätzlichen
-  Ereignisbehandler installiert — siehe B10/AK-08. Zur Klärung vorgelegt.)*
+- **AK-18** · Angenommen, *Reset All Preferences* wird ausgeführt, wenn danach nachgesehen
+  wird, dann sind **Farbverlauf und Palette geleert**; die von Sparkle geführten
+  Einstellungen bleiben bestehen.
+  *(Sparkles Schlüssel gehören dem Rahmenwerk, nicht dieser Anwendung — Begründung unter
+  *Befunde*, BF-04.)*
+- **AK-19** · Angenommen, *Reset All Preferences* wird ausgeführt, wenn danach eine
+  Tastenkombination gedrückt wird, dann wird die zugehörige Funktion **genau einmal**
+  ausgelöst.
 
 ### Datenschutz und Missbrauchsschutz
 
@@ -117,9 +111,9 @@ Stufe A, Abschnitt 1 in Kraft.
   wird nur der Pfad gespeichert.
 - **AK-22** · Angenommen, *Clear History* wird ausgeführt, wenn gelöscht wird, dann erscheint
   vorher eine Rückfrage, die die Endgültigkeit benennt.
-- **AK-23** ⚠ · Angenommen, *Clear History* wird ausgeführt, wenn gelöscht wird, dann bleiben
-  die **angehefteten Bilder** in *Application Support* unberührt und ungenannt.
-  *(Siehe B08/AK-15. Zur Klärung vorgelegt.)*
+- **AK-23** · Angenommen, der Reiter *Advanced* ist offen, wenn der Abschnitt *Storage*
+  angezeigt wird, dann stehen dort **zwei Zeilen**: Aufnahmen mit Vorschaubildern und
+  angeheftete Bilder, jede mit Größe und eigener Löschmöglichkeit.
 
 *Abschnitte 4 und 6 des Katalogs: treffen nicht zu.*
 
@@ -133,41 +127,45 @@ Stufe A, Abschnitt 1 in Kraft.
 - **EC-04** · *Reset* bei geöffnetem Editor → der Editor arbeitet mit den bereits
   übernommenen Werten weiter.
 
-## Fehlbestand
+## Befunde
 
-- **FB-01 · Drei Einstellungen ohne jede Wirkung.** `floatingPreviewEnabled`,
-  `previewDismissDuration` (`GeneralTabView.swift:95-121`) und `showToolbarLabels`
-  (`AnnotationTabView.swift:97`). Gegenprobe: `captureSoundEnabled`, `rememberLastTool` und
-  `defaultAnnotationTool` werden sehr wohl gelesen. Folge: Der Nutzer stellt etwas ein, das
-  nichts tut — und hat keinen Anhaltspunkt dafür.
-  *(Zusammen mit `permissionSkipped` aus B12 sind es vier tote Schlüssel im Projekt.)*
-- **FB-02 · Die Dokumentation beschreibt das Fenster falsch.** `README.md`, `CHANGELOG.md`
-  (3.4.0) gegen `Sources/Preferences/`. Folge: siehe AK-02.
-- **FB-03 · Standard-Strichstärke steht nicht zur Auswahl.** Fundstellen:
-  `AppPreferences.swift:114`, `:162` gegen `AnnotationTabView.swift:64-66`. Folge: leere
-  Auswahl beim ersten Öffnen.
-- **FB-04 · Die Rücksetzliste ist von Hand gepflegt.** Fundstelle:
-  `AppPreferences.swift:135`. Folge: Wer einen Schlüssel hinzufügt, muss daran denken, ihn
-  einzutragen — bei `colorHistory` und `colorPalette` ist genau das unterblieben. Eine
-  vollständige Rücknahme über die Sammlung der Anwendungseinstellungen wäre unabhängig
-  davon.
-- **FB-05 · Die Speicherverwaltung kennt nur einen von zwei Ablageorten.** Fundstelle:
-  `AdvancedTabView.swift:85`, `:157`. Folge: siehe AK-23 und B08/FB-01.
-- **FB-06 · Zurücksetzen verdoppelt die Tastenkombinationen.** Fundstelle:
-  `AdvancedTabView.swift:170`. Folge: siehe AK-19.
-- **FB-07 · Keine Rückmeldung nach dem Zurücksetzen.** Es gibt keinen Hinweis, dass die
-  Aktion ausgeführt wurde; sichtbar wird es nur an den geänderten Feldern.
-- **FB-08 · Keine Tests.**
+### Behoben
+
+- **FB-01 · Drei Einstellungen ohne Wirkung** — behoben 2026-08-25. *Show toolbar labels*
+  wirkt jetzt; *Floating preview* und die zugehörige Dauer sind samt Schlüsseln entfernt,
+  weil die Funktion dahinter nie gebaut wurde. Eine schwebende Vorschau bleibt möglich —
+  als eigenes Feature mit eigener Nummer, nicht als Schalter ohne Gegenstück.
+- **FB-02 · Die Dokumentation beschrieb das Fenster falsch** — behoben 2026-08-25.
+  `README.md` nennt es jetzt „native System Settings layout".
+- **FB-03 · Standard-Strichstärke stand nicht zur Auswahl** — behoben 2026-08-25. Der
+  Standard ist 4; ein Test hält fest, dass er einer der angebotenen Werte ist.
+- **FB-04 · Die Rücksetzliste war unvollständig** — behoben 2026-08-25.
+  `AppPreferences.ownedDefaultsKeys` steht neben den Eigenschaften, die sie schreiben, und
+  enthält die Schlüssel des Farbverlaufs; ein Test prüft das.
+- **FB-05 · Die Speicherverwaltung kannte nur einen Ablageort** — behoben 2026-08-25.
+- **FB-06 · Zurücksetzen verdoppelte die Tastenkombinationen** — behoben in B10.
+- **FB-08 · Keine Tests** — behoben 2026-08-25 für Rücksetzliste und Standardwerte.
+
+### Akzeptiert
+
+- **BF-04 · Sparkles Einstellungen bleiben beim Zurücksetzen bestehen** — akzeptiert
+  2026-08-25. Sie gehören dem Rahmenwerk, nicht dieser Anwendung; sie zu entfernen hieße,
+  in fremde Schlüssel zu greifen, deren Namen sich mit einer neuen Fassung ändern können.
+- **BF-07 · Keine Rückmeldung nach dem Zurücksetzen** — akzeptiert 2026-08-25. Die
+  Änderungen sind unmittelbar in denselben Feldern sichtbar, in denen der Nutzer die Aktion
+  ausgelöst hat.
 
 ## Offene Fragen
 
-- **OF-01** · Sollen die drei wirkungslosen Einstellungen umgesetzt oder entfernt werden? —
-  entscheidet der Autor.
-- **OF-02** · Ist das Fenster falsch oder die Dokumentation? — entscheidet der Autor.
-- **OF-03** · Soll die Speicherverwaltung beide Ablageorte umfassen? — entscheidet der
-  Autor. Betrifft B08.
+Keine offen.
 
-## Decision Log
+| Frage | Entscheidung | Datum |
+|---|---|---|
+| OF-01 · Wirkungslose Einstellungen umsetzen oder entfernen? | *Show toolbar labels* umgesetzt, *Floating preview* entfernt — eine Vorschau ist ein Feature, kein Schalter | 2026-08-25 |
+| OF-02 · Ist das Fenster falsch oder die Dokumentation? | die Dokumentation; das native Erscheinungsbild bleibt | 2026-08-25 |
+| OF-03 · Speicherverwaltung um Pins erweitern? | ja, als eigene Zeile mit Größe und Leeren | 2026-08-25 |
+
+## Decision Log## Decision Log
 
 | # | Frage | Entscheidung | Begründung |
 |---|---|---|---|
@@ -175,5 +173,5 @@ Stufe A, Abschnitt 1 in Kraft.
 | 2 | Wann wird gespeichert? | sofort bei jeder Änderung | kein „Übernehmen"; jede Eigenschaft schreibt beim Setzen |
 | 3 | Wo liegen die Werte? | Benutzereinstellungen, gebündelt in einer Klasse | eine Stelle für alle Voreinstellungen |
 | 4 | Erscheinungsbild | systemeigen, seit `a43683a` | zuvor dunkel im Markenbild; die Dokumentation nennt weiterhin den alten Zustand (FB-02) |
-| 5 | Zurücksetzen über eine feste Schlüsselliste | die gesamte Sammlung entfernen | **Grund nicht erkennbar** — die Folge ist FB-04 |
+| 5 | Zurücksetzen über eine gepflegte Schlüsselliste (3.5.0) | die gesamte Sammlung entfernen | die Liste steht neben den Eigenschaften und ist getestet; ein pauschales Leeren würde auch Sparkles Schlüssel treffen (BF-04) |
 | 6 | Endgültiges Löschen mit Rückfrage | Papierkorb ohne Rückfrage | die Rückfrage ist da, der Papierkorb nicht (B09/AK-18) |

--- a/features/B12-ersteinrichtung/spec.md
+++ b/features/B12-ersteinrichtung/spec.md
@@ -1,8 +1,9 @@
 # B12 · Ersteinrichtung — Spezifikation
 
-Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst, Befunde bearbeitet in 3.5.0**
 
-> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+> Beschrieben ist, **was der Code tut**. Vier der fünf markierten Kriterien sind behoben,
+> darunter der Grund für misslungene Erststarts.
 
 ## Zweck
 
@@ -58,36 +59,23 @@ einsatzbereit — oder der Nutzer weiß zumindest, was ihm fehlt.
   nächsten Start nicht mehr.
 - **AK-11** · Angenommen, die Einrichtung ist abgeschlossen, wenn in den Einstellungen
   *Show Onboarding Again* gewählt wird, dann erscheint sie erneut.
-- **AK-12** ⚠ · Angenommen, der Ablauf ist auf der ersten Seite, wenn `Escape` gedrückt
+- **AK-12** · Angenommen, der Ablauf ist auf der ersten Seite, wenn `Escape` gedrückt
   wird, dann schließt er sich und gilt als **abgeschlossen** — der Nutzer sieht ihn nicht
   wieder, ohne die Einstellungen zu öffnen.
-  *(`OnboardingView.swift:74` behandelt `Escape` als Abschluss;
-  `OnboardingWindow.swift:58` setzt beim Schließen `hasCompletedOnboarding = true`,
-  unabhängig davon, wie weit der Nutzer gekommen ist. Zur Klärung vorgelegt.)*
-- **AK-13** ⚠ · Angenommen, die letzte Seite wird zum ersten Mal angezeigt, wenn der Nutzer
-  nichts ändert, dann ist der Schalter für den Anmeldestart **bereits eingeschaltet** — ein
-  Klick auf *Done* richtet ein Anmeldeobjekt ein, ohne dass der Nutzer es ausdrücklich
-  gewählt hat.
-  *(`ShortcutsScreen.swift:14` setzt den Anfangswert auf `true`. Zur Klärung vorgelegt.)*
-- **AK-14** ⚠ · Angenommen, der Ablauf wird vor der letzten Seite abgebrochen, wenn er
-  schließt, dann wird der Anmeldestart **nicht** gesetzt — obwohl der Schalter „ein" zeigte.
-  *(`ShortcutsScreen.swift:63` ruft `setEnabled` ausschließlich in der *Done*-Aktion.
-  Zusammen mit AK-13 heißt das: Der angezeigte Zustand und der tatsächliche gehen
-  auseinander. Zur Klärung vorgelegt.)*
+  *(So verhält sich der Code, und das bleibt so — Begründung unter *Befunde*, BF-03.)*
+- **AK-13** · Angenommen, die letzte Seite wird angezeigt, wenn der Schalter für den
+  Anmeldestart erscheint, dann zeigt er den **tatsächlichen Zustand des Systems** — er ist
+  nicht vorangekreuzt.
+- **AK-14** · Angenommen, der Ablauf wird vor der letzten Seite abgebrochen, wenn er
+  schließt, dann bleibt der Anmeldestart so, wie er war — angezeigter und tatsächlicher
+  Zustand stimmen überein.
 
 ### Berechtigung
 
-- **AK-15** ⚠ · Angenommen, die Berechtigung fehlt, wenn der Ablauf sie behandelt, dann wird
-  sie **nie beim System angefordert** — es wird nur abgefragt und in die Systemeinstellungen
-  verwiesen.
-  *(Im gesamten Quelltext gibt es fünf Aufrufe von `CGPreflightScreenCaptureAccess()` und
-  **keinen einzigen** von `CGRequestScreenCaptureAccess()`. Der einzige Aufruf, der die
-  Anwendung in die Systemliste einträgt — `SCShareableContent.current` in
-  `MikaScreenSnapApp.swift:112` — steht in einem Zweig, der beim Erststart **nicht** läuft
-  (`:44-48`). Folge: Der Systemdialog erscheint nicht, und die Anwendung wird erst beim
-  zweiten Start oder beim ersten Aufnahmeversuch eingetragen. Ein Nutzer, der im
-  Einrichtungsablauf auf *Open System Settings* klickt, steht dort vor einer Liste, in der
-  die Anwendung noch gar nicht auftaucht. Zur Klärung vorgelegt.)*
+- **AK-15** · Angenommen, die Berechtigung fehlt, wenn auf der Berechtigungsseite *Grant
+  Access* gewählt wird, dann **fordert die Anwendung sie beim System an**; erst wenn das
+  Ansuchen abschlägig bleibt, öffnet sich die Systemeinstellung. Damit ist die Anwendung
+  dort in jedem Fall gelistet.
 
 ### Datenschutz und Missbrauchsschutz
 
@@ -95,14 +83,13 @@ Stufe A.
 
 - **AK-16** · Angenommen, die Berechtigungsseite wird angezeigt, wenn der Nutzer sie liest,
   dann nennt sie den Zweck und stellt fest, dass die Daten auf dem Rechner bleiben.
-- **AK-17** · Angenommen, der Ablauf läuft, wenn er abgeschlossen wird, dann werden
-  ausschließlich zwei Wahrheitswerte gespeichert (`hasCompletedOnboarding`,
-  `permissionSkipped`) — keine Nutzerdaten.
-- **AK-18** ⚠ · Angenommen, der Nutzer wählt *Skip for now*, wenn das vermerkt wird, dann
-  bleibt dieser Vermerk **wirkungslos**: `permissionSkipped` wird gespeichert und von
-  **niemandem** gelesen.
-  *(Einzige Fundstelle außerhalb der Einstellungsklasse: `PermissionScreen.swift:63`. Zur
-  Klärung vorgelegt.)*
+- **AK-17** · Angenommen, der Ablauf läuft, wenn er abgeschlossen wird, dann wird
+  ausschließlich ein Wahrheitswert gespeichert (`hasCompletedOnboarding`) — keine
+  Nutzerdaten.
+- **AK-18** · Angenommen, der Nutzer wählt *Skip for now*, wenn das geschieht, dann geht es
+  ohne Berechtigung weiter und **es wird nichts gespeichert** — der wirkungslose Vermerk
+  `permissionSkipped` ist entfernt. Dass die Berechtigung fehlt, zeigt stattdessen dauerhaft
+  das Menüleistenmenü.
 
 *Abschnitt 4 (Rate Limits) und Abschnitt 6 (Geheimnisse): treffen nicht zu.*
 
@@ -117,42 +104,41 @@ Stufe A.
   (AK-12).
 - **EC-05** · *Show Onboarding Again* bei erteilter Berechtigung → zweiseitiger Ablauf.
 
-## Fehlbestand
+## Befunde
 
-- **FB-01 · Die Berechtigung wird nie angefordert — und beim Erststart nicht einmal
-  angestoßen.** Fundstellen: kein Aufruf von `CGRequestScreenCaptureAccess()` im gesamten
-  Quelltext; zusätzlich `MikaScreenSnapApp.swift:44-48`. Dort steht die Prüfung, die über
-  `SCShareableContent.current` die Anwendung überhaupt erst in die Systemliste einträgt und
-  den Systemdialog auslösen kann — sie läuft aber **nur im `else`-Zweig**, also erst wenn
-  die Ersteinrichtung bereits abgeschlossen ist. Genau beim ersten Start übernimmt die
-  Ersteinrichtung, die ausschließlich abfragt. Folge: Der Nutzer klickt im Onboarding auf
-  *Open System Settings* und steht dort vor einer Liste, in der die Anwendung noch nicht
-  auftaucht — sie wird erst beim zweiten Start oder beim ersten Aufnahmeversuch eingetragen.
-  Das ist die wahrscheinlichste Ursache für einen misslungenen ersten Start.
-- **FB-02 · `permissionSkipped` ist wirkungslos.** Fundstelle: `PermissionScreen.swift:63`,
-  ohne Leser. Folge: Der vierte Einstellungsschlüssel ohne Wirkung — die Anwendung könnte
-  darauf aufbauend später erinnern, tut es aber nicht.
-- **FB-03 · Der Abschluss wird durch jedes Schließen ausgelöst.** Fundstelle:
-  `OnboardingWindow.swift:58`. Folge: Ein versehentliches `Escape` auf der ersten Seite
-  beendet die Einrichtung dauerhaft.
-- **FB-04 · Anzeigezustand und Wirkung des Anmeldestarts gehen auseinander.** Fundstellen:
-  `ShortcutsScreen.swift:14` (voreingestellt ein), `:63` (nur bei *Done* gesetzt). Folge:
-  Wer abbricht, hat einen Schalter gesehen, der „ein" zeigte, ohne dass etwas geschah — wer
-  *Done* drückt, richtet ein Anmeldeobjekt ein, ohne es gewählt zu haben.
-- **FB-05 · Kein Weg zurück im Ablauf.** Es gibt nur Vorwärtsnavigation; die Punkte am
-  unteren Rand sind Anzeige, nicht bedienbar.
-- **FB-06 · Keine Tests.**
+### Behoben
+
+- **FB-01 · Die Berechtigung wurde nie angefordert** — behoben 2026-08-25.
+  `CGRequestScreenCaptureAccess()` wird über *Grant Access* aufgerufen; die
+  Systemeinstellung öffnet sich nur, wenn das Ansuchen nicht zum Ziel führt. **Dies war die
+  wahrscheinlichste Ursache für einen misslungenen ersten Start.**
+- **FB-02 · `permissionSkipped` war wirkungslos** — behoben 2026-08-25 durch Entfernen.
+- **FB-04 · Anzeigezustand und Wirkung des Anmeldestarts gingen auseinander** — behoben
+  2026-08-25. Der Schalter wird aus `SMAppService` vorbelegt.
+
+### Akzeptiert
+
+- **BF-03 · Jedes Schließen gilt als Abschluss** — akzeptiert 2026-08-25. Ein Ablauf, der
+  nach `Escape` beim nächsten Start wiederkommt, ist aufdringlich; wer ihn wiedersehen will,
+  findet ihn unter *Preferences → Advanced → Onboarding*. Der eigentliche Schutz ist nicht
+  der Ablauf, sondern der dauerhafte Hinweis im Menü und die jetzt gesperrten
+  Aufnahmeeinträge (B15).
+- **BF-05 · Kein Weg zurück im Ablauf** — akzeptiert 2026-08-25. Drei Seiten ohne
+  Eingaben, die man verlieren könnte; ein Zurück wäre Zierrat.
+- **BF-06 · Keine Tests** — akzeptiert 2026-08-25. Der Ablauf besteht aus
+  Berechtigungsabfragen und Systemänderungen, die in einem Testlauf nichts zu suchen haben.
 
 ## Offene Fragen
 
-- **OF-01** · Soll `CGRequestScreenCaptureAccess()` aufgerufen werden, damit der
-  Systemdialog erscheint? — entscheidet der Autor. Betrifft B01.
-- **OF-02** · Soll ein Abbruch vor der letzten Seite als „abgeschlossen" gelten? —
-  entscheidet der Autor.
-- **OF-03** · Soll der Anmeldestart voreingestellt eingeschaltet sein? — entscheidet der
-  Autor.
+Keine offen.
 
-## Decision Log
+| Frage | Entscheidung | Datum |
+|---|---|---|
+| OF-01 · Berechtigung anfordern? | ja — und die Systemeinstellung erst danach öffnen | 2026-08-25 |
+| OF-02 · Abbruch als „abgeschlossen" werten? | ja, siehe BF-03 | 2026-08-25 |
+| OF-03 · Anmeldestart voreingestellt an? | nein — der Schalter zeigt den Systemzustand | 2026-08-25 |
+
+## Decision Log## Decision Log
 
 | # | Frage | Entscheidung | Begründung |
 |---|---|---|---|
@@ -161,4 +147,5 @@ Stufe A.
 | 3 | Selbsttätiges Weiterblättern nach Erteilung | auf einen Klick warten | der Nutzer kommt gerade aus den Systemeinstellungen zurück und soll nicht suchen |
 | 4 | Anmeldestart im Ablauf statt in den Einstellungen | nur in den Einstellungen | die naheliegende Stelle für eine Entscheidung, die man einmal trifft |
 | 5 | Abschluss beim Schließen des Fensters | erst nach der letzten Seite | **Grund nicht erkennbar** (FB-03) |
-| 6 | Nur abfragen, nie anfordern | `CGRequestScreenCaptureAccess()` aufrufen | **Grund nicht erkennbar** (FB-01) |
+| 6 | Berechtigung anfordern (3.5.0) | nur abfragen und verweisen | ohne Ansuchen trägt macOS die Anwendung nicht in die Liste ein — der Nutzer wurde in eine Liste geschickt, in der sie fehlte |
+| 7 | Anmeldestart aus dem System vorbelegt (3.5.0) | fest auf „ein" | ein vorangekreuztes Kästchen richtet eine Systemänderung ein, die niemand gewählt hat |

--- a/features/B13-start-bei-login/spec.md
+++ b/features/B13-start-bei-login/spec.md
@@ -1,8 +1,8 @@
 # B13 · Automatischer Start bei Login — Spezifikation
 
-Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst, Befunde behoben in 3.5.0**
 
-> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+> Beschrieben ist, **was der Code tut**. Das markierte Kriterium ist behoben.
 
 ## Zweck
 
@@ -51,12 +51,9 @@ Stufe A.
   Startordner geschrieben und kein Hintergrunddienst eingerichtet.
 - **AK-06** · Angenommen, der Anmeldestart wird gesetzt, wenn das geschieht, dann speichert
   die Anwendung selbst nichts darüber.
-- **AK-07** ⚠ · Angenommen, das Eintragen oder Entfernen schlägt fehl, wenn der Fehler
-  auftritt, dann erfährt der Nutzer nichts davon, und **der Schalter zeigt weiterhin den
-  gewünschten statt den tatsächlichen Zustand** — bis die Ansicht neu aufgebaut wird.
-  *(`LaunchAtLoginManager.swift:24` schreibt in ein `print()`. Die Klasse ist **nicht**
-  `@Observable`, weshalb eine fehlgeschlagene Änderung kein Neuzeichnen auslöst. Zur
-  Klärung vorgelegt.)*
+- **AK-07** · Angenommen, das Eintragen oder Entfernen schlägt fehl, wenn der Fehler
+  auftritt, dann erscheint eine Kurzmeldung und **der Schalter zeigt den tatsächlichen
+  Zustand des Systems**, nicht den gewünschten.
 
 *Abschnitte 4 und 6 des Katalogs: treffen nicht zu.*
 
@@ -69,25 +66,29 @@ Stufe A.
   Verhalten liegt beim System.
 - **EC-04** · Zwei Kopien der Anwendung auf dem Rechner → Verhalten ungeprüft.
 
-## Fehlbestand
+## Behobene Befunde
 
-- **FB-01 · Fehlschläge sind unsichtbar und der Schalter lügt.** Fundstelle:
-  `LaunchAtLoginManager.swift:24`. Folge: Der Nutzer glaubt, der Anmeldestart sei
-  eingerichtet, und wundert sich beim nächsten Anmelden. Zwei Ursachen wirken zusammen: das
-  wirkungslose `print()` und die fehlende Beobachtbarkeit der Klasse.
-- **FB-02 · Kein Abgleich beim Start.** Die Anwendung fragt den Zustand nur ab, wenn eine
-  Ansicht ihn anzeigt. Folge: keine unmittelbare — vermerkt, weil die Klasse damit als
-  einzige im Projekt ohne eigenen Zustand auskommt, was ausdrücklich so gewollt ist.
-- **FB-03 · Keine Tests.**
+- **FB-01 · Fehlschläge waren unsichtbar und der Schalter zeigte den falschen Zustand** —
+  behoben 2026-08-25. Der Fehler geht über `CaptureLog`, und die Klasse ist `@Observable`
+  mit einem Änderungszähler, sodass SwiftUI den Systemzustand neu liest.
+- **FB-02 · Kein Abgleich beim Start** — gegenstandslos: Die Klasse führt bewusst keinen
+  eigenen Zustand, es gibt also nichts abzugleichen.
+- **FB-03 · Keine Tests** — akzeptiert 2026-08-25. Ein Test müsste ein Anmeldeobjekt
+  eintragen; das ist eine Systemänderung, die in einem Testlauf nichts zu suchen hat.
 
 ## Offene Fragen
 
-- **OF-01** · Soll ein Fehlschlag gemeldet werden? — entscheidet der Autor.
+Keine offen.
 
-## Decision Log
+| Frage | Entscheidung | Datum |
+|---|---|---|
+| OF-01 · Fehlschlag melden? | ja, als Kurzmeldung — und der Schalter folgt dem System | 2026-08-25 |
+
+## Decision Log## Decision Log
 
 | # | Frage | Entscheidung | Begründung |
 |---|---|---|---|
 | 1 | Wie wird der Anmeldestart eingerichtet? | `SMAppService.mainApp` | ab macOS 13 der vorgesehene Weg; keine Hilfsanwendung, kein Startordner |
 | 2 | Wo liegt die Wahrheit? | beim System | ausdrücklich im Dateikopf vermerkt: keine eigene Ablage, die auseinanderlaufen kann |
-| 3 | Fehlerbehandlung | `print()` | **Grund nicht erkennbar** (FB-01) |
+| 3 | Fehlerbehandlung (3.5.0) | Kurzmeldung über `CaptureLog` | ein Anmeldeobjekt, das stillschweigend nicht eingerichtet wurde, fällt erst beim nächsten Anmelden auf |
+| 4 | Beobachtbarkeit (3.5.0) | `@Observable` mit Änderungszähler | ohne sie las SwiftUI den Systemzustand nach einem Fehlschlag nicht neu |

--- a/features/B14-automatische-updates/spec.md
+++ b/features/B14-automatische-updates/spec.md
@@ -1,8 +1,8 @@
 # B14 · Automatische Updates — Spezifikation
 
-Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst, Befunde bearbeitet in 3.5.0**
 
-> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+> Beschrieben ist, **was der Code tut**. Beide markierten Kriterien sind bearbeitet.
 >
 > **Dies ist das einzige Feature mit Netzwerkverkehr** — und das einzige, das
 > ausführbaren Code auf den Rechner bringt. Beides hebt es in der Prüfreihenfolge
@@ -54,19 +54,17 @@ Appcast auf `raw.githubusercontent.com`.
   öffentlichen Schlüssel passt, dann verweigert Sparkle die Installation.
 - **AK-06** · Angenommen, ein Update wird geladen, wenn die Verbindung fehlschlägt, dann
   meldet Sparkle den Fehler und die Anwendung läuft unverändert weiter.
-- **AK-07** ⚠ · Angenommen, das Aktualisierungswerk ist noch nicht bereit, wenn der
-  Menüeintrag *Check for Updates…* angezeigt wird, dann ist er **trotzdem anklickbar**.
-  *(`SparkleUpdater.swift:13` stellt `canCheckForUpdates` bereit; die Eigenschaft wird von
-  **keiner** Oberfläche gelesen. Der Eintrag in `CHANGELOG.md` zu 3.3.1 — „Update menu
-  button — now visually disabled when Sparkle updater is not ready" — beschreibt einen
-  Zustand, den der Code heute nicht mehr herstellt. Zur Klärung vorgelegt.)*
-- **AK-08** ⚠ · Angenommen, eine Fassung bis einschließlich 3.4.1 ist installiert, wenn sie
+- **AK-07** · Angenommen, das Aktualisierungswerk ist noch nicht bereit, wenn der
+  Menüeintrag *Check for Updates…* angezeigt wird, dann ist er **deaktiviert** — wie es der
+  Eintrag zu 3.3.1 in `CHANGELOG.md` seit jeher zusagt.
+- **AK-08** · Angenommen, eine Fassung bis einschließlich 3.4.1 ist installiert, wenn sie
   nach Updates sucht, dann fragt sie den Appcast auf dem Zweig **`master`** ab, nicht auf
   `main`.
-  *(Die Feed-Adresse ist ins Programmpaket kompiliert; erst `db55d1f` hat sie auf `main`
-  umgestellt. Solange solche Installationen bestehen, muss `main:master` mitgepusht werden,
-  sonst erreichen sie keine Aktualisierung mehr. Vermerkt in `README.md`. Zur Klärung
-  vorgelegt: bis wann?)*
+  *(Die Feed-Adresse ist ins Programmpaket kompiliert und lässt sich nachträglich nicht
+  ändern. Der Umgang damit ist organisatorisch geregelt — siehe *Befunde*, BF-04.)*
+- **AK-14** · Angenommen, der Annotationseditor hält ungesicherte Anmerkungen, wenn ein
+  Update installiert werden soll, dann fragt die Anwendung, ob später aktualisiert werden
+  soll, und verschiebt auf Wunsch auf den nächsten Start.
 
 ### Datenschutz und Missbrauchsschutz
 
@@ -106,40 +104,46 @@ das Repository nie berühren.*
 - **EC-06** · Nicht beglaubigtes Programmpaket → Gatekeeper verweigert den Start nach der
   Installation; der Nutzer sitzt dann vor einer beschädigten Installation.
 
-## Fehlbestand
+## Befunde
 
-- **FB-01 · `canCheckForUpdates` ist toter Code, und die Dokumentation behauptet das
-  Gegenteil.** Fundstelle: `SparkleUpdater.swift:13`, ohne Leser; `CHANGELOG.md`, Eintrag
-  3.3.1. Folge: Ein Zustand, den die Dokumentation zusichert, wird nicht hergestellt —
-  vermutlich bei der Neugestaltung der Einstellungen in 3.4.0 verloren gegangen.
-- **FB-02 · Keine Delegates am Aktualisierungswerk.** Fundstelle:
-  `SparkleUpdater.swift:23` übergibt `nil` für beide Delegates. Folge: Die Anwendung erfährt
-  nichts über Verlauf und Ausgang einer Prüfung, kann Fehler nicht protokollieren und den
-  Ablauf nicht beeinflussen — etwa um eine Installation zu verschieben, während der Editor
-  ungesicherte Anmerkungen hält.
-- **FB-03 · Ein Update kann ungesicherte Arbeit vernichten.** Es gibt keine Prüfung, ob der
-  Editor offen ist oder `hasUnsavedChanges` gesetzt ist, bevor Sparkle die Anwendung für die
-  Installation beendet. Folge: Anmerkungen gehen ohne Rückfrage verloren. Ohne Delegate
-  (FB-02) ist dieser Punkt auch nicht nachrüstbar.
-- **FB-04 · Der Zweigwechsel des Feeds hat kein Ende.** Fundstelle: `README.md`,
-  Abschnitt *Auto-Update*. Folge: `main:master` muss auf unbestimmte Zeit mitgepusht
-  werden; vergisst der Autor es einmal, bemerkt es niemand, weil die betroffenen
-  Installationen still auf altem Stand bleiben.
-- **FB-05 · Kein Prüfweg für den Appcast.** Es gibt keinen Test und keinen
-  Auslieferungsschritt, der die XML-Datei gegen Sparkles Erwartung prüft. Folge: Der Fehler
-  aus 3.3.2 (falscher Namensraum) konnte ausgeliefert werden und war erst am Gerät des
-  Nutzers sichtbar.
-- **FB-06 · Keine Tests.**
+### Behoben
+
+- **FB-01 · `canCheckForUpdates` war toter Code** — behoben 2026-08-25. Der Menüeintrag
+  liest die Eigenschaft und ist andernfalls deaktiviert; der CHANGELOG-Eintrag zu 3.3.1
+  trifft damit wieder zu.
+- **FB-02 · Keine Delegates am Aktualisierungswerk** — behoben 2026-08-25. `SparkleUpdater`
+  ist selbst `SPUUpdaterDelegate`.
+- **FB-03 · Ein Update konnte ungesicherte Arbeit vernichten** — behoben 2026-08-25 über
+  `updater(_:shouldPostponeRelaunchForUpdate:untilInvokingBlock:)`, das den Editor prüft und
+  auf Wunsch verschiebt. Zusätzlich meldet `didAbortWithError` fehlgeschlagene Prüfungen ins
+  Protokoll.
+
+### Akzeptiert
+
+- **BF-04 · Der Zweigwechsel des Feeds hat kein Ende** — akzeptiert 2026-08-25. Die
+  Feed-Adresse älterer Installationen lässt sich nachträglich nicht ändern; `main:master`
+  muss mitgepusht werden, solange solche Installationen bestehen. Der Ablauf steht in
+  `README.md` unter *Auto-Update*. Ein Ende wäre nur nach einer Zählung der verbleibenden
+  Installationen begründbar — und die gibt es bewusst nicht, weil die Anwendung keine
+  Nutzungsdaten erhebt.
+- **BF-05 · Kein Prüfweg für den Appcast** — akzeptiert 2026-08-25. Ein Test müsste
+  Sparkles Auswertung nachbilden; verlässlicher ist der Schritt, der in `README.md` ohnehin
+  vorgeschrieben ist: die Signatur über das von GitHub geladene DMG bilden und die
+  Aktualisierung vor der Veröffentlichung an einer echten Installation prüfen.
+- **BF-06 · Keine Tests** — akzeptiert 2026-08-25. Der Code besteht aus Weiterleitungen an
+  Sparkle; ein Test darüber prüfte das Rahmenwerk.
 
 ## Offene Fragen
 
-- **OF-01** · Bis wann muss `master` mitgepflegt werden? — entscheidet der Autor.
-- **OF-02** · Soll ein Update verschoben werden, wenn der Editor ungesicherte Anmerkungen
-  hält? — entscheidet der Autor.
-- **OF-03** · Soll `canCheckForUpdates` wieder benutzt oder entfernt werden? — entscheidet
-  der Autor. Der CHANGELOG-Eintrag zu 3.3.1 ist bis dahin unzutreffend.
+Keine offen.
 
-## Decision Log
+| Frage | Entscheidung | Datum |
+|---|---|---|
+| OF-01 · Bis wann `master` mitpflegen? | unbefristet, solange keine Zählung der Installationen existiert — und die soll es nicht geben. Der Aufwand ist ein zusätzlicher Push je Release und in `README.md` festgehalten | 2026-08-25 |
+| OF-02 · Update bei ungesicherten Anmerkungen verschieben? | ja, mit Rückfrage | 2026-08-25 |
+| OF-03 · `canCheckForUpdates` benutzen oder entfernen? | benutzen — der Menüeintrag ist deaktiviert, solange das Werk nicht bereit ist | 2026-08-25 |
+
+## Decision Log## Decision Log
 
 | # | Frage | Entscheidung | Begründung |
 |---|---|---|---|
@@ -147,6 +151,6 @@ das Repository nie berühren.*
 | 2 | Wie wird die Echtheit gesichert? | EdDSA-Signatur, öffentlicher Schlüssel im Paket | Sparkles empfohlener Weg; der private Schlüssel liegt im Schlüsselbund |
 | 3 | Wo liegt der Appcast? | `raw.githubusercontent.com`, Zweig `main` | keine eigene Serverinfrastruktur nötig |
 | 4 | Wie wird Sparkle eingebunden? | dünne Hülle um den Standardcontroller | die Oberfläche kommt vollständig von Sparkle |
-| 5 | Delegates? | keine | **Grund nicht erkennbar** — vermutlich nicht gebraucht (FB-02) |
+| 5 | Delegates (3.5.0) | Aktualisierungs-Delegate an der Hülle | ohne ihn konnte ein Update den Editor mitsamt ungesicherter Anmerkungen schließen, und ein Fehlschlag hinterließ keine Spur |
 | 6 | Wo steht der Schalter für die automatische Prüfung? | Reiter *Advanced* | wird selten geändert |
 | 7 | Zweigwechsel `master` → `main` | `db55d1f` | `master` war seit März unberührt, wodurch die Auslieferung von 3.4.1 zunächst unsichtbar blieb |

--- a/features/B15-menueleisten-hub/spec.md
+++ b/features/B15-menueleisten-hub/spec.md
@@ -1,8 +1,8 @@
 # B15 · Menüleisten-Hub & Programminfo — Spezifikation
 
-Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst**
+Status: `rekonstruiert` · Stand: 2026-08-25 · **rückwirkend erfasst, Befunde bearbeitet in 3.5.0**
 
-> Beschrieben ist, **was Version 3.4.1 tut**. Kriterien mit ⚠ stehen zur Klärung.
+> Beschrieben ist, **was der Code tut**. Beide markierten Kriterien sind behoben.
 
 ## Zweck
 
@@ -60,13 +60,14 @@ Hinweis auf eine fehlende Berechtigung, und dort wird die Anwendung beendet.
 - **AK-12** · Angenommen, ein Fenster wird aus dem Menü geöffnet, wenn es erscheint, dann
   kommt es nach vorn und nimmt den Tastaturfokus — obwohl die Anwendung kein Dock-Symbol
   hat.
-- **AK-13** ⚠ · Angenommen, die Berechtigung fehlt, wenn ein Aufnahmeeintrag angeklickt
-  wird, dann ist er **trotzdem anklickbar** und führt zu einem fehlgeschlagenen Versuch mit
-  Kurzmeldung.
-  *(`MikaScreenSnapApp.swift:159` zeigt den Warneintrag, deaktiviert aber keinen der
-  Aufnahmeeinträge. Zur Klärung vorgelegt.)*
-- **AK-14** ⚠ · Angenommen, das Aktualisierungswerk ist nicht bereit, wenn *Check for
-  Updates…* angezeigt wird, dann ist der Eintrag trotzdem anklickbar (siehe B14/AK-07).
+- **AK-13** · Angenommen, die Berechtigung fehlt, wenn das Menü geöffnet wird, dann sind
+  **alle sieben Aufnahme- und Zusatzeinträge deaktiviert** und nur der Warneintrag führt
+  weiter — in die Systemeinstellungen.
+- **AK-14** · Angenommen, das Aktualisierungswerk ist nicht bereit, wenn *Check for
+  Updates…* angezeigt wird, dann ist der Eintrag deaktiviert (siehe B14/AK-07).
+- **AK-17** · Angenommen, Farben wurden mit gedrückter Umschalttaste abgegriffen, wenn das
+  Menü geöffnet wird, dann steht neben *Color History* ein zweites Untermenü *Colour
+  Palette*; beide lassen sich dort leeren.
 
 ### Datenschutz und Missbrauchsschutz
 
@@ -91,33 +92,37 @@ Stufe A.
 - **EC-04** · Berechtigung wird bei geöffnetem Menü erteilt → der Warneintrag verschwindet
   erst beim nächsten Öffnen.
 
-## Fehlbestand
+## Befunde
 
-- **FB-01 · Der Warnhinweis warnt, hindert aber nicht.** Fundstelle:
-  `MikaScreenSnapApp.swift:159`. Folge: siehe AK-13 und B01/FB-03.
-- **FB-02 · Beim Erststart wird die Berechtigung nicht angestoßen.** Fundstelle:
-  `MikaScreenSnapApp.swift:44-48` — `checkScreenCapturePermission()`, das über
-  `SCShareableContent.current` die Anwendung überhaupt erst in die Systemliste einträgt,
-  läuft **nur im `else`-Zweig**, also wenn die Ersteinrichtung bereits abgeschlossen ist.
-  Beim ersten Start übernimmt die Ersteinrichtung, die ausschließlich abfragt. Folge: Der
-  Nutzer wird im Onboarding in die Systemeinstellungen geschickt, bevor die Anwendung dort
-  gelistet sein kann. Siehe B12/FB-01 — hier ist die Fundstelle für das *Warum*.
-- **FB-03 · Angeheftete Bilder heißen nur „Pin 1", „Pin 2".** Fundstelle:
-  `MikaScreenSnapApp.swift:206`. Folge: Bei mehreren angehefteten Bildern ist nicht
-  erkennbar, welches gemeint ist; ein Vorschaubild oder ein Zeitstempel fehlt.
-- **FB-04 · Kein Weg zur Projektseite oder Hilfe.** Weder Menü noch „Über"-Fenster
-  verlinken auf das Projekt. Folge: Wer einen Fehler melden will, findet den Weg nicht aus
-  der Anwendung heraus — bei „keine Fehlerberichte" als Erfolgskriterium (`docs/prd.md`)
-  ist das bemerkenswert.
-- **FB-05 · Keine Tests.**
+### Behoben
+
+- **FB-01 · Der Warnhinweis warnte, hinderte aber nicht** — behoben 2026-08-25. Die
+  Aufnahmeeinträge sind ohne Berechtigung deaktiviert.
+- **FB-02 · Beim Erststart wurde die Berechtigung nicht angestoßen** — behoben in B12: Die
+  Ersteinrichtung fordert sie an, statt sie nur abzufragen.
+
+### Akzeptiert
+
+- **BF-03 · Angeheftete Bilder heißen nur „Pin 1", „Pin 2"** — akzeptiert 2026-08-25. Der
+  Eintrag holt ein Fenster nach vorn, das ohnehin sichtbar ist; ein Vorschaubild im Menü
+  wäre Aufwand für einen Weg, den man selten geht.
+- **BF-04 · Kein Weg zur Projektseite aus der Anwendung** — akzeptiert 2026-08-25. Das
+  „Über"-Fenster nennt Name und Fassung; wer ein Problem meldet, findet das Projekt über
+  dieselbe Quelle, aus der er die Anwendung bezogen hat. Ein Verweis wäre eine Zeile — er
+  fehlt bewusst, weil das Menü bereits fünfzehn Einträge trägt.
+- **BF-05 · Keine Tests** — akzeptiert 2026-08-25. Das Menü ist eine SwiftUI-Ansicht ohne
+  eigene Logik.
 
 ## Offene Fragen
 
-- **OF-01** · Sollen Aufnahmeeinträge bei fehlender Berechtigung deaktiviert sein? —
-  entscheidet der Autor. Betrifft B01 und B12.
-- **OF-02** · Soll das „Über"-Fenster auf das Projekt verweisen? — entscheidet der Autor.
+Keine offen.
 
-## Decision Log
+| Frage | Entscheidung | Datum |
+|---|---|---|
+| OF-01 · Aufnahmeeinträge ohne Berechtigung sperren? | ja, im Menü. Tastenkombinationen bleiben aktiv und melden den Fehlschlag | 2026-08-25 |
+| OF-02 · Verweis auf das Projekt im „Über"-Fenster? | nein, siehe BF-04 | 2026-08-25 |
+
+## Decision Log## Decision Log
 
 | # | Frage | Entscheidung | Begründung |
 |---|---|---|---|
@@ -128,3 +133,4 @@ Stufe A.
 | 5 | Leerzustände als Text statt ausgeblendeter Untermenüs | Untermenü ausblenden | ein verschwundener Eintrag sieht aus wie ein Fehler |
 | 6 | Fassungsnummer aus dem Programmpaket | fest verdrahtet | seit 3.1.0; verhindert Abweichungen zwischen Anzeige und Paket |
 | 7 | `Capture Window…` ohne Kombination | eigene Kombination vergeben | die interaktive Auswahl braucht ohnehin die Maus; `⌃⇧⌘5` deckt den schnellen Fall ab |
+| 8 | Einträge ohne Berechtigung sperren (3.5.0) | anklickbar lassen | der Weg zur Berechtigung führte zuvor durch einen misslungenen Versuch |

--- a/features/befunde.md
+++ b/features/befunde.md
@@ -1,0 +1,93 @@
+# Befunde — projektweit
+
+Stand: 2026-08-25 · Quelle: **die Rückerfassung** (`sdd-erfassen` Phase 2), nicht QA-Berichte
+
+> Abweichung vom Regelfall: Diese Liste wird sonst von `sdd-qa` aus den `qa-report.md`
+> fortgeschrieben. Hier stammen die Einträge aus der Rückerfassung selbst — sie entstanden
+> beim Lesen des Codes, bevor je eine QA lief. Sobald `sdd-qa` läuft, schreibt sie hier
+> weiter; die Herkunft bleibt an der Spalte *Gefunden von* erkennbar.
+
+## Offen
+
+Keine. Alle 89 Einträge aus den Feature-Specs sind entweder behoben oder mit Begründung
+und Datum akzeptiert.
+
+## Behoben
+
+Ausgeliefert mit **3.5.0**. Die Reihenfolge folgt dem Schweregrad.
+
+| ID | Feature | Befund | Grad | Fundstelle | Behoben |
+|---|---|---|---|---|---|
+| BF-01 | B04, B09 | Auto-Save schrieb vor dem Editor, also immer das unzensierte Original — eine Zensur schützte nur das Weitergegebene | hoch | `CaptureEngine.postCapture` | 2026-08-25 |
+| BF-02 | B08 | Angeheftete Bilder wurden nie gelöscht; geschlossene kehrten beim Start zurück, weil alphabetisch die ältesten wiederhergestellt wurden | hoch | `PinnedScreenshotManager` | 2026-08-25 |
+| BF-03 | B10, B11 | Ereignisbehandler wurden bei jeder Neuanmeldung erneut installiert — nach *n* Änderungen löste ein Tastendruck *n+1* Aufnahmen aus | hoch | `HotkeyManager.registerHotkeys` | 2026-08-25 |
+| BF-04 | B01 | Vollbild und Bereich rechneten gegen `displays.first`; die Skalierung kam aus `NSScreen.main` bzw. einem festen Faktor 2 | mittel | `CaptureEngine` | 2026-08-25 |
+| BF-05 | B03, B09 | Dateinamen mit Sekundengenauigkeit, Schreiben ohne Prüfung — zwei Aufnahmen in derselben Sekunde ergaben eine Datei | mittel | `AppPreferences.saveImage` | 2026-08-25 |
+| BF-06 | B03, B05, B08, B09, B13 | Sechs `print()` in Fehlerpfaden, die in einem Programm ohne Dock-Symbol niemanden erreichen | mittel | mehrere | 2026-08-25 |
+| BF-07 | B12, B15 | Die Berechtigung wurde nie angefordert, beim Erststart nicht einmal angestoßen | mittel | `PermissionScreen`, `AppDelegate` | 2026-08-25 |
+| BF-08 | B04 | Weichzeichnen ohne Kantenfortsetzung; Zensurstärke unabhängig von der Bildauflösung | mittel | `AnnotationModels` | 2026-08-25 |
+| BF-09 | B11, B12 | Vier Einstellungsschlüssel ohne jeden Leser | mittel | `AppPreferences` | 2026-08-25 |
+| BF-10 | B06 | Palette wurde befüllt und nirgends angezeigt; Farbverlauf überstand das Zurücksetzen | mittel | `ColorHistoryManager` | 2026-08-25 |
+| BF-11 | B03 | `⌘S` sicherte auf den Schreibtisch, immer als PNG, und überschrieb die Zwischenablage | mittel | `AnnotationEditor.save` | 2026-08-25 |
+| BF-12 | B11 | README und CHANGELOG beschrieben die Einstellungen als dunkel und markenfarben | mittel | `README.md` | 2026-08-25 |
+| BF-13 | B05 | Leeres OCR-Ergebnis blieb stumm; die beiden OCR-Wege verhielten sich unterschiedlich | mittel | `CaptureEngine`, `AnnotationEditor` | 2026-08-25 |
+| BF-14 | B02 | Nur laufende Programme waren ausschließbar | mittel | `ExcludedAppsManager` | 2026-08-25 |
+| BF-15 | B14 | `canCheckForUpdates` war toter Code; keine Delegates, also konnte ein Update ungesicherte Anmerkungen vernichten | mittel | `SparkleUpdater` | 2026-08-25 |
+| BF-16 | B08, B11 | Die Speicherverwaltung kannte nur einen von zwei Ablageorten | mittel | `AdvancedTabView` | 2026-08-25 |
+| BF-17 | B09 | `clearAll()` löschte nur, was beim Start eingelesen wurde; die Speichergröße ließ Vorschaubilder aus | niedrig | `ScreenshotHistoryManager` | 2026-08-25 |
+| BF-18 | B07 | Leertaste doppelt belegt — Einheitenwechsel und Verschieben lösten gemeinsam aus | niedrig | `MeasurementTool` | 2026-08-25 |
+| BF-19 | B11 | Standard-Strichstärke 3 stand nicht zur Auswahl (2/4/6) | niedrig | `AppPreferences` | 2026-08-25 |
+| BF-20 | B12 | Anmeldestart war vorangekreuzt und wurde bei Abbruch dennoch nicht gesetzt | niedrig | `ShortcutsScreen` | 2026-08-25 |
+| BF-21 | B13 | Fehlschlag beim Anmeldestart blieb unsichtbar, der Schalter zeigte den falschen Zustand | niedrig | `LaunchAtLoginManager` | 2026-08-25 |
+| BF-22 | B07, B01 | `startMeasurement(appState:)` ignorierte seinen Parameter; der Controller wurde nie freigegeben | niedrig | `CaptureEngine` | 2026-08-25 |
+| BF-23 | projektweit | Keine Tests — die Fehlerklasse aus BF-04 wäre prüfbar gewesen | mittel | `Tests/` fehlte | 2026-08-25 |
+
+## Akzeptiert
+
+Bewusst nicht behoben. Ohne Begründung und Datum ist ein Befund nicht akzeptiert, sondern
+vergessen.
+
+| ID | Feature | Befund | Grad | Begründung | Beschlossen |
+|---|---|---|---|---|---|
+| BF-A1 | B03, B06 | Die Zwischenablage trägt für **Bilder** keine Vertraulichkeitskennzeichnung, sodass die geräteübergreifende Zwischenablage sie an andere Geräte trägt | mittel | macOS kennt eine solche Kennzeichnung nur für Text — dort wird sie gesetzt (B05). Für Bilder gibt es keinen Weg, das von der Anwendung aus zu unterbinden. Im PRD als Einschränkung der Datenschutzzusage ausgewiesen | 2026-08-25 |
+| BF-A2 | B02 | Der Ausschluss ist für den Nutzer nicht nachprüfbar | mittel | Eine Anzeige „hier wurde etwas ausgelassen" wäre irreführend: Ein Fenster kann auch fehlen, weil es nicht offen war. Der Ausschluss greift dort, wo er wirkt — als Filter an ScreenCaptureKit, bevor das Bild entsteht | 2026-08-25 |
+| BF-A3 | B10 | Fehlgeschlagene Anmeldung einer Tastenkombination bleibt in der Oberfläche unsichtbar; Konflikte mit fremden Programmen werden nicht erkannt | mittel | macOS stellt keine Abfrage bereit, über die sich fremde Belegungen feststellen ließen. Jede Anzeige wäre geraten; der Fehler steht in der Konsole | 2026-08-25 |
+| BF-A4 | B14 | Der Feed älterer Installationen zeigt auf `master`, ohne absehbares Ende | niedrig | Die Adresse ist in ausgelieferte Programmpakete kompiliert. Ein Ende wäre nur über eine Zählung der Installationen begründbar — und die soll es nicht geben, weil die Anwendung keine Nutzungsdaten erhebt | 2026-08-25 |
+| BF-A5 | B06 | Die Lupe zeigt einen eingefrorenen Bildschirm | niedrig | Sie zeichnet bei jeder Mausbewegung neu; fortlaufendes Neulesen würde ruckeln und den gesamten Bildschirminhalt dauernd erneuern | 2026-08-25 |
+| BF-A6 | B09 | Der Verlauf wird beim Start vollständig und synchron eingelesen | niedrig | Das Verzeichnis **ist** das Datenmodell; ein Index könnte von der Wirklichkeit abweichen. Ein Zwischenspeicher wäre ein eigenes Feature | 2026-08-25 |
+| BF-A7 | B09 | Endgültiges Löschen statt Papierkorb; kein automatisches Aufräumen | niedrig | Beides ist beabsichtigt: Löschen soll löschen, und eine automatische Bereinigung würde Aufnahmen entfernen, die noch gebraucht werden | 2026-08-25 |
+| BF-A8 | B08 | Position, Größe und Deckkraft angehefteter Bilder überleben keinen Neustart | niedrig | Ein angehefteter Screenshot ist ein Arbeitsmittel für den Moment | 2026-08-25 |
+| BF-A9 | B03 | Kein bearbeitbarer Projektstand; `AnnotationSnapshot.data` untypisiert | niedrig | Der Editor ist ein Durchgangsschritt. Neun typisierte Momentaufnahmen für einen rein internen Pfad wären Aufwand ohne Ertrag | 2026-08-25 |
+| BF-A10 | B12 | Jedes Schließen des Einrichtungsablaufs gilt als Abschluss | niedrig | Ein Ablauf, der nach `Escape` wiederkommt, ist aufdringlich. Der Schutz liegt im dauerhaften Menühinweis und den gesperrten Aufnahmeeinträgen | 2026-08-25 |
+| BF-A11 | B05 | Erkennungsgüte wird verworfen; die Sprachen sind fest | niedrig | Der Nutzer sieht den Text und beurteilt ihn selbst; drei Sprachen decken den Bedarf | 2026-08-25 |
+| BF-A12 | B07 | Zwei getrennte Implementierungen des Messens | niedrig | Overlay und Editorwerkzeug arbeiten in verschiedenen Koordinatenräumen; ein gemeinsamer Kern kostete mehr als die Dopplung | 2026-08-25 |
+| BF-A13 | B11 | Sparkles eigene Einstellungen überstehen *Reset All Preferences* | niedrig | Sie gehören dem Rahmenwerk; in fremde Schlüssel zu greifen, deren Namen sich ändern können, wäre unsicherer als sie stehen zu lassen | 2026-08-25 |
+| BF-A14 | B15 | Kein Verweis auf das Projekt aus der Anwendung heraus | niedrig | Das Menü trägt bereits fünfzehn Einträge; wer die Anwendung bezogen hat, kennt die Quelle | 2026-08-25 |
+| BF-A15 | projektweit | Keine Schemaversion in den Benutzereinstellungen | niedrig | Kein Formatwechsel steht an. Die Rücksetzliste ist zentralisiert und getestet, was den häufigsten Fehlerfall abdeckt | 2026-08-25 |
+
+## Muster
+
+Was in mehreren Features zugleich auftrat — der eigentliche Ertrag der Vollerfassung.
+
+- **Ein Fehler wurde einmal behoben und blieb an drei anderen Stellen stehen.** 3.4.1
+  korrigierte die Displaywahl und die Skalierung für Fensteraufnahmen; Vollbild, Bereich
+  und Texterkennung behielten `displays.first` und `NSScreen.main`. Die Anwendung besaß mit
+  `ScreenGeometry` sogar die richtige Umrechnung — sie wurde nur an einer Stelle benutzt
+  (BF-04). **Ursache: keine Tests.** Ein Test über die Koordinatenrechnung hätte alle vier
+  Stellen zugleich erfasst; er existiert jetzt.
+- **Fehlerpfade endeten in `print()`.** Sechs Stellen, alle nach demselben Muster, alle
+  wirkungslos in einem Programm ohne Dock-Symbol (BF-06). 3.4.1 hatte das für den
+  Aufnahmepfad bereits erkannt und `CaptureLog` eingeführt — die übrigen Pfade wurden nicht
+  mitgezogen.
+- **Einstellungen ohne Gegenstück.** Vier Schlüssel wurden gespeichert, geladen,
+  zurückgesetzt und angeboten, ohne dass irgendetwas sie las (BF-09). Ein Schalter ist
+  schnell gebaut, das Verhalten dahinter nicht.
+- **Schreiben ohne Löschen.** Zwei Ablageorte wuchsen unbegrenzt, weil jeder Schreibpfad
+  ein Gegenstück brauchte, das niemand gebaut hatte (BF-01, BF-02).
+- **Die Dokumentation lief dem Code hinterher.** Drei Stellen beschrieben Verhalten, das es
+  nicht mehr gab (BF-12, BF-15) oder nie so gegeben hatte (BF-10). Alle drei entstanden bei
+  Umbauten, bei denen der Text nicht mitgezogen wurde.
+
+Für den Betrieb (`sdd-betrieb`) folgt daraus: Der wirksamste Hebel dieses Projekts ist
+nicht mehr Sorgfalt im Einzelfall, sondern **Tests für alles, was rechnet**, und **ein
+Blick auf die Dokumentation bei jedem Umbau**.

--- a/features/index.md
+++ b/features/index.md
@@ -1,6 +1,6 @@
 # Features
 
-Stand: 2026-08-25 · Stack-Profil: `swiftui-macos` · Artefaktpfad: `docs/`
+Stand: 2026-08-25 · Stack-Profil: `swiftui-macos` · Artefaktpfad: `docs/` · Fassung 3.5.0
 
 Alle Einträge sind **Bestand**: Sie existieren im ausgelieferten Code (Version 3.4.1) und
 sind nie durch die SDD-Kette gelaufen. Das `B`-Präfix hält das dauerhaft sichtbar — bei
@@ -27,24 +27,26 @@ einem Fehler in `B04` ist die Spec eine Rekonstruktion und kann selbst falsch se
 **Alle fünfzehn Features sind rückerfasst.** Je Feature liegen `spec.md` und `design.md`
 vor. Nächster Schritt: `/sdd-qa B01` und so fort, in der Reihenfolge unten.
 
-## Was `rekonstruiert` hier bedeutet — und was noch fehlt
+## Stand der Rückerfassung
 
-Die Specs beschreiben, **was der Code tut**, nicht was er tun sollte. Wo das Verhalten
-fragwürdig aussieht, steht es trotzdem als Kriterium da, mit ⚠ markiert — damit `sdd-qa` es
-reproduziert statt es zu übersehen.
+Die Specs beschreiben, **was der Code tut**. Sie sind auf 3.5.0 nachgeführt: Alle Befunde
+der Erfassung sind entweder behoben oder mit Begründung und Datum akzeptiert, und alle
+markierten Kriterien sind entschieden.
 
-**Der Bestätigungsschritt steht aus.** Nach dem Verfahren wird jedes ⚠-Kriterium einzeln
-vorgelegt mit der Frage: *„Das tut der Code heute — soll er das?"* Diese Frage kann kein
-Agent beantworten, weil die Absicht nirgends im Code steht. Bis sie beantwortet ist, gilt:
+| | Erfassung (3.4.1) | Jetzt (3.5.0) |
+|---|---|---|
+| Einträge unter *Fehlbestand* | 89 | 0 offen — 23 behoben, 15 akzeptiert (zusammengefasst in `befunde.md`) |
+| Kriterien mit ⚠ | 51 | 0 |
+| Offene Fragen in den Specs | 40 | 0 |
+| Offene Punkte im PRD | 6 | 0 |
+| Tests | keine | 28 |
 
-| Antwort | Folge |
-|---|---|
-| „ja, so gewollt" | Marker entfällt, bleibt reguläres Kriterium |
-| „nein, das ist ein Fehler" | wandert aus den Kriterien in den *Fehlbestand* |
-| „unklar" | bleibt als offene Frage stehen |
+Die vollständige Liste mit Fundstellen, Graden und Begründungen steht in
+`features/befunde.md`, einschließlich der Muster, die erst projektweit sichtbar wurden.
 
-**51 Kriterien** tragen den Marker. Sie sind konservativ gesetzt: im Zweifel markiert statt
-stillschweigend durchgewunken.
+**Was noch aussteht: die QA.** Die Befunde stammen aus dem Lesen des Codes, nicht aus dem
+Prüfen. `sdd-qa` weist jedes Kriterium einzeln nach — das ist der Schritt, der aus
+„beschrieben" ein „belegt" macht.
 
 ## Prüfreihenfolge
 
@@ -64,56 +66,22 @@ wer mit der Darstellung anfängt, prüft zuletzt, was zuerst brennen kann.
 | 7 | B03, B10, B11 | nehmen Eingaben entgegen und schreiben Dateien |
 | 8 | B13, B07, B15 | geringstes Risiko |
 
-## Befunde aus der Rückerfassung
+## Befunde
 
-**89 Einträge unter *Fehlbestand*** über alle Specs, jeder mit Fundstelle und Folge. Hier
-stehen nur die, die über ein einzelnes Feature hinausreichen oder Daten betreffen. Die
-Grade sind **vorläufig** — gesetzt beim Lesen, nicht beim Prüfen. `sdd-qa` bewertet neu und
-schreibt nach `features/befunde.md` fort.
-
-### Datenverlust und Datenverbleib
-
-| Befund | Feature | Grad (vorläufig) | Kern |
-|---|---|---|---|
-| Auto-Save schreibt **vor** dem Editor, also immer das unzensierte Original | B04, B09 | **hoch** | wer ein Passwort verpixelt und exportiert, hat das Original weiter in `~/Pictures/MikaScreenSnap/` |
-| Angeheftete Bilder werden nie gelöscht, geschlossene kehren zurück | B08 | **hoch** | unsichtbarer, unbegrenzt wachsender Ablageort, in der Anwendung nicht leerbar |
-| Dateiname mit Sekundengenauigkeit, Schreiben ohne Prüfung | B03, B09 | mittel | zwei Aufnahmen in derselben Sekunde → eine Datei |
-| Fehlgeschlagenes Sichern schließt den Editor trotzdem und meldet nichts | B03, B09 | mittel | stiller Datenverlust |
-| Anheften ignoriert die Einstellung zum automatischen Sichern | B08 | mittel | eine ausdrückliche Nutzerentscheidung wird übergangen |
-
-### Zusagen, die nicht eingelöst werden
+Vollständig in `features/befunde.md`. Die drei schwersten, alle in 3.5.0 behoben:
 
 | Befund | Feature | Grad | Kern |
 |---|---|---|---|
-| Zwischenablage ohne Vertraulichkeitskennzeichnung | B03, B05, B06 | mittel | bei geräteübergreifender Zwischenablage trägt **macOS** Bild und erkannten Text zu anderen Geräten — die einzige Einschränkung der Zusage „kein Byte verlässt den Rechner" |
-| Zensurstärke fest und nicht auflösungsbezogen; Weichzeichnen ohne Kantenfortsetzung | B04 | mittel | am Rand eines weichgezeichneten Bereichs bleibt mehr Originalinformation stehen |
-| Palette wird befüllt und nirgends angezeigt | B06 | mittel | im README beworben, aus Nutzersicht wirkungslos |
-| Ausschlussliste nicht nachprüfbar, nur laufende Programme wählbar | B02 | mittel | eine Zusage ohne Kontrollmöglichkeit; Passwortmanager nicht vorbeugend ausschließbar |
-| Vier Einstellungsschlüssel ohne jeden Leser | B11, B12 | mittel | `floatingPreviewEnabled`, `previewDismissDuration`, `showToolbarLabels`, `permissionSkipped` |
-| README und CHANGELOG beschreiben die Einstellungen als dunkel und markenfarben | B11 | mittel | der Code ist seit `a43683a` systemnativ |
-| CHANGELOG 3.3.1 sagt, die Update-Schaltfläche werde deaktiviert | B14 | niedrig | `canCheckForUpdates` ist toter Code |
+| Auto-Save schrieb vor dem Editor, also immer das unzensierte Original | B04, B09 | hoch | wer ein Passwort verpixelte und exportierte, hatte das Original weiter im Verlaufsordner |
+| Angeheftete Bilder wurden nie gelöscht, geschlossene kehrten zurück | B08 | hoch | ein unsichtbarer, unbegrenzt wachsender Ablageort |
+| Ereignisbehandler wurden bei jeder Neuanmeldung erneut installiert | B10, B11 | hoch | nach *n* Änderungen der Belegung löste ein Tastendruck *n+1* Aufnahmen aus |
 
-### Fehlverhalten mit Außenwirkung
-
-| Befund | Feature | Grad | Kern |
-|---|---|---|---|
-| Ereignisbehandler werden bei jeder Neuanmeldung erneut installiert | B10, B11 | **hoch** | nach *n* Änderungen der Belegung löst ein Tastendruck *n+1* Aufnahmen aus; *Reset All Preferences* nimmt denselben Weg |
-| Vollbild und Bereich rechnen immer gegen `displays.first` | B01 | mittel | auf Mehrschirm-Arbeitsplätzen falscher Bildschirm und falscher Ausschnitt — obwohl `ScreenGeometry` die Lösung enthält und der Fensterpfad sie benutzt |
-| Vollbild multipliziert die Pixelgröße fest mit 2 | B01 | mittel | falsche Auflösung bei Skalierung ≠ 2 |
-| Berechtigung wird nie angefordert, beim Erststart nicht einmal angestoßen | B12, B15, B01 | mittel | der Nutzer wird in eine Systemliste geschickt, in der die Anwendung noch nicht steht |
-| Leertaste doppelt belegt (Einheitenwechsel und Verschieben) | B07, B03 | niedrig | Messen und Verschieben lösen gleichzeitig aus |
-| Leeres OCR-Ergebnis bleibt stumm; die beiden OCR-Wege verhalten sich unterschiedlich | B05 | niedrig | Fehlschlag und Nichtstun sind nicht unterscheidbar |
-| Lupe zeigt einen eingefrorenen Bildschirm | B06 | niedrig | bewusste Entscheidung, aber nicht gekennzeichnet |
-
-### Projektweit
-
-| Befund | Grad | Kern |
-|---|---|---|
-| **Keine Tests** (`Tests/` fehlt) | mittel | betrifft alle 15 Features. Genau die Fehlerklasse, die 3.4.1 im Fensterpfad behoben hat, ist im Bereichs- und Vollbildpfad unbemerkt geblieben — sie wäre testbar gewesen |
-| Sechs `print()` in Fehlerpfaden | mittel | erreichen in einem Programm ohne Dock-Symbol niemanden |
-| Keine Schemaversion in den Benutzereinstellungen | niedrig | ein Formatwechsel verliert die Konfiguration unbemerkt |
-| Rücksetzliste von Hand gepflegt | niedrig | Farbverlauf, Palette und Sparkles Schlüssel überstehen *Reset All Preferences* |
-| Kein Weg zur Projektseite aus der Anwendung | niedrig | bei „keine Fehlerberichte" als Erfolgskriterium bemerkenswert |
+Das aufschlussreichste Muster: **Ein Fehler wurde einmal behoben und blieb an drei anderen
+Stellen stehen.** 3.4.1 korrigierte Displaywahl und Skalierung für Fensteraufnahmen;
+Vollbild, Bereich und Texterkennung behielten `displays.first` und `NSScreen.main` — obwohl
+die Anwendung mit `ScreenGeometry` die richtige Umrechnung bereits besaß. Ursache waren die
+fehlenden Tests: Eine Prüfung der Koordinatenrechnung hätte alle vier Stellen zugleich
+erfasst. Sie existiert jetzt.
 
 ## Nächster Schritt
 
@@ -121,8 +89,13 @@ schreibt nach `features/befunde.md` fort.
 /sdd-qa B01
 ```
 
-Findet die QA nichts, geht das Feature auf `deployed` mit Auditvermerk — ausgeliefert wird
-nichts, der Code läuft ja. Ein kritischer oder hoher Befund **unterbricht** die Reihe, bis
-die Reparatur draußen ist; mittlere und niedrige sammeln sich in `features/befunde.md`.
+In der Prüfreihenfolge oben. Findet die QA nichts, geht das Feature auf `deployed` mit
+Auditvermerk — ausgeliefert wird nichts, der Code läuft ja. Ein kritischer oder hoher
+Befund unterbricht die Reihe, bis die Reparatur draußen ist.
 
-Nach allen fünfzehn: `/sdd-erfassen abschluss` für den Auditbericht.
+Nach allen fünfzehn: `/sdd-erfassen abschluss` für den Auditbericht, dessen Eingabe
+`features/befunde.md` ist.
+
+**Zur Auslieferung von 3.5.0** siehe die Reihenfolge in `README.md` unter *Auto-Update* —
+Version, Bau, Beglaubigung, GitHub-Release, Signatur über das geladene DMG, dann der
+Appcast-Eintrag als letzter Schritt. Und `main:master` mitpushen.

--- a/web/lib/content.ts
+++ b/web/lib/content.ts
@@ -6,7 +6,7 @@
  * that needs editing.
  */
 
-const version = "3.4.1";
+const version = "3.5.0";
 const repo = "https://github.com/daumedia/MikaScreenSnap";
 
 export const product = {


### PR DESCRIPTION
The reconstruction (#31, #32) read all fifteen features and recorded 89 findings, 51
unconfirmed criteria and 46 open questions. This closes all of them: **0 open findings, 0
markers, 0 open questions**, plus a test suite for the arithmetic that had none.

## The three high findings

**Redacting left the original on disk.** Auto-save runs before the editor opens, so the
saved file was always the untouched capture. Blur a password, export, and the readable
original still sat in `~/Pictures/MikaScreenSnap/`. The editor now keeps the auto-saved URL
and replaces that file on every export — and on close whenever the image carries a blur or
pixelate region, exported or not. A redaction is a promise about content, not a styling
choice.

**Pinned screenshots were never deleted.** Closing a pin only hid the window; the PNG
stayed in Application Support forever, the twenty-pin cap applied to windows rather than
files, and `restorePins` sorted filenames ascending — restoring the *oldest* twenty, so a
deliberately closed pin could come back. Pins now carry their URL, closing deletes it,
restoration is newest-first, surplus files are removed, and Preferences shows and clears
that storage.

**One keypress fired several captures.** `registerHotkeys()` called `InstallEventHandler`
every time it ran — from `init` and from every re-binding — with no `RemoveEventHandler`
anywhere and the handler ref not even retained. After *n* re-binds a single shortcut fired
*n+1* times, and "Reset All Preferences" took the same path without the user touching a
shortcut.

## The pattern behind the rest

**A fix landed once and was left standing in three other places.** 3.4.1 corrected display
selection and scaling for window captures. Full-screen, area and text capture kept
`displays.first` and `NSScreen.main` — even though `ScreenGeometry` already held the correct
conversion and was used by exactly one path.

The cause was the absence of tests. One test over the coordinate maths would have caught all
four at once. `Tests/` now holds 28 of them, over what this project's bugs have actually
lived in: multi-display coordinates, hotkey encoding, colour conversion, redaction strength
and filename collisions.

## Behaviour changes

| Change | Why |
|---|---|
| `⌘S` saves to the configured folder and format | It wrote a PNG to the Desktop regardless of both settings, and overwrote the clipboard as a side effect |
| The measurement tool toggles units with `U` | Space is the pan modifier in the editor; both fired at once |
| Onboarding calls `CGRequestScreenCaptureAccess` | Only ever preflighting meant the app was never registered, so the Screen Recording list a user was sent to could not contain it yet — the likeliest cause of a failed first run |
| Capture entries are disabled without the permission | The path to granting it ran through a failed attempt |
| Launch at Login is no longer pre-ticked | A pre-ticked box registered a login item nobody chose |
| Recognised text is marked concealed on the pasteboard | It can be a password that happened to sit in the selected region |

Removed: **"Floating preview"** and its dismiss duration — stored, loaded, reset and offered
in Preferences, read by nothing. A preview window was never built; that belongs in a feature
of its own, not a switch that does nothing. Same for `permissionSkipped`. The two dead
settings that *could* be honoured now are: toolbar labels work, and the colour palette has a
menubar submenu instead of filling up unseen.

## Three findings accepted rather than fixed

Recorded with a reason and a date in `features/befunde.md`, because a finding without both
is not accepted but forgotten:

- **Pasteboard images cannot be marked concealed** — macOS has no such marker for images,
  only for text, where it is now set. The PRD states this as the one qualification to "no
  byte leaves the machine".
- **The exclusion list cannot show that it worked** — a missing window is indistinguishable
  from one that was never open, so any indicator would mislead. The exclusion is enforced
  where it matters: as a filter handed to ScreenCaptureKit before the image exists.
- **Hotkey conflicts with other apps cannot be detected** — macOS exposes no way to ask.

## What is in this PR

- `Sources/` — the fixes above, plus `CaptureLog` for the six surviving `print()` calls
- `Tests/` — new, 28 tests
- `features/BNN-*/spec.md` — all fifteen brought to the state of 3.5.0
- `features/befunde.md` — new: every finding with source, severity, outcome, and the
  patterns that only became visible project-wide
- `docs/` — PRD open points decided, non-goals confirmed, data model and app shell updated
- `CHANGELOG.md`, `README.md`, `CLAUDE.md`, version bumped to 3.5.0

`swift build` and `swift test` pass; the bundle builds and verifies.

**Still outstanding: the QA.** These findings come from reading the code, not from testing
it. `/sdd-qa B01` onwards is what turns "described" into "demonstrated".

🤖 Generated with [Claude Code](https://claude.com/claude-code)